### PR TITLE
Support any usage ids from the HID consumer page

### DIFF
--- a/teensy3/keylayouts.h
+++ b/teensy3/keylayouts.h
@@ -80,14 +80,14 @@ extern "C"{
 #define MODIFIERKEY_RIGHT_ALT   ( 0x40 | 0x8000 )
 #define MODIFIERKEY_RIGHT_GUI   ( 0x80 | 0x8000 )
 
-#define KEY_MEDIA_VOLUME_INC    0x01
-#define KEY_MEDIA_VOLUME_DEC    0x02
-#define KEY_MEDIA_MUTE          0x04
-#define KEY_MEDIA_PLAY_PAUSE    0x08
-#define KEY_MEDIA_NEXT_TRACK    0x10
-#define KEY_MEDIA_PREV_TRACK    0x20
-#define KEY_MEDIA_STOP          0x40
-#define KEY_MEDIA_EJECT         0x80
+#define KEY_MEDIA_VOLUME_INC    0xE9
+#define KEY_MEDIA_VOLUME_DEC    0xEA
+#define KEY_MEDIA_MUTE          0xE2
+#define KEY_MEDIA_PLAY_PAUSE    0xCD
+#define KEY_MEDIA_NEXT_TRACK    0xB5
+#define KEY_MEDIA_PREV_TRACK    0xB6
+#define KEY_MEDIA_STOP          0xB7
+#define KEY_MEDIA_EJECT         0xB8
 
 #define KEY_A           ( 4   | 0x4000 )
 #define KEY_B           ( 5   | 0x4000 )

--- a/teensy3/usb_desc.c
+++ b/teensy3/usb_desc.c
@@ -117,20 +117,16 @@ static uint8_t keyboard_report_desc[] = {
         0x15, 0x00,             //  Logical Minimum (0),
         0x25, 0x01,             //  Logical Maximum (1),
         0x81, 0x02,             //  Input (Data, Variable, Absolute), ;Modifier byte
-        0x95, 0x08,             //  Report Count (8),
-        0x75, 0x01,             //  Report Size (1),
-        0x15, 0x00,             //  Logical Minimum (0),
-        0x25, 0x01,             //  Logical Maximum (1),
+        
+        0x95, 0x01,             //  Report Count (1),
+        0x75, 0x10,             //  Report Size (16),
         0x05, 0x0C,             //  Usage Page (Consumer),
-        0x09, 0xE9,             //  Usage (Volume Increment),
-        0x09, 0xEA,             //  Usage (Volume Decrement),
-        0x09, 0xE2,             //  Usage (Mute),
-        0x09, 0xCD,             //  Usage (Play/Pause),
-        0x09, 0xB5,             //  Usage (Scan Next Track),
-        0x09, 0xB6,             //  Usage (Scan Previous Track),
-        0x09, 0xB7,             //  Usage (Stop),
-        0x09, 0xB8,             //  Usage (Eject),
-        0x81, 0x02,             //  Input (Data, Variable, Absolute), ;Media keys
+        0x15, 0x01,             //  Logical Minimum (1),
+        0x26, 0x0C, 0x29,       //  Logical Maximum (0x029C),
+        0x19, 0x01,             //  Usage Minimum (1),
+        0x2a, 0x0C, 0x29,       //  Usage Maximum (0x029C),
+        0x81, 0x00,             //  Input (Data, Array, Absolute), ;Consumer keys
+
         0x95, 0x05,             //  Report Count (5),
         0x75, 0x01,             //  Report Size (1),
         0x05, 0x08,             //  Usage Page (LEDs),
@@ -140,7 +136,7 @@ static uint8_t keyboard_report_desc[] = {
         0x95, 0x01,             //  Report Count (1),
         0x75, 0x03,             //  Report Size (3),
         0x91, 0x03,             //  Output (Constant),                 ;LED report padding
-        0x95, 0x06,             //  Report Count (6),
+        0x95, 0x05,             //  Report Count (5),
         0x75, 0x08,             //  Report Size (8),
         0x15, 0x00,             //  Logical Minimum (0),
         0x25, 0x7F,             //  Logical Maximum(104),

--- a/teensy3/usb_dev.h
+++ b/teensy3/usb_dev.h
@@ -77,10 +77,11 @@ extern void usb_seremu_flush_callback(void);
 
 #ifdef KEYBOARD_INTERFACE
 extern uint8_t keyboard_modifier_keys;
-extern uint8_t keyboard_keys[6];
+extern uint8_t keyboard_keys[5];
 extern uint8_t keyboard_protocol;
 extern uint8_t keyboard_idle_config;
 extern uint8_t keyboard_idle_count;
+extern uint16_t keyboard_consumer_keys;
 extern volatile uint8_t keyboard_leds;
 #endif
 

--- a/teensy3/usb_keyboard.h
+++ b/teensy3/usb_keyboard.h
@@ -49,8 +49,8 @@ void usb_keyboard_release_all(void);
 int usb_keyboard_press(uint8_t key, uint8_t modifier);
 int usb_keyboard_send(void);
 extern uint8_t keyboard_modifier_keys;
-extern uint8_t keyboard_media_keys;
-extern uint8_t keyboard_keys[6];
+extern uint16_t keyboard_consumer_keys;
+extern uint8_t keyboard_keys[5];
 extern uint8_t keyboard_protocol;
 extern uint8_t keyboard_idle_config;
 extern uint8_t keyboard_idle_count;
@@ -82,8 +82,8 @@ public:
 	void set_key3(uint8_t c) { keyboard_keys[2] = c; }
 	void set_key4(uint8_t c) { keyboard_keys[3] = c; }
 	void set_key5(uint8_t c) { keyboard_keys[4] = c; }
-	void set_key6(uint8_t c) { keyboard_keys[5] = c; }
-	void set_media(uint8_t c) { keyboard_media_keys = c; }
+	void set_media(uint8_t c) { set_consumer(c); }
+	void set_consumer(uint16_t c) { keyboard_consumer_keys = c; }
 	void send_now(void) { usb_keyboard_send(); }
 	void press(uint16_t n) { usb_keyboard_press_keycode(n); }
 	void release(uint16_t n) { usb_keyboard_release_keycode(n); }


### PR DESCRIPTION
The implementation in Teensy 3 (and previous) only supports 8 hard-coded consumer-keys, so it was not possible to send the key AC_HOME (0x223) or any of the other 660 consumer-keys. I need some of these consumer-keys to create a custom button-panel for my in-car Nexus 7. The home-button, back-button and many other Android functions can only be triggered by consumer-keys (reference http://source.android.com/devices/te...d-devices.html). Some of them are two bytes, so I found it was not sufficient to just modify the keyboard report descriptor.

I changed the keyboard report descriptor to use an array for the consumer-keys. Not sure if that's Correct™, but that's what I got working. Since some of the consumer page usage ids consists of 2 bytes, I also had to steal one byte from the 6 “normal” keyboard keys (now 5). It's also only possible to send one consumer key at the time. Not sure if there are enough available bytes in the packet to add more consumer-keys, or if it's better to add a new HID config for Consumer Keyboard?

Since set_media was only for media-related keys, I added a new method; set_consumer that can take a 16-bit int. Changed the media-key constants in keylayouts.h to the usage id, and set_media now just calls set_consumer.

Tested many different consumer keys on Android 4.2, and they work perfectly. Only tested the volume-keys on OS X 10.9.1, and they work as well. Tried to test on Windows in VirtualBox, but it wouldn't allow me to use the Teensy USB keyboard :( The AC_HOME even works as the home-button on an iPad if using the iPad camera connection kit!
