### PR TITLE
Fix print() for long long

### DIFF
--- a/teensy3/Print.cpp
+++ b/teensy3/Print.cpp
@@ -57,7 +57,7 @@ size_t Print::print(const String &s)
 }
 
 
-size_t Print::print(long n)
+size_t Print::print(long long n)
 {
 	uint8_t sign=0;
 
@@ -99,9 +99,9 @@ int Print::printf(const __FlashStringHelper *format, ...)
 }
 
 
-size_t Print::printNumber(unsigned long n, uint8_t base, uint8_t sign)
+size_t Print::printNumber(unsigned long long n, uint8_t base, uint8_t sign)
 {
-	uint8_t buf[34];
+	uint8_t buf[20];
 	uint8_t digit, i;
 
 	// TODO: make these checks as inline, since base is

--- a/teensy3/Print.h
+++ b/teensy3/Print.h
@@ -62,14 +62,18 @@ class Print
 	size_t print(uint8_t b)				{ return printNumber(b, 10, 0); }
 	size_t print(int n)				{ return print((long)n); }
 	size_t print(unsigned int n)			{ return printNumber(n, 10, 0); }
-	size_t print(long n);
+	size_t print(long n)			{ return print((long long)n); }
+	size_t print(long long n);
 	size_t print(unsigned long n)			{ return printNumber(n, 10, 0); }
+	size_t print(unsigned long long n)			{ return printNumber(n, 10, 0); }
 
 	size_t print(unsigned char n, int base)		{ return printNumber(n, base, 0); }
 	size_t print(int n, int base)			{ return (base == 10) ? print(n) : printNumber(n, base, 0); }
 	size_t print(unsigned int n, int base)		{ return printNumber(n, base, 0); }
 	size_t print(long n, int base)			{ return (base == 10) ? print(n) : printNumber(n, base, 0); }
+	size_t print(long long n, int base)			{ return (base == 10) ? print(n) : printNumber(n, base, 0); }
 	size_t print(unsigned long n, int base)		{ return printNumber(n, base, 0); }
+	size_t print(unsigned long long n, int base)		{ return printNumber(n, base, 0); }
 
 	size_t print(double n, int digits = 2)		{ return printFloat(n, digits); }
 	size_t print(const Printable &obj)		{ return obj.printTo(*this); }
@@ -83,7 +87,9 @@ class Print
 	size_t println(int n)				{ return print(n) + println(); }
 	size_t println(unsigned int n)			{ return print(n) + println(); }
 	size_t println(long n)				{ return print(n) + println(); }
+	size_t println(long long n)				{ return print(n) + println(); }
 	size_t println(unsigned long n)			{ return print(n) + println(); }
+	size_t println(unsigned long long n)			{ return print(n) + println(); }
 
 	size_t println(unsigned char n, int base)	{ return print(n, base) + println(); }
 	size_t println(int n, int base)			{ return print(n, base) + println(); }
@@ -102,7 +108,7 @@ class Print
   private:
 	char write_error;
 	size_t printFloat(double n, uint8_t digits);
-	size_t printNumber(unsigned long n, uint8_t base, uint8_t sign);
+	size_t printNumber(unsigned long long n, uint8_t base, uint8_t sign);
 };
 
 


### PR DESCRIPTION
Printing huge integer numbers did not work; this patch repairs this.
Additionaly, in print() was uint8_t buf[34]; which was bigger than
nessesary.

Testsketch (did not work before):

#include <climits>

void setup(){
Serial1.begin(115200);
Serial1.println();
Serial1.println();
Serial1.println(LONG_MIN);
Serial1.println(LONG_MAX);
Serial1.println(ULONG_MAX);
Serial1.println(LLONG_MIN);
Serial1.println(LLONG_MAX);
Serial1.println(ULLONG_MAX);
}

void loop(){
}