### PR TITLE
Streaming callback API for SysEx messages

### DIFF
--- a/teensy3/usb_midi.h
+++ b/teensy3/usb_midi.h
@@ -77,6 +77,7 @@ extern void (*usb_midi_handleControlChange)(uint8_t ch, uint8_t control, uint8_t
 extern void (*usb_midi_handleProgramChange)(uint8_t ch, uint8_t program);
 extern void (*usb_midi_handleAfterTouch)(uint8_t ch, uint8_t pressure);
 extern void (*usb_midi_handlePitchChange)(uint8_t ch, int pitch);
+extern void (*usb_midi_handleSysEx)(uint8_t length, const uint8_t *data, uint8_t complete);
 extern void (*usb_midi_handleRealTimeSystem)(uint8_t rtb);
 
 #ifdef __cplusplus
@@ -164,6 +165,9 @@ class usb_midi_class
         inline void setHandlePitchChange(void (*fptr)(uint8_t channel, int pitch)) {
                 usb_midi_handlePitchChange = fptr;
         };
+        inline void setHandleSysEx(void (*fptr)(uint8_t length, const uint8_t *data, bool complete)) {
+                usb_midi_handleSysEx = (void (*)(uint8_t, const uint8_t*, uint8_t))fptr;
+        }
         inline void setHandleRealTimeSystem(void (*fptr)(uint8_t realtimebyte)) {
                 usb_midi_handleRealTimeSystem = fptr;
         };


### PR DESCRIPTION
Here's the streaming API I proposed here:

http://forum.pjrc.com/threads/23530-Any-reason-why-SysEx-length-is-hardcoded-at-60-bytes-in-usbMIDI-usb_api-h?p=48019&viewfull=1#post48019
