### PR TITLE
Use the proper way to refer to gcc's asm extension so we can compile this in C standard mode.

### DIFF
--- a/teensy3/core_pins.h
+++ b/teensy3/core_pins.h
@@ -790,7 +790,7 @@ static inline void delayMicroseconds(uint32_t usec)
 	uint32_t n = usec >> 1;
 #endif
 	if (usec == 0) return;
-	asm volatile(
+	__asm__ volatile(
 		"L_%=_delayMicroseconds:"		"\n\t"
 #if F_CPU < 10000000
 		"nop"					"\n\t"

--- a/teensy3/mk20dx128.c
+++ b/teensy3/mk20dx128.c
@@ -366,8 +366,8 @@ void ResetHandler(void)
 
 	WDOG_UNLOCK = WDOG_UNLOCK_SEQ1;
 	WDOG_UNLOCK = WDOG_UNLOCK_SEQ2;
-	asm volatile ("nop");
-	asm volatile ("nop");
+	__asm__ volatile ("nop");
+	__asm__ volatile ("nop");
 	// programs using the watchdog timer or needing to initialize hardware as
 	// early as possible can implement startup_early_hook()
 	startup_early_hook();
@@ -595,16 +595,16 @@ int nvic_execution_priority(void)
 
 	// full algorithm in ARM DDI0403D, page B1-639
 	// this isn't quite complete, but hopefully good enough
-	asm volatile("mrs %0, faultmask\n" : "=r" (faultmask)::);
+	__asm__ volatile("mrs %0, faultmask\n" : "=r" (faultmask)::);
 	if (faultmask) return -1;
-	asm volatile("mrs %0, primask\n" : "=r" (primask)::);
+	__asm__ volatile("mrs %0, primask\n" : "=r" (primask)::);
 	if (primask) return 0;
-	asm volatile("mrs %0, ipsr\n" : "=r" (ipsr)::);
+	__asm__ volatile("mrs %0, ipsr\n" : "=r" (ipsr)::);
 	if (ipsr) {
 		if (ipsr < 16) priority = 0; // could be non-zero
 		else priority = NVIC_GET_PRIORITY(ipsr - 16);
 	}
-	asm volatile("mrs %0, basepri\n" : "=r" (basepri)::);
+	__asm__ volatile("mrs %0, basepri\n" : "=r" (basepri)::);
 	if (basepri > 0 && basepri < priority) priority = basepri;
 	return priority;
 }

--- a/teensy3/mk20dx128.h
+++ b/teensy3/mk20dx128.h
@@ -2224,8 +2224,8 @@ typedef struct {
 
 
 
-#define __disable_irq() asm volatile("CPSID i");
-#define __enable_irq()	asm volatile("CPSIE i");
+#define __disable_irq() __asm__ volatile("CPSID i");
+#define __enable_irq()	__asm__ volatile("CPSIE i");
 
 // System Control Space (SCS), ARMv7 ref manual, B3.2, page 708
 #define SCB_CPUID		*(const	   uint32_t *)0xE000ED00 // CPUID Base Register

--- a/teensy3/usb_dev.c
+++ b/teensy3/usb_dev.c
@@ -688,7 +688,7 @@ void usb_tx(uint32_t endpoint, usb_packet_t *packet)
 void _reboot_Teensyduino_(void)
 {
 	// TODO: initialize R0 with a code....
-	asm volatile("bkpt");
+	__asm__ volatile("bkpt");
 }
 
 


### PR DESCRIPTION
Hi Paul,

This patch fixes some problems one will encounter when compiling in standard C mode, instead of GNU C mode.
It's a simple fix that converts uses of the "asm" keyword to "**asm**", which is allowed both in GNU C and Standard C mode.

Thank you,

Filipe
