### PR TITLE
Add usb_midi_class::setHandleSysEx()

### DIFF
--- a/teensy3/usb_midi.c
+++ b/teensy3/usb_midi.c
@@ -49,6 +49,7 @@ void (*usb_midi_handleControlChange)(uint8_t ch, uint8_t control, uint8_t value)
 void (*usb_midi_handleProgramChange)(uint8_t ch, uint8_t program) = NULL;
 void (*usb_midi_handleAfterTouch)(uint8_t ch, uint8_t pressure) = NULL;
 void (*usb_midi_handlePitchChange)(uint8_t ch, int pitch) = NULL;
+void (*usb_midi_handleSysEx)(const uint8_t *data, uint16_t length, uint8_t complete) = NULL;
 void (*usb_midi_handleRealTimeSystem)(uint8_t rtb) = NULL;
 
 // Maximum number of transmit packets to queue so we don't starve other endpoints for memory
@@ -143,6 +144,13 @@ void usb_midi_flush_output(void)
 
 void static sysex_byte(uint8_t b)
 {
+	// when buffer is full, send another chunk to handler.
+	if (usb_midi_msg_sysex_len == USB_MIDI_SYSEX_MAX) {
+		if (usb_midi_handleSysEx) {
+			(*usb_midi_handleSysEx)(usb_midi_msg_sysex, usb_midi_msg_sysex_len, 0);
+			usb_midi_msg_sysex_len = 0;
+		}
+	}
 	if (usb_midi_msg_sysex_len < USB_MIDI_SYSEX_MAX) {
 		usb_midi_msg_sysex[usb_midi_msg_sysex_len++] = b;
 	}
@@ -246,6 +254,8 @@ int usb_midi_read(uint32_t channel)
 		usb_midi_msg_data1 = usb_midi_msg_sysex_len;
 		usb_midi_msg_sysex_len = 0;
 		usb_midi_msg_type = 7;				// 7 = Sys Ex
+		if (usb_midi_handleSysEx)
+			(*usb_midi_handleSysEx)(usb_midi_msg_sysex, usb_midi_msg_data1, 1);
 		return 1;
 	}
 	if (type1 == 0x0F) {

--- a/teensy3/usb_midi.h
+++ b/teensy3/usb_midi.h
@@ -77,6 +77,7 @@ extern void (*usb_midi_handleControlChange)(uint8_t ch, uint8_t control, uint8_t
 extern void (*usb_midi_handleProgramChange)(uint8_t ch, uint8_t program);
 extern void (*usb_midi_handleAfterTouch)(uint8_t ch, uint8_t pressure);
 extern void (*usb_midi_handlePitchChange)(uint8_t ch, int pitch);
+extern void (*usb_midi_handleSysEx)(const uint8_t *data, uint16_t length, uint8_t complete);
 extern void (*usb_midi_handleRealTimeSystem)(uint8_t rtb);
 
 #ifdef __cplusplus
@@ -164,6 +165,9 @@ class usb_midi_class
         inline void setHandlePitchChange(void (*fptr)(uint8_t channel, int pitch)) {
                 usb_midi_handlePitchChange = fptr;
         };
+        inline void setHandleSysEx(void (*fptr)(const uint8_t *data, uint16_t length, bool complete)) {
+                usb_midi_handleSysEx = (void (*)(const uint8_t *, uint16_t, uint8_t))fptr;
+        }
         inline void setHandleRealTimeSystem(void (*fptr)(uint8_t realtimebyte)) {
                 usb_midi_handleRealTimeSystem = fptr;
         };


### PR DESCRIPTION
Switched order of parameters as suggested by PaulStoffregen.
