### PR TITLE
Allow custom USB enumeration.

### DIFF
--- a/teensy3/usb_desc.c
+++ b/teensy3/usb_desc.c
@@ -31,6 +31,7 @@
 #if F_CPU >= 20000000
 
 #include "usb_desc.h"
+#ifdef NUM_ENDPOINTS
 #include "usb_names.h"
 #include "mk20dx128.h"
 #include "avr_functions.h"
@@ -891,5 +892,5 @@ const uint8_t usb_endpoint_config_table[NUM_ENDPOINTS] =
 };
 
 
-
+#endif // NUM_ENDPOINTS
 #endif // F_CPU >= 20 MHz

--- a/teensy3/usb_desc.h
+++ b/teensy3/usb_desc.h
@@ -295,6 +295,7 @@ let me know?  http://forum.pjrc.com/forums/4-Suggestions-amp-Bug-Reports
 
 #endif
 
+#ifdef NUM_ENDPOINTS
 // NUM_ENDPOINTS = number of non-zero endpoints (0 to 15)
 extern const uint8_t usb_endpoint_config_table[NUM_ENDPOINTS];
 
@@ -306,7 +307,7 @@ typedef struct {
 } usb_descriptor_list_t;
 
 extern const usb_descriptor_list_t usb_descriptor_list[];
-
+#endif // NUM_ENDPOINTS
 
 #endif // F_CPU >= 20 MHz
 

--- a/teensy3/usb_dev.c
+++ b/teensy3/usb_dev.c
@@ -28,11 +28,11 @@
  * SOFTWARE.
  */
 
-#if F_CPU >= 20000000
+#include "usb_dev.h"
+#if F_CPU >= 20000000 && defined(NUM_ENDPOINTS)
 
 #include "mk20dx128.h"
 //#include "HardwareSerial.h"
-#include "usb_dev.h"
 #include "usb_mem.h"
 
 // buffer descriptor table
@@ -971,10 +971,10 @@ void usb_init(void)
 }
 
 
-#else // F_CPU < 20 MHz
+#else // F_CPU < 20 MHz && defined(NUM_ENDPOINTS)
 
 void usb_init(void)
 {
 }
 
-#endif // F_CPU >= 20 MHz
+#endif // F_CPU >= 20 MHz && defined(NUM_ENDPOINTS)

--- a/teensy3/usb_dev.h
+++ b/teensy3/usb_dev.h
@@ -31,7 +31,8 @@
 #ifndef _usb_dev_h_
 #define _usb_dev_h_
 
-#if F_CPU >= 20000000
+#include "usb_desc.h"
+#if F_CPU >= 20000000 && defined(NUM_ENDPOINTS)
 
 // This header is NOT meant to be included when compiling
 // user sketches in Arduino.  The low-level functions
@@ -39,7 +40,6 @@
 // code which provides higher-level interfaces to the user.
 
 #include "usb_mem.h"
-#include "usb_desc.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -102,7 +102,19 @@ extern void usb_flightsim_flush_callback(void);
 }
 #endif
 
+#else // F_CPU >= 20000000 && defined(NUM_ENDPOINTS)
 
-#endif // F_CPU >= 20 MHz
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void usb_init(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+
+#endif // F_CPU >= 20000000 && defined(NUM_ENDPOINTS)
 
 #endif

--- a/teensy3/usb_mem.c
+++ b/teensy3/usb_mem.c
@@ -28,11 +28,11 @@
  * SOFTWARE.
  */
 
-#if F_CPU >= 20000000
+#include "usb_dev.h"
+#if F_CPU >= 20000000 && defined(NUM_ENDPOINTS)
 
 #include "mk20dx128.h"
 //#include "HardwareSerial.h"
-#include "usb_dev.h"
 #include "usb_mem.h"
 
 __attribute__ ((section(".usbbuffers"), used))
@@ -106,4 +106,4 @@ void usb_free(usb_packet_t *p)
 	//serial_print("\n");
 }
 
-#endif // F_CPU >= 20 MHz
+#endif // F_CPU >= 20 MHz && defined(NUM_ENDPOINTS)


### PR DESCRIPTION
This patch simply checks if NUM_ENDPOINTS is defined, and will bypass the
built-in USB descriptor, device and memory code, and allows a custom setting.
This bug does not affect the IDE unless someone adds the custom option to
the boards.txt file, and provides replacement code in a library or sketch.
It can also be used to turn off USB by providing no replacements, while
allowing speeds >= 20MHz.
