### PR TITLE
fix for (long) destinationBuffer  TCD->ATTR_DST

### DIFF
--- a/teensy3/DMAChannel.h
+++ b/teensy3/DMAChannel.h
@@ -216,7 +216,7 @@ public:
 	void destinationBuffer(volatile unsigned long p[], unsigned int len) {
 		TCD->DADDR = p;
 		TCD->DOFF = 4;
-		TCD->ATTR_DST = 1;
+		TCD->ATTR_DST = 2;
 		TCD->NBYTES = 4;
 		TCD->DLASTSGA = -len;
 		TCD->BITER = len / 4;


### PR DESCRIPTION
This was set for 16 bit.
