### PR TITLE
Update DMAChannel.h

### DIFF
--- a/teensy3/DMAChannel.h
+++ b/teensy3/DMAChannel.h
@@ -15,7 +15,7 @@
 // https://github.com/pedvide/ADC
 // https://github.com/duff2013/SerialEvent
 // https://github.com/pixelmatix/SmartMatrix
-// https://github.com/crteensy/DmaSpi
+// https://github.com/crteensy/DmaSpi <-- DmaSpi has adopted this scheme
 
 #ifdef __cplusplus
 


### PR DESCRIPTION
I'm planning to merge the teensyduino 1.20 branch of DmaSpi to master tomorrow and then you can remove that hint, or update it please.
