### PR TITLE
Fix F_PLL

### DIFF
--- a/teensy3/kinetis.h
+++ b/teensy3/kinetis.h
@@ -237,7 +237,7 @@ enum IRQ_NUMBER_t {
  #define F_BUS 36000000
  #define F_MEM 24000000
 #elif (F_CPU == 48000000)
- #define F_PLL 96000000
+ #define F_PLL 48000000
  #if defined(KINETISK)
  #define F_BUS 48000000
  #elif defined(KINETISL)
@@ -245,19 +245,19 @@ enum IRQ_NUMBER_t {
  #endif
  #define F_MEM 24000000
 #elif (F_CPU == 24000000)
- #define F_PLL 96000000
+ #define F_PLL 24000000
  #define F_BUS 24000000
  #define F_MEM 24000000
 #elif (F_CPU == 16000000)
- #define F_PLL 96000000
+ #define F_PLL 16000000
  #define F_BUS 16000000
  #define F_MEM 16000000
 #elif (F_CPU == 8000000)
- #define F_PLL 96000000
+ #define F_PLL 8000000
  #define F_BUS 8000000
  #define F_MEM 8000000
 #elif (F_CPU == 4000000)
- #define F_PLL 96000000
+ #define F_PLL 4000000
  #define F_BUS 4000000
  #define F_MEM 4000000
 #elif (F_CPU == 2000000)


### PR DESCRIPTION
Shouldn't the F_PLL match the F_CPU when defined in kinetis.h? Anyway this fixes them if thats the case.