### PR TITLE
(MKL26Z64) update for F_CPU <= 16MHz

### DIFF
--- a/teensy3/HardwareSerial.h
+++ b/teensy3/HardwareSerial.h
@@ -90,7 +90,15 @@
 #define BAUD2DIV2(baud) (((F_CPU * 2) + ((baud) >> 1)) / (baud))
 #define BAUD2DIV3(baud) (((F_BUS * 2) + ((baud) >> 1)) / (baud))
 #elif defined(KINETISL)
+
+#if F_CPU <= 2000000
+#define BAUD2DIV(baud)  (((F_PLL / 16 ) + ((baud) >> 1)) / (baud))
+#elif F_CPU <= 16000000
+#define BAUD2DIV(baud)  (((F_PLL / (F_PLL / 1000000)) + ((baud) >> 1)) / (baud))
+#else
 #define BAUD2DIV(baud)  (((F_PLL / 2 / 16) + ((baud) >> 1)) / (baud))
+#endif
+
 #define BAUD2DIV2(baud) (((F_BUS / 16) + ((baud) >> 1)) / (baud))
 #define BAUD2DIV3(baud) (((F_BUS / 16) + ((baud) >> 1)) / (baud))
 #endif

--- a/teensy3/kinetis.h
+++ b/teensy3/kinetis.h
@@ -249,15 +249,15 @@ enum IRQ_NUMBER_t {
  #define F_BUS 24000000
  #define F_MEM 24000000
 #elif (F_CPU == 16000000)
- #define F_PLL 96000000
+ #define F_PLL 16000000
  #define F_BUS 16000000
  #define F_MEM 16000000
 #elif (F_CPU == 8000000)
- #define F_PLL 96000000
+ #define F_PLL 8000000
  #define F_BUS 8000000
  #define F_MEM 8000000
 #elif (F_CPU == 4000000)
- #define F_PLL 96000000
+ #define F_PLL 4000000
  #define F_BUS 4000000
  #define F_MEM 4000000
 #elif (F_CPU == 2000000)

--- a/teensy3/mk20dx128.c
+++ b/teensy3/mk20dx128.c
@@ -554,7 +554,7 @@ void ResetHandler(void)
 	//  C2[LP] bit is written to 1
 #else
 	// enable capacitors for crystal
-	OSC0_CR = OSC_SC8P | OSC_SC2P | 0x80;
+	OSC0_CR = OSC_SC8P | OSC_SC2P | OSC_ERCLKEN;
 	// enable osc, 8-32 MHz range, low power mode
 	MCG_C2 = MCG_C2_RANGE0(2) | MCG_C2_EREFS;
 	// switch to crystal as clock source, FLL input = 16 MHz / 512

--- a/teensy3/mk20dx128.c
+++ b/teensy3/mk20dx128.c
@@ -553,8 +553,13 @@ void ResetHandler(void)
 	//  C6[PLLS] bit is written to 0
 	//  C2[LP] bit is written to 1
 #else
-	// enable capacitors for crystal
-	OSC0_CR = OSC_SC8P | OSC_SC2P | OSC_ERCLKEN;
+    #if defined(KINETISK)
+    // enable capacitors for crystal
+    OSC0_CR = OSC_SC8P | OSC_SC2P;
+    #elif defined(KINETISL)
+    // enable capacitors for crystal
+    OSC0_CR = OSC_SC8P | OSC_SC2P | OSC_ERCLKEN;
+    #endif
 	// enable osc, 8-32 MHz range, low power mode
 	MCG_C2 = MCG_C2_RANGE0(2) | MCG_C2_EREFS;
 	// switch to crystal as clock source, FLL input = 16 MHz / 512

--- a/teensy3/pins_teensy.c
+++ b/teensy3/pins_teensy.c
@@ -391,7 +391,13 @@ extern void usb_init(void);
 #if defined(KINETISK)
 #define F_TIMER F_BUS
 #elif defined(KINETISL)
+
+#if F_CPU > 16000000
 #define F_TIMER (F_PLL/2)
+#else 
+#define F_TIMER (F_PLL)
+#endif//Low Power
+
 #endif
 
 #if F_TIMER == 60000000

--- a/teensy3/serial1.c
+++ b/teensy3/serial1.c
@@ -107,7 +107,7 @@ void serial_begin(uint32_t divisor)
 	UART0_C1 = 0;
 	UART0_PFIFO = 0;
 #endif
-#elif defined(KINETISL_UART1)
+#elif defined(KINETISL_UART0)
 	UART0_BDH = (divisor >> 8) & 0x1F;
 	UART0_BDL = divisor & 0xFF;
 	UART0_C1 = 0;


### PR DESCRIPTION
Tested just Uart1 so far and there is a problem at 2 MHz with the baud rate divisor. I'm just not seeing how to produce the right divisor? Also haven't looked at any other peripherals so I'm sure they will need some help also. Here is list of what I did:

1. Updated Uart BAUD2DIV, problem @ 2 MHz with baud generation.
2. Fixed F_PLL value <= 16 MHz.
3. Enabled MCGIRCLK and OSRERCLK @ F_CPU <= 16 MHz.
4. Fixed divider, no need to set SIM_CLKDIV1_OUTDIV2 @ F_CPU <= 16 MHz.
5. Fixed SIM_SOPT2_CLKOUTSEL & SIM_SOPT2_UART0SRC clocks @ F_CPU <= 16 MHz.
6. Fixed F_TIMER, not sure this is right but had touch it to make it compile, might want to double check this.

