### PR TITLE
Fix Flash and Bus Clock dividers for F_CPU <= 16MHz for TeensyLC

### DIFF
--- a/teensy3/mk20dx128.c
+++ b/teensy3/mk20dx128.c
@@ -658,7 +658,7 @@ void ResetHandler(void)
 #if defined(KINETISK)
     SIM_CLKDIV1 = SIM_CLKDIV1_OUTDIV1(1) | SIM_CLKDIV1_OUTDIV2(1) |	 SIM_CLKDIV1_OUTDIV4(1);
 #elif defined(KINETISL)
-    SIM_CLKDIV1 = SIM_CLKDIV1_OUTDIV1(1) | SIM_CLKDIV1_OUTDIV4(1);
+    SIM_CLKDIV1 = SIM_CLKDIV1_OUTDIV1(1) | SIM_CLKDIV1_OUTDIV4(0);
 #endif
 #elif F_CPU == 4000000
     // config divisors: 4 MHz core, 4 MHz bus, 2 MHz flash
@@ -669,7 +669,7 @@ void ResetHandler(void)
 #if defined(KINETISK)
     SIM_CLKDIV1 = SIM_CLKDIV1_OUTDIV1(3) | SIM_CLKDIV1_OUTDIV2(3) |	 SIM_CLKDIV1_OUTDIV4(3);
 #elif defined(KINETISL)
-    SIM_CLKDIV1 = SIM_CLKDIV1_OUTDIV1(3) | SIM_CLKDIV1_OUTDIV4(3);
+    SIM_CLKDIV1 = SIM_CLKDIV1_OUTDIV1(3) | SIM_CLKDIV1_OUTDIV4(0);
 #endif
 #elif F_CPU == 2000000
     // since we are running from the fast internal reference clock 4MHz

--- a/teensy3/mk20dx128.c
+++ b/teensy3/mk20dx128.c
@@ -679,6 +679,7 @@ void ResetHandler(void)
 #if defined(KINETISK)
     SIM_CLKDIV1 = SIM_CLKDIV1_OUTDIV1(0) | SIM_CLKDIV1_OUTDIV2(0) |	 SIM_CLKDIV1_OUTDIV4(1);
 #elif defined(KINETISL)
+    // config divisors: 2 MHz core, 1 MHz bus, 1 MHz flash
     SIM_CLKDIV1 = SIM_CLKDIV1_OUTDIV1(0) | SIM_CLKDIV1_OUTDIV4(1);
 #endif
 #else


### PR DESCRIPTION
I believe this fixes the bus and flash clocks on the TeensyLC from a previous pull I did: https://github.com/PaulStoffregen/cores/pull/51. I now see where the flash and bus get thier divide value from OUTDIV and OUTDIV4.

I tested Serial1,2,3 and they work from 4-16 MHz but at 2 MHz the baud rate generator can't divide down to most of the standard baud rates for either System or Bus clocks that the serial ports use even though Serial1 has the OSR. Maybe I'm not seeing it but I'll bring this up on the forum.