### PR TITLE
Fix for IDE Menu option "NO USB" @ F_CPU <= 16MHz LC/T3.x

### DIFF
--- a/teensy3/usb_inst.cpp
+++ b/teensy3/usb_inst.cpp
@@ -77,6 +77,8 @@ usb_serial_class Serial;
 
 #if defined(USB_SERIAL) || defined(USB_SERIAL_HID)
 usb_serial_class Serial;
+#elif (USB_DISABLED)
+usb_serial_class Serial;
 #else
 usb_seremu_class Serial;
 #endif


### PR DESCRIPTION
This makes it so you can compile with IDE option "NO USB" at F_CPU <= 16MHz for Teensy 3.x/LC. This is important for LC's small RAM if not using usb at those slower speeds. 