### PR TITLE
delay/micros fail until first clock tick

### DIFF
--- a/teensy3/mk20dx128.c
+++ b/teensy3/mk20dx128.c
@@ -717,7 +717,9 @@ void ResetHandler(void)
 #endif
 
 	// initialize the SysTick counter
+	// Set Reset value, clear current and set control and status
 	SYST_RVR = (F_CPU / 1000) - 1;
+	SYST_CVR = 0; 
 	SYST_CSR = SYST_CSR_CLKSOURCE | SYST_CSR_TICKINT | SYST_CSR_ENABLE;
 	SCB_SHPR3 = 0x20200000;  // Systick = priority 32
 


### PR DESCRIPTION
On the Teensy LC - there is an issue that delay was not working at the
beginning of setup.  Turns out that the system tick clock was giving a
real high bogus value, which cause micros to give bad value, until the
first tick at which time the value was reset to a good state.
More details in thread: