### PR TITLE
strlen is already in string.h

### DIFF
--- a/teensy3/nonstd.c
+++ b/teensy3/nonstd.c
@@ -32,14 +32,6 @@
 #include <string.h>
 #include <stdlib.h>
 
-size_t strlen(const char *s)
-{
-	size_t n=0;
-
-	while (*s++) n++;
-	return n;
-}
-
 
 char * ultoa(unsigned long val, char *buf, int radix) 	
 {


### PR DESCRIPTION
or, alternativly one could write size_t strlen(const char *s) {return __builtin_strlen(s);} to use the gcc-builtin function.
I think, both are faster than the bytewise search.