### PR TITLE
Fix packet stuffing in usb_flightsim_flush_callback

### DIFF
--- a/teensy3/usb_flightsim.cpp
+++ b/teensy3/usb_flightsim.cpp
@@ -377,7 +377,7 @@ extern "C" {
 void usb_flightsim_flush_callback(void)
 {
 	if (tx_noautoflush || !tx_packet || tx_packet->index == 0) return;
-	for (int i=tx_packet->index; i < FLIGHTSIM_TX_ENDPOINT; i++) {
+	for (int i=tx_packet->index; i < FLIGHTSIM_TX_SIZE; i++) {
 		tx_packet->buf[i] = 0;
 	}
 	tx_packet->len = FLIGHTSIM_TX_SIZE;


### PR DESCRIPTION
Picking up some work on the Flightsim interface to incorporate long datarefs. Reviewing the T3 implementation, I found this typo. 