### PR TITLE
Update begin() - wait for availability

### DIFF
--- a/teensy3/usb_serial.h
+++ b/teensy3/usb_serial.h
@@ -69,7 +69,7 @@ extern volatile uint8_t usb_configuration;
 class usb_serial_class : public Stream
 {
 public:
-        void begin(long) { /* TODO: call a function that tries to wait for enumeration */ };
+        void begin(long) {  int m = millis(); while(!(usb_configuration  && (usb_cdc_line_rtsdtr & (USB_SERIAL_DTR | USB_SERIAL_RTS))) && (millis()-m < 1500) );  };
         void end() { /* TODO: flush output and shut down USB port */ };
         virtual int available() { return usb_serial_available(); }
         virtual int read() { return usb_serial_getchar(); }


### PR DESCRIPTION
New users often have problems with printing values in setup().
This does not work, because the teensy is too fast, and prints before the usb-connection is ready.
This fix mimics "While (!Serial);" with a additional timeout.

Example: https://forum.pjrc.com/threads/28992-arduino-compatibility-writing-to-serial-monitor-from-setup-does-not-work