### PR TITLE
Remove functions already defined in the standard library

### DIFF
--- a/teensy3/avr_functions.h
+++ b/teensy3/avr_functions.h
@@ -94,10 +94,14 @@ static inline void eeprom_update_block(const void *buf, void *addr, uint32_t len
 
 char * ultoa(unsigned long val, char *buf, int radix);
 char * ltoa(long val, char *buf, int radix);
+
+#if defined(_NEWLIB_VERSION) && (__NEWLIB__ < 2 || __NEWLIB__ == 2 && __NEWLIB_MINOR__ < 2)
 static inline char * utoa(unsigned int val, char *buf, int radix) __attribute__((always_inline, unused));
 static inline char * utoa(unsigned int val, char *buf, int radix) { return ultoa(val, buf, radix); }
 static inline char * itoa(int val, char *buf, int radix) __attribute__((always_inline, unused));
 static inline char * itoa(int val, char *buf, int radix) { return ltoa(val, buf, radix); }
+#endif
+
 char * dtostrf(float val, int width, unsigned int precision, char *buf);
 
 


### PR DESCRIPTION
Perhaps I'm supposed to do something else, but with `arm-none-eabi-newlib` I get errors because `utoa` and `itoa` are already defined in `stdlib.h`. This is similar to commit 7d3da62a4817ad5e4d96e4271642d3b294ce0e94.