### PR TITLE
prevent including Serial1,2,3 if not used

### DIFF
--- a/teensy3/yield.cpp
+++ b/teensy3/yield.cpp
@@ -41,8 +41,14 @@ void yield(void)
 	if (running) return; // TODO: does this need to be atomic?
 	running = 1;
 	if (Serial.available()) serialEvent();
+	#ifndef _DISABLE_SERIAL1
 	if (Serial1.available()) serialEvent1();
+	#endif
+	#ifndef _DISABLE_SERIAL2
 	if (Serial2.available()) serialEvent2();
+	#endif
+	#ifndef _DISABLE_SERIAL3
 	if (Serial3.available()) serialEvent3();
+	#endif
 	running = 0;
 };


### PR DESCRIPTION
Disabling the corresponding calls is sufficiant to prevent including  Serial1, Serial2 & Serial3.
The #defines must be set before yield.cpp is built.
For example in Boards.txt, or perhaps the new buildsystem allows a better way (per sketch)? 
