### PR TITLE
include, warnings, make use of USB_DISABLE

### DIFF
--- a/teensy3/Client.h
+++ b/teensy3/Client.h
@@ -1,4 +1,4 @@
-#if ARDUINO >= 100
+#if defined(ARDUINO) && ARDUINO >= 100
 
 #ifndef client_h
 #define client_h

--- a/teensy3/IPAddress.h
+++ b/teensy3/IPAddress.h
@@ -26,7 +26,7 @@
 #ifndef IPAddress_h
 #define IPAddress_h
 
-#include <Printable.h>
+#include "Printable.h"
 
 // A class to make it easier to handle and pass around IP addresses
 

--- a/teensy3/Print.cpp
+++ b/teensy3/Print.cpp
@@ -24,7 +24,7 @@
 //#include <string.h>
 #include <inttypes.h>
 //#include <math.h>
-//#include <avr/pgmspace.h>
+//#include "avr/pgmspace.h"
 //#include "wiring.h"
 
 #include "Print.h"

--- a/teensy3/Server.h
+++ b/teensy3/Server.h
@@ -1,4 +1,4 @@
-#if ARDUINO >= 100
+#if defined(ARDUINO) && ARDUINO >= 100
 
 #ifndef server_h
 #define server_h

--- a/teensy3/Udp.h
+++ b/teensy3/Udp.h
@@ -37,8 +37,8 @@
 #ifndef udp_h
 #define udp_h
 
-#include <Stream.h>
-#include <IPAddress.h>
+#include "Stream.h"
+#include "IPAddress.h"
 
 class UDP : public Stream {
 

--- a/teensy3/Udp.h
+++ b/teensy3/Udp.h
@@ -32,7 +32,7 @@
  * bjoern@cs.stanford.edu 12/30/2008
  */
 
-#if ARDUINO >= 100
+#if defined(ARDUINO) && ARDUINO >= 100
 
 #ifndef udp_h
 #define udp_h

--- a/teensy3/WProgram.h
+++ b/teensy3/WProgram.h
@@ -8,8 +8,8 @@
 // some libraries and sketches depend on this
 // AVR stuff, assuming Arduino.h or WProgram.h
 // automatically includes it...
-#include <avr/pgmspace.h>
-#include <avr/interrupt.h>
+#include "avr/pgmspace.h"
+#include "avr/interrupt.h"
 
 #include "avr_functions.h"
 #include "wiring.h"
@@ -23,7 +23,7 @@
 #include "avr_emulation.h"
 #include "usb_serial.h"
 #include "usb_seremu.h"
-#include "usb_keyboard.h"
+//#include "usb_keyboard.h"
 #include "usb_mouse.h"
 #include "usb_joystick.h"
 #include "usb_midi.h"

--- a/teensy3/core_cm4.h
+++ b/teensy3/core_cm4.h
@@ -151,9 +151,9 @@
 #endif
 
 #include <stdint.h>                      /* standard types definitions                      */
-#include <core_cmInstr.h>                /* Core Instruction Access                         */
-#include <core_cmFunc.h>                 /* Core Function Access                            */
-#include <core_cm4_simd.h>               /* Compiler specific SIMD Intrinsics               */
+#include "core_cmInstr.h"                /* Core Instruction Access                         */
+#include "core_cmFunc.h"                 /* Core Function Access                            */
+#include "core_cm4_simd.h"               /* Compiler specific SIMD Intrinsics               */
 
 #endif /* __CORE_CM4_H_GENERIC */
 

--- a/teensy3/elapsedMillis.h
+++ b/teensy3/elapsedMillis.h
@@ -25,7 +25,7 @@
 #define elapsedMillis_h
 #ifdef __cplusplus
 
-#if ARDUINO >= 100
+#if defined(ARDUINO) && ARDUINO >= 100
 #include "Arduino.h"
 #else
 #include "WProgram.h"

--- a/teensy3/keylayouts.c
+++ b/teensy3/keylayouts.c
@@ -28,7 +28,6 @@
  * SOFTWARE.
  */
 
-#include <avr/pgmspace.h>
 #include <stdint.h>
 
 #include "keylayouts.h"

--- a/teensy3/keylayouts.h
+++ b/teensy3/keylayouts.h
@@ -32,7 +32,6 @@
 #define KEYLAYOUTS_H__
 
 #include <stdint.h>
-#include <avr/pgmspace.h>
 
 #ifdef __cplusplus
 extern "C"{

--- a/teensy3/mk20dx128.c
+++ b/teensy3/mk20dx128.c
@@ -877,7 +877,7 @@ void ResetHandler(void)
 		// flag into the VBAT register file indicating the
 		// RTC is set with known-stale time and should be
 		// updated when fresh time is known.
-		#if ARDUINO >= 10600
+		#if defined(ARDUINO) && ARDUINO >= 10600
 		rtc_set((uint32_t)&__rtc_localtime);
 		#else
 		rtc_set(TIME_T);
@@ -891,7 +891,7 @@ void ResetHandler(void)
 		// the RTC with this, and clear the VBAT resister file
 		// data so we don't mess with the time after it's been
 		// set well.
-		#if ARDUINO >= 10600
+		#if defined(ARDUINO) && ARDUINO >= 10600
 		rtc_set((uint32_t)&__rtc_localtime);
 		#else
 		rtc_set(TIME_T);

--- a/teensy3/mk20dx128.c
+++ b/teensy3/mk20dx128.c
@@ -29,8 +29,7 @@
  */
 
 #include "kinetis.h"
-#include "core_pins.h" // testing only
-#include "ser_print.h" // testing only
+//#include "ser_print.h" // testing only
 
 extern unsigned long _stext;
 extern unsigned long _etext;
@@ -863,7 +862,6 @@ void ResetHandler(void)
 	SYST_CSR = SYST_CSR_CLKSOURCE | SYST_CSR_TICKINT | SYST_CSR_ENABLE;
 	SCB_SHPR3 = 0x20200000;  // Systick = priority 32
 
-	//init_pins();
 	__enable_irq();
 
 	_init_Teensyduino_internal_();

--- a/teensy3/mk20dx128.c
+++ b/teensy3/mk20dx128.c
@@ -956,7 +956,7 @@ void _exit(int status)
 }
 
 __attribute__((weak)) 
-void __cxa_pure_virtual()
+void __cxa_pure_virtual(void)
 {
 	while (1);
 }

--- a/teensy3/pins_teensy.c
+++ b/teensy3/pins_teensy.c
@@ -571,10 +571,14 @@ void _init_Teensyduino_internal_(void)
 	FTM3_SC = FTM_SC_CLKS(1) | FTM_SC_PS(DEFAULT_FTM_PRESCALE);
 #endif
 	analog_init();
+	#ifndef USB_DISABLED
 	// for background about this startup delay, please see this conversation
+	// Note, when running without USB (and no delay), an additional delay may be required
+	// for some devices.
 	// https://forum.pjrc.com/threads/31290-Teensey-3-2-Teensey-Loader-1-24-Issues?p=87273&viewfull=1#post87273
 	delay(250);
 	usb_init();
+	#endif
 }
 
 

--- a/teensy3/usb_serial.h
+++ b/teensy3/usb_serial.h
@@ -65,6 +65,7 @@ extern volatile uint8_t usb_configuration;
 
 // C++ interface
 #ifdef __cplusplus
+#include "core_pins.h" // for yield millis
 #include "Stream.h"
 class usb_serial_class : public Stream
 {

--- a/teensy3/wiring.h
+++ b/teensy3/wiring.h
@@ -25,7 +25,7 @@
 #ifndef Wiring_h
 #define Wiring_h
 
-//#include <avr/io.h>
+//#include "avr/io.h"
 #include <stdint.h>
 #include <stdlib.h>
 #include "binary.h"


### PR DESCRIPTION
I'm building my project without the Arduino IDE, just the arm gcc, newlib, and this.  I did test these changes with a sample program with the Arduino IDE to verify I didn't see any problems.  I broke up the changes into logical commits to make it easy to review, what is your preference, would you have liked it in just one commit?

I would like to (time pending), make some changes to allow a more bare metal compile.  Specifically make it easier to compile things out, and a little more control over what is initialized on start up.  Things like I'm not using the digitalWrite so I don't need those register lookup tables, I'm not doing analog, so I don't need that start up logic.  I was thinking following the example of the current USB_DISABLE, to add additional disables.  That would let the Arduino IDE continue to compile everything out of the box.  What do you think
