### PR TITLE
Do not put ResetHandler in .startup with clang

### DIFF
--- a/teensy3/mk20dx128.c
+++ b/teensy3/mk20dx128.c
@@ -577,7 +577,12 @@ void startup_early_hook(void)		__attribute__ ((weak, alias("startup_default_earl
 void startup_late_hook(void)		__attribute__ ((weak, alias("startup_default_late_hook")));
 
 
+#ifdef __clang__
+// Clang seems to generate slightly larger code with Os than gcc
+__attribute__ ((optimize("-Os")))
+#else
 __attribute__ ((section(".startup"),optimize("-Os")))
+#endif
 void ResetHandler(void)
 {
 	uint32_t *src = &_etext;


### PR DESCRIPTION
Clang seems to generate slightly larger code with Os than gcc, and
ResetHandler doesn't fit into the .startup section.