### PR TITLE
Remove definitions of itoa and utoa

### DIFF
--- a/teensy3/avr_functions.h
+++ b/teensy3/avr_functions.h
@@ -94,10 +94,6 @@ static inline void eeprom_update_block(const void *buf, void *addr, uint32_t len
 
 char * ultoa(unsigned long val, char *buf, int radix);
 char * ltoa(long val, char *buf, int radix);
-static inline char * utoa(unsigned int val, char *buf, int radix) __attribute__((always_inline, unused));
-static inline char * utoa(unsigned int val, char *buf, int radix) { return ultoa(val, buf, radix); }
-static inline char * itoa(int val, char *buf, int radix) __attribute__((always_inline, unused));
-static inline char * itoa(int val, char *buf, int radix) { return ltoa(val, buf, radix); }
 char * dtostrf(float val, int width, unsigned int precision, char *buf);
 
 


### PR DESCRIPTION
These are declared (although not part of the C standard) in stdlib.h.