### PR TITLE
Un-inlined and weakened the definitions of utoa and itoa.

### DIFF
--- a/teensy3/avr_functions.h
+++ b/teensy3/avr_functions.h
@@ -94,10 +94,9 @@ static inline void eeprom_update_block(const void *buf, void *addr, uint32_t len
 
 char * ultoa(unsigned long val, char *buf, int radix);
 char * ltoa(long val, char *buf, int radix);
-static inline char * utoa(unsigned int val, char *buf, int radix) __attribute__((always_inline, unused));
-static inline char * utoa(unsigned int val, char *buf, int radix) { return ultoa(val, buf, radix); }
-static inline char * itoa(int val, char *buf, int radix) __attribute__((always_inline, unused));
-static inline char * itoa(int val, char *buf, int radix) { return ltoa(val, buf, radix); }
+char * utoa(unsigned int val, char *buf, int radix) __attribute__((weak, unused));
+char * itoa(int val, char *buf, int radix) __attribute__((weak, unused));
+
 char * dtostrf(float val, int width, unsigned int precision, char *buf);
 
 

--- a/teensy3/nonstd.c
+++ b/teensy3/nonstd.c
@@ -66,6 +66,16 @@ char * ltoa(long val, char *buf, int radix)
 	}
 }
 
+char * utoa(unsigned int val, char *buf, int radix)
+{
+	return ultoa(val, buf, radix);
+}
+
+char * itoa(int val, char *buf, int radix)
+{
+	return ltoa(val, buf, radix);
+}
+
 char * dtostrf(float val, int width, unsigned int precision, char *buf)
 {
 	int decpt, sign, reqd, pad;


### PR DESCRIPTION
The problem with the definitions of utoa and itoa is that they
are implemented in the latest version newlib. This means that
these functions will be redefined from a linker point of view,
if the linker uses versions of newlib, in which utoa and itoa are
implemented.

As the weak attribute is not compatible with static and inline,
both static and inline was removed from the definition.

The implementation of utoa and itoa was moved to nonstd.c.
