### PR TITLE
bug fix, USB system, enable irq only if it was enabled

### DIFF
--- a/teensy3/avr_emulation.h
+++ b/teensy3/avr_emulation.h
@@ -1459,7 +1459,7 @@ class SREGemulation
 public:
 	operator int () const __attribute__((always_inline)) {
 		uint32_t primask;
-		asm volatile("mrs %0, primask\n" : "=r" (primask)::);
+		__irq_status(primask);
 		if (primask) return 0;
 		return (1<<7);
 	}

--- a/teensy3/kinetis.h
+++ b/teensy3/kinetis.h
@@ -4526,8 +4526,11 @@ typedef struct __attribute__((packed)) {
 
 
 
-#define __disable_irq() __asm__ volatile("CPSID i":::"memory");
-#define __enable_irq()	__asm__ volatile("CPSIE i":::"memory");
+#define __disable_irq()  __asm__ volatile("CPSID i":::"memory");
+#define __enable_irq()   __asm__ volatile("CPSIE i":::"memory");
+// assigns 1 if irqs are disabled (exceptions are prevented), 0 if enabled
+// use int or uint32_t or the compiler will clear the full register after
+#define __irq_status(irq_disabled) __asm__ volatile("mrs %0, primask\n" : "=r" (irq_disabled)::);
 
 // System Control Space (SCS), ARMv7 ref manual, B3.2, page 708
 #define SCB_CPUID		(*(const    uint32_t *)0xE000ED00) // CPUID Base Register

--- a/teensy3/usb_desc.c
+++ b/teensy3/usb_desc.c
@@ -848,8 +848,9 @@ struct usb_string_descriptor_struct usb_string_serial_number_default = {
 void usb_init_serialnumber(void)
 {
 	char buf[11];
-	uint32_t i, num;
+	uint32_t i, num, irq_disabled;
 
+	__irq_status(irq_disabled);
 	__disable_irq();
 	FTFL_FSTAT = FTFL_FSTAT_RDCOLERR | FTFL_FSTAT_ACCERR | FTFL_FSTAT_FPVIOL;
 	FTFL_FCCOB0 = 0x41;
@@ -857,7 +858,9 @@ void usb_init_serialnumber(void)
 	FTFL_FSTAT = FTFL_FSTAT_CCIF;
 	while (!(FTFL_FSTAT & FTFL_FSTAT_CCIF)) ; // wait
 	num = *(uint32_t *)&FTFL_FCCOB7;
-	__enable_irq();
+	if(!irq_disabled) {
+		__enable_irq();
+	}
 	// add extra zero to work around OS-X CDC-ACM driver bug
 	if (num < 10000000) num = num * 10;
 	ultoa(num, buf, 10);


### PR DESCRIPTION
I have a program that's receiving data over USB serial and consuming that data as timers expire (two interrupt routines).  I'm having data corruption, hangs, and other odd problems.  I disabled interrupts in my routines, but I'm calling the usb_serial routines and they unconditionally enable interrupts.  Here are corrected versions of the usb routines that will only enable interrupts if interrupts were previously enabled.  This fixed the problems I was seeing.
