### PR TITLE
introduce send/receive notification  usb_tx_cb/usb_rx_cb

### DIFF
--- a/teensy3/usb_dev.c
+++ b/teensy3/usb_dev.c
@@ -718,7 +718,12 @@ void _reboot_Teensyduino_(void)
 	__asm__ volatile("bkpt");
 }
 
+void usb_unused_cb(void)
+{
+}
 
+void usb_tx_cb(void)	__attribute__ ((weak, alias("usb_unused_cb")));
+void usb_rx_cb(void)	__attribute__ ((weak, alias("usb_unused_cb")));
 
 void usb_isr(void)
 {
@@ -829,6 +834,7 @@ void usb_isr(void)
 						break;
 					}
 				}
+				usb_tx_cb();
 			} else { // receive
 				packet->len = b->desc >> 16;
 				if (packet->len > 0) {
@@ -865,6 +871,7 @@ void usb_isr(void)
 						b->desc = 0;
 						usb_rx_memory_needed++;
 					}
+					usb_rx_cb();
 				} else {
 					b->desc = BDT_DESC(64, ((uint32_t)b & 8) ? DATA1 : DATA0);
 				}

--- a/teensy3/usb_dev.h
+++ b/teensy3/usb_dev.h
@@ -55,6 +55,16 @@ uint32_t usb_tx_byte_count(uint32_t endpoint);
 uint32_t usb_tx_packet_count(uint32_t endpoint);
 void usb_tx(uint32_t endpoint, usb_packet_t *packet);
 void usb_tx_isr(uint32_t endpoint, usb_packet_t *packet);
+/* *_cb callbacks are weak symbols, define your own with "C" linkage to override
+ * this avoids introducing a conditional and the variable to hold a
+ * callback pointer
+ */
+/* called when a packet has been transmitted */
+void usb_tx_cb(void);
+#define USB_TX_CB_AVAILABLE
+/* called when a USB packet is received (non control, non 0 length) */
+void usb_rx_cb(void);
+#define USB_RX_CB_AVAILABLE
 
 extern volatile uint8_t usb_configuration;
 


### PR DESCRIPTION
The usb system is interrupt driven to be notified when packets are
sent or received, introduce functions so program using the usb
system can be notified instead of requiring polling.