### PR TITLE
add function eeprom_size()

### DIFF
--- a/teensy3/avr_functions.h
+++ b/teensy3/avr_functions.h
@@ -38,6 +38,7 @@ extern "C" {
 #endif
 
 void eeprom_initialize(void);
+uint32_t eeprom_size(void) __attribute__((const));
 uint8_t eeprom_read_byte(const uint8_t *addr) __attribute__ ((pure));
 uint16_t eeprom_read_word(const uint16_t *addr) __attribute__ ((pure));
 uint32_t eeprom_read_dword(const uint32_t *addr) __attribute__ ((pure));

--- a/teensy3/eeprom.c
+++ b/teensy3/eeprom.c
@@ -490,3 +490,5 @@ void eeprom_write_block(const void *buf, void *addr, uint32_t len)
 
 
 #endif // KINETISL
+
+uint32_t eeprom_size(void) { return EEPROM_SIZE; }


### PR DESCRIPTION
Useful to know the size !
(And would be very useful to have this  for "TeensyTransfer" )

Would it be possible to add this to 1.28 ??