### PR TITLE
Allow the teensy3 library to be used with strict C++11 conformance.

### DIFF
--- a/teensy3/wiring.h
+++ b/teensy3/wiring.h
@@ -60,6 +60,10 @@ extern "C"{
 #undef abs
 #endif
 
+#if __cplusplus >= 201103L && defined(__STRICT_ANSI__)
+#define typeof(a) decltype(a)
+#endif
+
 #define min(a, b) ({ \
   typeof(a) _a = (a); \
   typeof(b) _b = (b); \


### PR DESCRIPTION
The wiring.h file uses the "typeof" construct which is a GNU extension to the language. Under C++11 this is superseeded by the "decltype" keyword.
This change declare "typeof" to be "decltype" whenever the code is compiled with a strict C++11 compiler.