### PR TITLE
Corrected typecast in usb_flightsim.cpp

### DIFF
--- a/teensy3/usb_flightsim.cpp
+++ b/teensy3/usb_flightsim.cpp
@@ -219,7 +219,7 @@ void FlightSimFloat::update(float val)
 		if (!hasCallbackInfo) {
 			(*change_callback)(val);
 		} else {
-			(*(void(*)(long,void*))change_callback)(val,callbackInfo);
+			(*(void(*)(float,void*))change_callback)(val,callbackInfo);
 		}
 	}
 }


### PR DESCRIPTION
This change affects a feature that (probably) only was used by myself, since it's not (yet) documented on the PJRC homepage. 

The onChange functions can receive an optional void* that is configured with the dataref, which permits a single onChange function for various datarefs.

While this worked fine for FlightSimInts, a wrong typecast destroyed the value passed to the onChange function for floats when the void* was used.

Paul, I don't know how to put this in simple words on the homepage. I'm torn between documenting it for completeness and possibly confusing the user. Do you have any idea on that? Maybe, a simple example could help? Fact is that I'm using this feature in my projects...

Signed-off-by: Jorg Neves Bliesener <jbliesener@bliesener.com>