### PR TITLE
Spi1 defined

### DIFF
--- a/teensy3/avr_emulation.cpp
+++ b/teensy3/avr_emulation.cpp
@@ -10,10 +10,10 @@
  * permit persons to whom the Software is furnished to do so, subject to
  * the following conditions:
  *
- * 1. The above copyright notice and this permission notice shall be 
+ * 1. The above copyright notice and this permission notice shall be
  * included in all copies or substantial portions of the Software.
  *
- * 2. If the Software is incorporated into a build system that allows 
+ * 2. If the Software is incorporated into a build system that allows
  * selection among a list of target devices, then similar target
  * devices manufactured by PJRC.COM must be included in the list of
  * target devices and selectable in the same manner.
@@ -36,7 +36,9 @@ uint8_t SPCRemulation::pinout = 0;
 #if defined(KINETISL)
 uint8_t SPCR1emulation::pinout = 0;
 #endif
-
+#if defined(__MK64FX512__) || defined(__MK66FX1M0__)
+uint8_t SPCR1emulation::pinout = 0;
+#endif
 #ifdef HAS_SPIFIFO
 
 uint8_t SPIFIFOclass::pcs = 0;

--- a/teensy3/avr_emulation.h
+++ b/teensy3/avr_emulation.h
@@ -1091,6 +1091,66 @@ public:
 };
 extern SPCRemulation SPCR;
 
+#if defined(__MK64FX512__) || defined(__MK66FX1M0__)
+class SPCR1emulation
+{
+public:
+	inline void setMOSI(uint8_t pin) __attribute__((always_inline)) {
+		if (pin == 0) pinout &= ~1; // MOSI1 = 0  (PTB16)
+		if (pin == 21) pinout |= 1; // MOSI1 = 21 (PTD6)
+	}
+	inline void setMISO(uint8_t pin) __attribute__((always_inline)) {
+		if (pin == 1) pinout &= ~2; // MISO1 = 1  (PTB17)
+		if (pin == 5) pinout |= 2;  // MISO1 = 5  (PTD7)
+	}
+	inline void setSCK(uint8_t pin) __attribute__((always_inline)) {
+		if (pin == 20) pinout &= ~4; // SCK = 20  (PTD5)
+		if (pin == 32) pinout |= 4;  // MISO1 = 32  (PTB11)
+	}
+	inline void enable_pins(void) __attribute__((always_inline)) {
+		//serial_print("enable_pins\n");
+		if ((pinout & 1) == 0) {
+			CORE_PIN0_CONFIG = PORT_PCR_MUX(2);  // MOSI1 = 0  (PTB16)
+		} else {
+			CORE_PIN21_CONFIG = PORT_PCR_MUX(7); // MOSI1 = 21 (PTD6)
+		}
+		if ((pinout & 2) == 0) {
+			CORE_PIN1_CONFIG = PORT_PCR_MUX(2);  // MISO1 = 1  (PTB17)
+		} else {
+			CORE_PIN5_CONFIG = PORT_PCR_MUX(7);  // MISO1 = 5  (PTD7)
+		}
+		if ((pinout & 4) == 0) {
+			CORE_PIN20_CONFIG = PORT_PCR_MUX(7); // SCK1 = 20 (PTD5)
+		} else {
+			CORE_PIN32_CONFIG = PORT_PCR_MUX(2);  // MISO1 = 5  (PTD7)
+		}
+	}
+	inline void disable_pins(void) __attribute__((always_inline)) {
+		//serial_print("disable_pins\n");
+		if ((pinout & 1) == 0) {
+			CORE_PIN0_CONFIG = PORT_PCR_SRE | PORT_PCR_MUX(1);
+		} else {
+			CORE_PIN21_CONFIG = PORT_PCR_SRE | PORT_PCR_MUX(1);
+		}
+		if ((pinout & 2) == 0) {
+			CORE_PIN1_CONFIG = PORT_PCR_SRE | PORT_PCR_MUX(1);
+		} else {
+			CORE_PIN5_CONFIG = PORT_PCR_SRE | PORT_PCR_MUX(1);
+		}
+		if ((pinout & 4) == 0) {
+			CORE_PIN20_CONFIG = PORT_PCR_SRE | PORT_PCR_MUX(1); // SCK1 = 20 (PTD5)
+		} else {
+			CORE_PIN32_CONFIG = PORT_PCR_SRE | PORT_PCR_MUX(1);  // MISO1 = 5  (PTD7)
+		}
+	}
+	friend class SPIFIFO1class;
+private:
+	static uint8_t pinout;
+};
+extern SPCR1emulation SPCR1;
+
+#endif
+
 class SPSRemulation
 {
 public:
@@ -1553,9 +1613,9 @@ public:
 extern SREGemulation SREG;
 
 
-		// 22211  
+		// 22211
 		// 84062840
-		// 322111 
+		// 322111
 		// 17395173
 #if defined(__MK20DX128__) || defined(__MK20DX256__) || defined(__MK64FX512__) || defined(__MK66FX1M0__)
 

--- a/teensy3/kinetis.h
+++ b/teensy3/kinetis.h
@@ -1045,7 +1045,7 @@ enum IRQ_NUMBER_t {
 
 #define SIM_SOPT1		(*(volatile uint32_t *)0x40047000) // System Options Register 1
 #define SIM_SOPT1_USBREGEN		((uint32_t)0x80000000)		// USB regulator enable
-#define SIM_SOPT1_USBSSTBY		((uint32_t)0x40000000)		// USB regulator standby in Stop, VLPS, LLS and VLLS 
+#define SIM_SOPT1_USBSSTBY		((uint32_t)0x40000000)		// USB regulator standby in Stop, VLPS, LLS and VLLS
 #define SIM_SOPT1_USBVSTBY		((uint32_t)0x20000000)		// USB regulator standby in  VLPR and VLPW
 #define SIM_SOPT1_OSC32KSEL(n)		((uint32_t)(((n) & 3) << 18))	// 32K oscillator clock, 0=system osc, 2=rtc osc, 3=lpo
 #define SIM_SOPT1CFG		(*(volatile uint32_t *)0x40047004) // SOPT1 Configuration Register
@@ -1171,8 +1171,8 @@ enum IRQ_NUMBER_t {
 #define SIM_SCGC4_CMT			((uint32_t)0x00000004)		// CMT Clock Gate Control
 #define SIM_SCGC4_EWM			((uint32_t)0x00000002)		// EWM Clock Gate Control
 #ifdef KINETISL
-#define SIM_SCGC4_SPI1			((uint32_t)0x00800000)		// 
-#define SIM_SCGC4_SPI0			((uint32_t)0x00400000)		// 
+#define SIM_SCGC4_SPI1			((uint32_t)0x00800000)		//
+#define SIM_SCGC4_SPI0			((uint32_t)0x00400000)		//
 #endif
 #define SIM_SCGC5		(*(volatile uint32_t *)0x40048038) // System Clock Gating Control Register 5
 #define SIM_SCGC5_PORTE			((uint32_t)0x00002000)		// Port E Clock Gate Control
@@ -1263,8 +1263,8 @@ enum IRQ_NUMBER_t {
 #define RCM_RPFC		(*(volatile uint8_t  *)0x4007F004) // Reset Pin Filter Control Register
 #define RCM_RPFW		(*(volatile uint8_t  *)0x4007F005) // Reset Pin Filter Width Register
 #define RCM_MR			(*(volatile uint8_t  *)0x4007F007) // Mode Register
-#define RCM_SSRS0		(*(volatile uint8_t  *)0x4007F008) // Sticky System Reset Status Register 0 
-#define RCM_SSRS1		(*(volatile uint8_t  *)0x4007F009) // Sticky System Reset Status Register 0 
+#define RCM_SSRS0		(*(volatile uint8_t  *)0x4007F008) // Sticky System Reset Status Register 0
+#define RCM_SSRS1		(*(volatile uint8_t  *)0x4007F009) // Sticky System Reset Status Register 0
 
 // System Mode Controller
 
@@ -2523,10 +2523,10 @@ typedef struct {
 #define MCG_C2                  (KINETIS_MCG.C2)		// 40064001  MCG Control 2 Register
 #define MCG_C2_IRCS			(uint8_t)0x01			// Internal Reference Clock Select, Selects between the fast or slow internal reference clock source.
 #define MCG_C2_LP			(uint8_t)0x02			// Low Power Select, Controls whether the FLL or PLL is disabled in BLPI and BLPE modes.
-#define MCG_C2_EREFS			(uint8_t)0x04			// External Reference Select, Selects the source for the external reference clock. 
+#define MCG_C2_EREFS			(uint8_t)0x04			// External Reference Select, Selects the source for the external reference clock.
 #define MCG_C2_HGO0			(uint8_t)0x08			// High Gain Oscillator Select, Controls the crystal oscillator mode of operation
 #define MCG_C2_RANGE0(n)		(uint8_t)(((n) & 0x03) << 4)	// Frequency Range Select, Selects the frequency range for the crystal oscillator
-#define MCG_C2_LOCRE0			(uint8_t)0x80			// Loss of Clock Reset Enable, Determines whether an interrupt or a reset request is made following a loss of OSC0 
+#define MCG_C2_LOCRE0			(uint8_t)0x80			// Loss of Clock Reset Enable, Determines whether an interrupt or a reset request is made following a loss of OSC0
 #define MCG_C3                  (KINETIS_MCG.C3)		// 40064002  MCG Control 3 Register
 #define MCG_C3_SCTRIM(n)		(uint8_t)(n)			// Slow Internal Reference Clock Trim Setting
 #define MCG_C4                  (KINETIS_MCG.C4)		// 40064003  MCG Control 4 Register
@@ -2541,7 +2541,7 @@ typedef struct {
 #define MCG_C6                  (KINETIS_MCG.C6)		// 40064005  MCG Control 6 Register
 #define MCG_C6_VDIV0(n)			(uint8_t)((n) & 0x1F)		// VCO 0 Divider
 #define MCG_C6_CME0			(uint8_t)0x20			// Clock Monitor Enable
-#define MCG_C6_PLLS			(uint8_t)0x40			// PLL Select, Controls whether the PLL or FLL output is selected as the MCG source when CLKS[1:0]=00. 
+#define MCG_C6_PLLS			(uint8_t)0x40			// PLL Select, Controls whether the PLL or FLL output is selected as the MCG source when CLKS[1:0]=00.
 #define MCG_C6_LOLIE0			(uint8_t)0x80			// Loss of Lock Interrrupt Enable
 #define MCG_S                   (KINETIS_MCG.S)			// 40064006  MCG Status Register
 #define MCG_S_IRCST			(uint8_t)0x01			// Internal Reference Clock Status
@@ -3996,9 +3996,9 @@ typedef struct {
 #define KINETISL_SPI0		(*(KINETISL_SPI_t *)0x40076000)
 #define KINETISL_SPI1		(*(KINETISL_SPI_t *)0x40077000)
 #define SPI0_S			(KINETISL_SPI0.S)		// Status
-#define SPI_S_SPRF			((uint8_t)0x80)			// Read Buffer Full Flag 
+#define SPI_S_SPRF			((uint8_t)0x80)			// Read Buffer Full Flag
 #define SPI_S_SPMF			((uint8_t)0x40)			// Match Flag
-#define SPI_S_SPTEF			((uint8_t)0x20)			// Transmit Buffer Empty Flag 
+#define SPI_S_SPTEF			((uint8_t)0x20)			// Transmit Buffer Empty Flag
 #define SPI_S_MODF			((uint8_t)0x10)			// Fault Flag
 #define SPI_S_RNFULLF			((uint8_t)0x08)			// Receive FIFO nearly full flag
 #define SPI_S_TNEAREF			((uint8_t)0x04)			// Transmit FIFO nearly empty flag
@@ -4855,7 +4855,7 @@ typedef struct __attribute__((packed)) {
 #define TSI_GENCS_ESOR			((uint32_t)0x10000000)		// End-of-scan or Out-of-Range Interrupt Selection
 #define TSI_GENCS_MODE(n)		(((n) & 15) << 24)		// analog modes & status
 #define TSI_GENCS_REFCHRG(n)		(((n) & 7) << 21)		// reference  charge and discharge current
-#define TSI_GENCS_DVOLT(n)		(((n) & 3) << 19)		// voltage rails 
+#define TSI_GENCS_DVOLT(n)		(((n) & 3) << 19)		// voltage rails
 #define TSI_GENCS_EXTCHRG(n)		(((n) & 7) << 16)		// electrode charge and discharge current
 #define TSI_GENCS_PS(n)			(((n) & 7) << 13)		// prescaler
 #define TSI_GENCS_NSCN(n)		(((n) & 31) << 8)		// scan number

--- a/teensy3/kinetis.h
+++ b/teensy3/kinetis.h
@@ -3957,6 +3957,27 @@ typedef struct {
 #define SPI0_RXFR2		(KINETISK_SPI0.RXFR[2])	// DSPI Receive FIFO Registers
 #define SPI0_RXFR3		(KINETISK_SPI0.RXFR[3])	// DSPI Receive FIFO Registers
 
+#if defined(__MK64FX512__) || defined(__MK66FX1M0__)
+#define KINETISK_SPI1		(*(KINETISK_SPI_t *)0x4002D000)
+#define SPI1_MCR		(KINETISK_SPI1.MCR)	// DSPI Module Configuration Register
+#define SPI1_TCR		(KINETISK_SPI1.TCR)	// DSPI Transfer Count Register
+#define SPI1_CTAR0		(KINETISK_SPI1.CTAR0)	// DSPI Clock and Transfer Attributes Register, In Master Mode
+#define SPI1_CTAR0_SLAVE	(KINETISK_SPI1.CTAR0)	// DSPI Clock and Transfer Attributes Register, In Slave Mode
+#define SPI1_CTAR1		(KINETISK_SPI1.CTAR1)	// DSPI Clock and Transfer Attributes Register, In Master Mode
+#define SPI1_SR			(KINETISK_SPI1.SR)	// DSPI Status Register
+#define SPI1_RSER		(KINETISK_SPI1.RSER)	// DSPI DMA/Interrupt Request Select and Enable Register
+#define SPI1_PUSHR		(KINETISK_SPI1.PUSHR)	// DSPI PUSH TX FIFO Register In Master Mode
+#define SPI1_PUSHR_SLAVE	(KINETISK_SPI1.PUSHR)	// DSPI PUSH TX FIFO Register In Slave Mode
+#define SPI1_POPR		(KINETISK_SPI1.POPR)	// DSPI POP RX FIFO Register
+#define SPI1_TXFR0		(KINETISK_SPI1.TXFR[0])	// DSPI Transmit FIFO Registers
+#define SPI1_TXFR1		(KINETISK_SPI1.TXFR[1])	// DSPI Transmit FIFO Registers
+#define SPI1_TXFR2		(KINETISK_SPI1.TXFR[2])	// DSPI Transmit FIFO Registers
+#define SPI1_TXFR3		(KINETISK_SPI1.TXFR[3])	// DSPI Transmit FIFO Registers
+#define SPI1_RXFR0		(KINETISK_SPI1.RXFR[0])	// DSPI Receive FIFO Registers
+#define SPI1_RXFR1		(KINETISK_SPI1.RXFR[1])	// DSPI Receive FIFO Registers
+#define SPI1_RXFR2		(KINETISK_SPI1.RXFR[2])	// DSPI Receive FIFO Registers
+#define SPI1_RXFR3		(KINETISK_SPI1.RXFR[3])	// DSPI Receive FIFO Registers
+#endif
 #elif defined(KINETISL)
 typedef struct {
 	volatile uint8_t	S;

--- a/teensy3/kinetis.h
+++ b/teensy3/kinetis.h
@@ -3977,6 +3977,27 @@ typedef struct {
 #define SPI1_RXFR1		(KINETISK_SPI1.RXFR[1])	// DSPI Receive FIFO Registers
 #define SPI1_RXFR2		(KINETISK_SPI1.RXFR[2])	// DSPI Receive FIFO Registers
 #define SPI1_RXFR3		(KINETISK_SPI1.RXFR[3])	// DSPI Receive FIFO Registers
+
+#define KINETISK_SPI2		(*(KINETISK_SPI_t *)0x400AC000)
+#define SPI2_MCR		(KINETISK_SPI2.MCR)	// DSPI Module Configuration Register
+#define SPI2_TCR		(KINETISK_SPI2.TCR)	// DSPI Transfer Count Register
+#define SPI2_CTAR0		(KINETISK_SPI2.CTAR0)	// DSPI Clock and Transfer Attributes Register, In Master Mode
+#define SPI2_CTAR0_SLAVE	(KINETISK_SPI2.CTAR0)	// DSPI Clock and Transfer Attributes Register, In Slave Mode
+#define SPI2_CTAR1		(KINETISK_SPI2.CTAR1)	// DSPI Clock and Transfer Attributes Register, In Master Mode
+#define SPI2_SR			(KINETISK_SPI2.SR)	// DSPI Status Register
+#define SPI2_RSER		(KINETISK_SPI2.RSER)	// DSPI DMA/Interrupt Request Select and Enable Register
+#define SPI2_PUSHR		(KINETISK_SPI2.PUSHR)	// DSPI PUSH TX FIFO Register In Master Mode
+#define SPI2_PUSHR_SLAVE	(KINETISK_SPI2.PUSHR)	// DSPI PUSH TX FIFO Register In Slave Mode
+#define SPI2_POPR		(KINETISK_SPI2.POPR)	// DSPI POP RX FIFO Register
+#define SPI2_TXFR0		(KINETISK_SPI2.TXFR[0])	// DSPI Transmit FIFO Registers
+#define SPI2_TXFR1		(KINETISK_SPI2.TXFR[1])	// DSPI Transmit FIFO Registers
+#define SPI2_TXFR2		(KINETISK_SPI2.TXFR[2])	// DSPI Transmit FIFO Registers
+#define SPI2_TXFR3		(KINETISK_SPI2.TXFR[3])	// DSPI Transmit FIFO Registers
+#define SPI2_RXFR0		(KINETISK_SPI2.RXFR[0])	// DSPI Receive FIFO Registers
+#define SPI2_RXFR1		(KINETISK_SPI2.RXFR[1])	// DSPI Receive FIFO Registers
+#define SPI2_RXFR2		(KINETISK_SPI2.RXFR[2])	// DSPI Receive FIFO Registers
+#define SPI2_RXFR3		(KINETISK_SPI2.RXFR[3])	// DSPI Receive FIFO Registers
+
 #endif
 #elif defined(KINETISL)
 typedef struct {

--- a/teensy3/serial1.c
+++ b/teensy3/serial1.c
@@ -118,12 +118,18 @@ void serial_begin(uint32_t divisor)
 		#if defined(KINETISL)
 		case 3:  CORE_PIN3_CONFIG = PORT_PCR_PE | PORT_PCR_PS | PORT_PCR_PFE | PORT_PCR_MUX(2); break;
 		#endif
+		#if defined(__MK64FX512__) || defined(__MK66FX1M0__)
+		case 27: CORE_PIN27_CONFIG = PORT_PCR_PE | PORT_PCR_PS | PORT_PCR_PFE | PORT_PCR_MUX(3); break;
+		#endif
 	}
 	switch (tx_pin_num) {
 		case 1:  CORE_PIN1_CONFIG = PORT_PCR_DSE | PORT_PCR_SRE | PORT_PCR_MUX(3); break;
 		case 5:  CORE_PIN5_CONFIG = PORT_PCR_DSE | PORT_PCR_SRE | PORT_PCR_MUX(3); break;
 		#if defined(KINETISL)
 		case 4:  CORE_PIN4_CONFIG = PORT_PCR_DSE | PORT_PCR_SRE | PORT_PCR_MUX(2); break;
+		#endif
+		#if defined(__MK64FX512__) || defined(__MK66FX1M0__)
+		case 26: CORE_PIN26_CONFIG = PORT_PCR_DSE | PORT_PCR_SRE | PORT_PCR_MUX(3); break;
 		#endif
 	}
 #if defined(HAS_KINETISK_UART0)


### PR DESCRIPTION
Added the SPI1_ defines plus SPCR1 logical register (like LC).

Plus tested with updated SPI library such that a simple hack to SerialFlash to use SPI1 worked on test board using pins 0, 1, 20, 6