### PR TITLE
T T3.4 T3.5 SPI2 support

### DIFF
--- a/teensy3/avr_emulation.cpp
+++ b/teensy3/avr_emulation.cpp
@@ -38,6 +38,7 @@ uint8_t SPCR1emulation::pinout = 0;
 #endif
 #if defined(__MK64FX512__) || defined(__MK66FX1M0__)
 uint8_t SPCR1emulation::pinout = 0;
+uint8_t SPCR2emulation::pinout = 0;
 #endif
 #ifdef HAS_SPIFIFO
 


### PR DESCRIPTION
Added Support for the new Teensy 3.4/3.5 boards for SPI2.  Added the emulation psuedo register like we did for SPI1