### PR TITLE
Ser2 ser4 fixes

### DIFF
--- a/teensy3/serial2.c
+++ b/teensy3/serial2.c
@@ -184,8 +184,18 @@ void serial2_end(void)
 	while (transmitting) yield();  // wait for buffered data to send
 	NVIC_DISABLE_IRQ(IRQ_UART1_STATUS);
 	UART1_C2 = 0;
-	CORE_PIN9_CONFIG = PORT_PCR_PE | PORT_PCR_PS | PORT_PCR_MUX(1);
-	CORE_PIN10_CONFIG = PORT_PCR_PE | PORT_PCR_PS | PORT_PCR_MUX(1);
+	switch (rx_pin_num) {
+		case 9: CORE_PIN9_CONFIG = PORT_PCR_PE | PORT_PCR_PS | PORT_PCR_MUX(1); break; // PTC3
+		#if !(defined(__MK64FX512__) || defined(__MK66FX1M0__))  // not on T3.4 or T3.5
+		case 26: CORE_PIN26_CONFIG = PORT_PCR_PE | PORT_PCR_PS | PORT_PCR_MUX(1); break; // PTE1
+		#endif
+	}
+	switch (tx_pin_num & 127) {
+		case 10: CORE_PIN10_CONFIG = PORT_PCR_PE | PORT_PCR_PS | PORT_PCR_MUX(1); break; // PTC4
+		#if !(defined(__MK64FX512__) || defined(__MK66FX1M0__))  // not on T3.4 or T3.5
+		case 31: CORE_PIN31_CONFIG = PORT_PCR_PE | PORT_PCR_PS | PORT_PCR_MUX(1); break; // PTE0
+		#endif
+	}
 	rx_buffer_head = 0;
 	rx_buffer_tail = 0;
 	if (rts_pin) rts_deassert();

--- a/teensy3/serial4.c
+++ b/teensy3/serial4.c
@@ -161,7 +161,7 @@ void serial4_set_tx(uint8_t pin, uint8_t opendrain)
 
 	if (opendrain) pin |= 128;
 	if (pin == tx_pin_num) return;
-	if ((SIM_SCGC4 & SIM_SCGC4_UART2)) {
+	if ((SIM_SCGC4 & SIM_SCGC4_UART3)) {
 		switch (tx_pin_num & 127) {
 			case 32:  CORE_PIN32_CONFIG = 0; break; // PTB11
 		}


### PR DESCRIPTION
These fixes were extracted from the SDCard pins

Pull request: https://github.com/PaulStoffregen/cores/pull/161

As not sure if you were interested in those or not. 

Fixes Serial2 to not assume pins 9,10 on Serial2.end

Serial4.setTX uses the right test UART3 instead of UART2