### PR TITLE
When concat is same string to string, use memcpy

### DIFF
--- a/teensy3/WString.cpp
+++ b/teensy3/WString.cpp
@@ -248,8 +248,19 @@ String & String::append(const String &s)
 String & String::append(const char *cstr, unsigned int length)
 {
 	unsigned int newlen = len + length;
+	bool self = false;
+	unsigned int buffer_offset; 
+	if ( (cstr >= buffer) && (cstr < (buffer+len) ) ) {
+		self = true;
+		buffer_offset = (unsigned int)(cstr-buffer);
+	}
 	if (length == 0 || !reserve(newlen)) return *this;
-	strcpy(buffer + len, cstr);
+	if ( self ) {
+		memcpy(buffer + len, buffer+buffer_offset, length);
+		buffer[newlen] = 0;
+		}
+	else
+		strcpy(buffer + len, cstr);
 	len = newlen;
 	return *this;
 }


### PR DESCRIPTION
allows for re-alloc to move string on growth

https://forum.pjrc.com/threads/35688-Something-wrong-with-Adding-a-String-to-itself!?p=111109#post111109