### PR TITLE
T3.6 - If we are going to use HSRUN, read serial number before

### DIFF
--- a/teensy3/mk20dx128.c
+++ b/teensy3/mk20dx128.c
@@ -842,6 +842,8 @@ void ResetHandler(void)
 	// if we need faster than the crystal, turn on the PLL
    #if defined(__MK66FX1M0__)
     #if F_CPU > 120000000
+	extern void usb_init_serialnumber(void);
+	usb_init_serialnumber();	// see if we can call this before we are in HS mode if we get
 	SMC_PMCTRL = SMC_PMCTRL_RUNM(3); // enter HSRUN mode
 	while (SMC_PMSTAT != SMC_PMSTAT_HSRUN) ; // wait for HSRUN
     #endif

--- a/teensy3/usb_desc.c
+++ b/teensy3/usb_desc.c
@@ -1215,11 +1215,14 @@ struct usb_string_descriptor_struct usb_string_serial_number_default = {
         {0,0,0,0,0,0,0,0,0,0}
 };
 
+// BUGBUG:: test to see if we can call earlier on. 
+static uint8_t usb_init_serialnumber_called = 0;
 void usb_init_serialnumber(void)
 {
 	char buf[11];
 	uint32_t i, num;
-
+	if (usb_init_serialnumber_called)
+		return;
 	__disable_irq();
 #if defined(HAS_KINETIS_FLASH_FTFA) || defined(HAS_KINETIS_FLASH_FTFL)
 	FTFL_FSTAT = FTFL_FSTAT_RDCOLERR | FTFL_FSTAT_ACCERR | FTFL_FSTAT_FPVIOL;
@@ -1246,6 +1249,7 @@ void usb_init_serialnumber(void)
 		usb_string_serial_number_default.wString[i] = c;
 	}
 	usb_string_serial_number_default.bLength = i * 2 + 2;
+        usb_init_serialnumber_called = 1;
 }
 
 


### PR DESCRIPTION
If we are runnig at over 120mhz and turn on HSRUN mode, we can not read
in the USB serial number.

This is one attempt to see if we can read it in before we switch to
HSRUN mode.

My quick couple of test appeared to work, but may be cleaner ways