### PR TITLE
Add A23 and A24 for T3.5 and T3.6 board

### DIFF
--- a/teensy3/analog.c
+++ b/teensy3/analog.c
@@ -397,7 +397,7 @@ static const uint8_t channel2sc1a[] = {
 // A18  PTC10  ADC1_SE6b
 // A19  PTC11  ADC1_SE7b
 // A20  PTA17  ADC1_SE17
-	23, 23+128, 26, 18+128  // A21-A22, temp sensor, vref
+	23, 23+128, 10+128, 11+128, 26, 18+128  // A21-A24, temp sensor, vref
 // A21  DAC0  ADC0_SE23
 // A22  DAC1  ADC1_SE23
 };
@@ -452,8 +452,13 @@ int analogRead(uint8_t pin)
 		index = pin - 19;  // 31-39 are A12-A20
 	} else if (pin >= 40 && pin <= 41) {
 		index = pin - 30;  // 40-41 are A10-A11
-	} else if (pin >= 42 && pin <= 45) {
-		index = pin - 21;  // 42-43 are A21-A22, 44 is temp sensor, 45 is vref
+	} else if (pin >= 42 && pin <= 43) {
+		index = pin - 21;  // 42-43 are A21-A22
+	} else if (pin >= 49 && pin <= 50) {
+		index = pin - 26;  // 50 and 51 are A23-A24
+	// Leave compatibility with older where 44 and 45 are Temp and Vref
+	} else if (pin >= 44 && pin <= 45) {
+		index = pin - 19;  // 42-43 are A21-A22, 44 is temp sensor, 45 is vref A25, 26
 	} else {
 		return 0;
 	}

--- a/teensy3/analog.c
+++ b/teensy3/analog.c
@@ -397,7 +397,7 @@ static const uint8_t channel2sc1a[] = {
 // A18  PTC10  ADC1_SE6b
 // A19  PTC11  ADC1_SE7b
 // A20  PTA17  ADC1_SE17
-	23, 23+128, 10+128, 11+128, 26, 18+128  // A21-A24, temp sensor, vref
+	23, 23+128, 26, 18+128, 10+128, 11+128  // A21-A22, temp sensor, vref A23, A24
 // A21  DAC0  ADC0_SE23
 // A22  DAC1  ADC1_SE23
 };
@@ -452,13 +452,10 @@ int analogRead(uint8_t pin)
 		index = pin - 19;  // 31-39 are A12-A20
 	} else if (pin >= 40 && pin <= 41) {
 		index = pin - 30;  // 40-41 are A10-A11
-	} else if (pin >= 42 && pin <= 43) {
+	} else if (pin >= 42 && pin <= 45) {
 		index = pin - 21;  // 42-43 are A21-A22
 	} else if (pin >= 49 && pin <= 50) {
-		index = pin - 26;  // 50 and 51 are A23-A24
-	// Leave compatibility with older where 44 and 45 are Temp and Vref
-	} else if (pin >= 44 && pin <= 45) {
-		index = pin - 19;  // 42-43 are A21-A22, 44 is temp sensor, 45 is vref A25, 26
+		index = pin - 24;  // 49 and 50 are A23-A24
 	} else {
 		return 0;
 	}

--- a/teensy3/pins_arduino.h
+++ b/teensy3/pins_arduino.h
@@ -111,6 +111,8 @@ const static uint8_t A12 = 26;
 #define PIN_A20 (39)
 #define PIN_A21 (42)
 #define PIN_A22 (43)
+#define PIN_A23 (49)
+#define PIN_A24 (50)
 const static uint8_t A10 = 40;
 const static uint8_t A11 = 41;
 const static uint8_t A12 = 31;
@@ -124,6 +126,8 @@ const static uint8_t A19 = 38;
 const static uint8_t A20 = 39;
 const static uint8_t A21 = 42;
 const static uint8_t A22 = 43;
+const static uint8_t A23 = 49;
+const static uint8_t A24 = 50;
 #endif
 
 #define LED_BUILTIN   (13)


### PR DESCRIPTION
I added pins  49 and 50 as analog pins A23 and A24.  I still left in the
special casing for pins 44 and 45 being used for Temp and analog
reference