### PR TITLE
Realtime message value assignment

### DIFF
--- a/teensy3/usb_midi.c
+++ b/teensy3/usb_midi.c
@@ -281,9 +281,10 @@ int usb_midi_read(uint32_t channel)
 			// From Sebastian Tomczak, seb.tomczak at gmail.com
 			// http://little-scale.blogspot.com/2011/08/usb-midi-game-boy-sync-for-16.html
 			usb_midi_msg_type = 8;
+			usb_midi_msg_data1 = (n >> 8);
 			if (usb_midi_handleRealTimeSystem)
 				(*usb_midi_handleRealTimeSystem)(n >> 8);
-			goto return_message;
+			return 1;
 		}
 	}
 	if (type1 == 0x02) {


### PR DESCRIPTION
Realtime messages (type:8) was not being captured, only the callback function had access to the actual received message. Assigned the message to usb_midi_msg_data1, so the value is located in usbMidi.getData1();