### PR TITLE
Fix PWM and Analog Pin counts om T3.5 and T3.6

### DIFF
--- a/teensy3/core_pins.h
+++ b/teensy3/core_pins.h
@@ -112,12 +112,18 @@
 #define CORE_NUM_INTERRUPT      24  // really only 18, but 6 "holes"
 #define CORE_NUM_ANALOG         13
 #define CORE_NUM_PWM            10
-#elif defined(__MK64FX512__) || defined(__MK66FX1M0__)
+#elif defined(__MK64FX512__)
 #define CORE_NUM_TOTAL_PINS     64
 #define CORE_NUM_DIGITAL        64
 #define CORE_NUM_INTERRUPT      64
-#define CORE_NUM_ANALOG         23
+#define CORE_NUM_ANALOG         27
 #define CORE_NUM_PWM            20
+#elif defined(__MK66FX1M0__)
+#define CORE_NUM_TOTAL_PINS     64
+#define CORE_NUM_DIGITAL        64
+#define CORE_NUM_INTERRUPT      64
+#define CORE_NUM_ANALOG         25
+#define CORE_NUM_PWM            22
 #endif
 
 #if defined(__MK20DX128__) || defined(__MK20DX256__)


### PR DESCRIPTION
Recent additions did not update these counts.

Seperated T3.5 from T3.6 as PWM and Analog counts are different