### PR TITLE
Add memory_total

### DIFF
--- a/teensy3/AudioStream.cpp
+++ b/teensy3/AudioStream.cpp
@@ -38,6 +38,7 @@ uint32_t AudioStream::memory_pool_available_mask[6];
 
 uint16_t AudioStream::cpu_cycles_total = 0;
 uint16_t AudioStream::cpu_cycles_total_max = 0;
+uint8_t AudioStream::memory_total;
 uint8_t AudioStream::memory_used = 0;
 uint8_t AudioStream::memory_used_max = 0;
 
@@ -64,7 +65,7 @@ void AudioStream::initialize_memory(audio_block_t *data, unsigned int num)
 		data[i].memory_pool_index = i;
 	}
 	__enable_irq();
-
+	memory_total = num;
 }
 
 // Allocate 1 audio data block.  If successful

--- a/teensy3/AudioStream.h
+++ b/teensy3/AudioStream.h
@@ -91,6 +91,7 @@ protected:
 #define AudioProcessorUsage() (CYCLE_COUNTER_APPROX_PERCENT(AudioStream::cpu_cycles_total))
 #define AudioProcessorUsageMax() (CYCLE_COUNTER_APPROX_PERCENT(AudioStream::cpu_cycles_total_max))
 #define AudioProcessorUsageMaxReset() (AudioStream::cpu_cycles_total_max = AudioStream::cpu_cycles_total)
+#define AudioMemoryTotal() (AudioStream::memory_total)
 #define AudioMemoryUsage() (AudioStream::memory_used)
 #define AudioMemoryUsageMax() (AudioStream::memory_used_max)
 #define AudioMemoryUsageMaxReset() (AudioStream::memory_used_max = AudioStream::memory_used)
@@ -126,6 +127,7 @@ public:
 	uint16_t cpu_cycles_max;
 	static uint16_t cpu_cycles_total;
 	static uint16_t cpu_cycles_total_max;
+	static uint8_t memory_total;
 	static uint8_t memory_used;
 	static uint8_t memory_used_max;
 protected:


### PR DESCRIPTION
Its sometimes very useful to know how much memory was allocated - it
allows, together with memory_used, how many blocks are free. Esp. useful
for queue-like objects (I'm working on a MP3 integration to the
Audio-Library - it needs to know whoe much blocks are free before trying
to decode aMP3-Frame.)
