### PR TITLE
Fix compilation error with recent newlib/gcc versions because of random()

### DIFF
--- a/teensy3/WMath.cpp
+++ b/teensy3/WMath.cpp
@@ -12,7 +12,7 @@ void srandom(uint32_t newseed)
 	seed = newseed;
 }
 
-uint32_t random(void)
+int32_t random(void)
 {
 	int32_t hi, lo, x;
 

--- a/teensy3/WProgram.h
+++ b/teensy3/WProgram.h
@@ -50,7 +50,7 @@ void tone(uint8_t pin, uint16_t frequency, uint32_t duration = 0);
 void noTone(uint8_t pin);
 
 // WMath prototypes
-uint32_t random(void);
+int32_t random(void);
 uint32_t random(uint32_t howbig);
 int32_t random(int32_t howsmall, int32_t howbig);
 void randomSeed(uint32_t newseed);


### PR DESCRIPTION
`long random()` was added to stdlib.h in newlib project used by gcc arm toolchains in this [commit](https://github.com/bminor/newlib/commit/ecf453f9635fb278cff4d4bae21a1e249313b817). 
This gives compilation error when compiling with [gnu-arm-embedded](https://launchpad.net/gcc-arm-embedded) toolchain starting from 5_3-2016q1 version.

The diff changes signature to signed int, so that there's no ambiguity. Linker will then choose the version of this function from WMath.h (because it'll be from the same module).

This change is safe to do because the internal state/seed is a signed int, so we won't overflow.

Fixes PaulStoffregen/cores#122.