### PR TITLE
Fix compilation warnings related to kinetis_hsrun_enable() for older teensies

### DIFF
--- a/teensy3/kinetis.h
+++ b/teensy3/kinetis.h
@@ -5667,8 +5667,8 @@ extern int nvic_execution_priority(void);
 extern int kinetis_hsrun_disable(void);
 extern int kinetis_hsrun_enable(void);
 #else
-#define kinetis_hsrun_disable() (0)
-#define kinetis_hsrun_enable() (0)
+__attribute__((always_inline)) static inline int kinetis_hsrun_disable(void) { return 0; }
+__attribute__((always_inline)) static inline int kinetis_hsrun_enable(void)  { return 0; }
 #endif
 
 extern void nmi_isr(void);


### PR DESCRIPTION
When I'm trying to compile teensy3 core on gcc 5.4, I'm getting these warnings:
```
In file included from <project>/cores/teensy3/eeprom.c:31:0:
<project>/cores/teensy3/eeprom.c: In function 'eeprom_initialize':
<project>/cores/teensy3/kinetis.h:5670:33: warning: statement with no effect [-Wunused-value]
 #define kinetis_hsrun_disable() (0)
                                 ^
<project>/cores/teensy3/eeprom.c:118:3: note: in expansion of macro 'kinetis_hsrun_disable'
   kinetis_hsrun_disable();
   ^
... and 150 more lines.
```

Converting macros to actual inline functions solve this problem and doesn't add any runtime footprint.