### PR TITLE
Fix fcvtf warning in newer versions of newlib

### DIFF
--- a/teensy3/nonstd.c
+++ b/teensy3/nonstd.c
@@ -66,6 +66,8 @@ char * ltoa(long val, char *buf, int radix)
 	}
 }
 
+char * fcvtf(float, int, int *, int *);
+
 char * dtostrf(float val, int width, unsigned int precision, char *buf)
 {
 	int decpt, sign, reqd, pad;


### PR DESCRIPTION
One last warning that I have while using new version of gcc-arm-embedded/newlib:
```
<project>/cores/teensy3/nonstd.c: In function 'dtostrf':
<project>/cores/teensy3/nonstd.c:77:6: warning: implicit declaration of function 'fcvtf' [-Wimplicit-function-declaration]
  s = fcvtf(val, precision, &decpt, &sign);
      ^
<project>/cores/teensy3/nonstd.c:77:4: warning: assignment makes pointer from integer without a cast [-Wint-conversion]
  s = fcvtf(val, precision, &decpt, &sign);
    ^
```

Happens because `fcvtf` is technically not available in ANSI standard and newlib moved it under legacy versions (see [source](https://github.com/bminor/newlib/blob/master/newlib/libc/include/stdlib.h#L209)).

This diff fixes it by declaring it explicitly.