### PR TITLE
Making this delay(400) split gets T_3.0 and 3.6 online in 405ms

### DIFF
--- a/teensy3/pins_teensy.c
+++ b/teensy3/pins_teensy.c
@@ -578,8 +578,9 @@ void _init_Teensyduino_internal_(void)
 	// for background about this startup delay, please see these conversations
 	// https://forum.pjrc.com/threads/36606-startup-time-(400ms)?p=113980&viewfull=1#post113980
 	// https://forum.pjrc.com/threads/31290-Teensey-3-2-Teensey-Loader-1-24-Issues?p=87273&viewfull=1#post87273
-	delay(400);
+	delay(40);
 	usb_init();
+	delay(360);
 }
 
 

--- a/teensy3/pins_teensy.c
+++ b/teensy3/pins_teensy.c
@@ -578,7 +578,8 @@ void _init_Teensyduino_internal_(void)
 	// for background about this startup delay, please see these conversations
 	// https://forum.pjrc.com/threads/36606-startup-time-(400ms)?p=113980&viewfull=1#post113980
 	// https://forum.pjrc.com/threads/31290-Teensey-3-2-Teensey-Loader-1-24-Issues?p=87273&viewfull=1#post87273
-	delay(40);
+	//delay(40);
+        delayMicroseconds(40000);
 	usb_init();
 	delay(360);
 }


### PR DESCRIPTION
The delay(400) before usb_init() results in USB first Serial.print in about 800ms with newer faster TYQT - On Windows 10.

Making this change keeps the setup() entry time the same ( for i2c etc ) - but USB is now online at 405ms.