### PR TITLE
AudioStream.h: Allow inclusion from assembler .S files

### DIFF
--- a/teensy3/AudioStream.h
+++ b/teensy3/AudioStream.h
@@ -31,20 +31,24 @@
 #ifndef AudioStream_h
 #define AudioStream_h
 
+#ifndef __ASSEMBLER__
 #include <stdio.h>  // for NULL
 #include <string.h> // for memcpy
 #include "kinetis.h"
+#endif
 
-#if defined(KINETISK)
-#define AUDIO_BLOCK_SAMPLES  128
+
+#if defined(__MK20DX128__) || defined(__MK20DX256__) || defined(__MK64FX512__) || defined(__MK66FX1M0__)
+#define AUDIO_BLOCK_SAMPLES  16
 #define AUDIO_SAMPLE_RATE    44117.64706
 #define AUDIO_SAMPLE_RATE_EXACT 44117.64706 // 48 MHz / 1088, or 96 MHz * 2 / 17 / 256
-#elif defined(KINETISL)
+#elif defined(__MKL26Z64__)
 #define AUDIO_BLOCK_SAMPLES  64
 #define AUDIO_SAMPLE_RATE    22058.82353
 #define AUDIO_SAMPLE_RATE_EXACT 22058.82353 // 48 MHz / 2176, or 96 MHz * 1 / 17 / 256
 #endif
 
+#ifndef __ASSEMBLER__
 class AudioStream;
 class AudioConnection;
 
@@ -152,4 +156,5 @@ private:
 	static uint32_t memory_pool_available_mask[6];
 };
 
+#endif
 #endif

--- a/teensy3/AudioStream.h
+++ b/teensy3/AudioStream.h
@@ -39,7 +39,7 @@
 
 
 #if defined(__MK20DX128__) || defined(__MK20DX256__) || defined(__MK64FX512__) || defined(__MK66FX1M0__)
-#define AUDIO_BLOCK_SAMPLES  16
+#define AUDIO_BLOCK_SAMPLES  128
 #define AUDIO_SAMPLE_RATE    44117.64706
 #define AUDIO_SAMPLE_RATE_EXACT 44117.64706 // 48 MHz / 1088, or 96 MHz * 2 / 17 / 256
 #elif defined(__MKL26Z64__)


### PR DESCRIPTION
This way, we can use it (i.e.) in memcpy_audio.S
(Pullrequest follows)