### PR TITLE
Fix: write returns zero

### DIFF
--- a/teensy3/usb_serial.c
+++ b/teensy3/usb_serial.c
@@ -189,6 +189,7 @@ int usb_serial_putchar(uint8_t c)
 
 int usb_serial_write(const void *buffer, uint32_t size)
 {
+	uint32_t ret = size;
 	uint32_t len;
 	uint32_t wait_count;
 	const uint8_t *src = (const uint8_t *)buffer;
@@ -231,7 +232,7 @@ int usb_serial_write(const void *buffer, uint32_t size)
 		usb_cdc_transmit_flush_timer = TRANSMIT_FLUSH_TIMEOUT;
 	}
 	tx_noautoflush = 0;
-	return 0;
+	return ret;
 }
 
 int usb_serial_write_buffer_free(void)


### PR DESCRIPTION
https://forum.pjrc.com/threads/40893-Incorrect-return-for-Serial-write()-on-Teensy-3-6?p=127732#post127732

I'm not sure if this fix has some side-effects - how will other functions react when it does not return zero anymore ?