### PR TITLE
usb_serial.clear doesn't compile for F_CPU < 20 MHz

### DIFF
--- a/teensy3/usb_serial.h
+++ b/teensy3/usb_serial.h
@@ -128,6 +128,7 @@ public:
         virtual int read() { return -1; }
         virtual int peek() { return -1; }
         virtual void flush() { }
+        virtual void clear() { }
         virtual size_t write(uint8_t c) { return 1; }
         virtual size_t write(const uint8_t *buffer, size_t size) { return size; }
 	size_t write(unsigned long n) { return 1; }


### PR DESCRIPTION
When clear function was added, it was not put in the null operations list when no USB enabled.

Compile at <20 MHz to test/verify:

```
void setup() {
  Serial.clear ();
}

void loop() {
}
```