### PR TITLE
Fix malloc corrupting the stack. Added new function reserve_stack() t…

### DIFF
--- a/teensy3/kinetis.h
+++ b/teensy3/kinetis.h
@@ -5794,6 +5794,11 @@ extern void software_isr(void);
 extern void (* _VectorsRam[NVIC_NUM_INTERRUPTS+16])(void);
 extern void (* const _VectorsFlash[NVIC_NUM_INTERRUPTS+16])(void);
 
+// Reserve stack memory. This is the amount of memory malloc will leave alone
+// for the stack. The stack can grow larger than this limit (growing towards /
+// into the heap). 512 bytes are reserved by default.
+extern void reserve_stack(int size);
+
 #ifdef __cplusplus
 }
 #endif

--- a/teensy3/mk20dx128.c
+++ b/teensy3/mk20dx128.c
@@ -32,6 +32,7 @@
 #include "core_pins.h" // testing only
 #include "ser_print.h" // testing only
 
+#include <errno.h>
 
 // Flash Security Setting. On Teensy 3.2, you can lock the MK20 chip to prevent
 // anyone from reading your code.  You CAN still reprogram your Teensy while
@@ -1137,8 +1138,20 @@ void ResetHandler(void)
 
 char *__brkval = (char *)&_ebss;
 
+int reserved_stack_size = 512;
+
+void reserve_stack(int size)
+{
+    reserved_stack_size = size;
+}
+
 void * _sbrk(int incr)
 {
+    if(__brkval + incr >= (char*) &_estack - reserved_stack_size)
+    {
+        errno = ENOMEM;
+        return (void*) -1;
+    }
 	char *prev = __brkval;
 	__brkval += incr;
 	return prev;


### PR DESCRIPTION
…o adjust the amount of memory reserved for the stack.

Forum thread:
https://forum.pjrc.com/threads/26559-How-to-detect-when-no-RAM-left-for-a-malloc-It-seems-to-just-keep-going-(Teensy-3-1)