### PR TITLE
Disable definition of __ARM_FEATURE_UNALIGNED.

### DIFF
--- a/teensy3/memcpy-armv7m.S
+++ b/teensy3/memcpy-armv7m.S
@@ -28,7 +28,14 @@
 
 #if defined(__MK20DX128__) || defined(__MK20DX256__) || defined(__MK64FX512__) || defined(__MK66FX1M0__)
 #if defined (__ARM_ARCH_7M__) || defined (__ARM_ARCH_7EM__)
+/*
+ * Let __ARM_FEATURE_UNALIGNED be set by the achitechture and the compiler flags:
+ *   -munaligned-access
+ *   -mno-unaligned-access
+ * instead of always setting it here.
+ *
 #define __ARM_FEATURE_UNALIGNED 1
+ */
  
 /* This memcpy routine is optimised for Cortex-M3/M4 cores with/without
    unaligned access.


### PR DESCRIPTION
Defining __ARM_FEATURE_UNALIGNED in memcpy-armv7m.S prevents -mno-unaligned-access from being honoured properly.