### PR TITLE
Add define guards to allow compiler flags to change product name/serial number

### DIFF
--- a/usb_disk/usb_private.h
+++ b/usb_disk/usb_private.h
@@ -15,8 +15,12 @@ extern "C"{
 
 #define VENDOR_ID		0x16C0
 #define PRODUCT_ID		0x0484
+#ifndef STR_PRODUCT
 #define STR_PRODUCT		L"Teensy Disk/Keyboard"
+#endif
+#ifndef STR_SERIAL_NUMBER
 #define STR_SERIAL_NUMBER	L"123456789ABCDEF0"
+#endif
 
 // Some operating systems, especially Windows, may cache USB device
 // info.  Changes to the device name may not update on the same

--- a/usb_hid/usb_private.h
+++ b/usb_hid/usb_private.h
@@ -38,7 +38,10 @@ extern "C"{
 // computer unless the vendor or product ID numbers change, or the
 // "bcdDevice" revision code is increased.
 
+#ifndef STR_PRODUCT
 #define STR_PRODUCT             L"Teensy Keyboard/Mouse/Joystick"
+#endif
+
 #define ENDPOINT0_SIZE          64
 
 #define DEBUG_INTERFACE		2

--- a/usb_midi/usb_private.h
+++ b/usb_midi/usb_private.h
@@ -44,7 +44,10 @@ extern "C"{
 // computer unless the vendor or product ID numbers change, or the
 // "bcdDevice" revision code is increased.
 
+#ifndef STR_PRODUCT
 #define STR_PRODUCT             L"Teensy MIDI"
+#endif
+
 #define ENDPOINT0_SIZE          64
 
 #define DEBUG_INTERFACE		1

--- a/usb_rawhid/usb_private.h
+++ b/usb_rawhid/usb_private.h
@@ -34,9 +34,15 @@ extern "C"{
  *
  **************************************************************************/
 
+#ifndef STR_PRODUCT
 #define STR_PRODUCT             L"Teensyduino RawHID Device"
+#endif
+#ifndef STR_RAWHID
 #define STR_RAWHID		L"Teensyduino RawHID"
+#endif
+#ifndef STR_DEBUG
 #define STR_DEBUG		L"Emulated Arduino Serial"
+#endif
 #define ENDPOINT0_SIZE          64
 
 // Some operating systems, especially Windows, may cache USB device

--- a/usb_serial/usb_private.h
+++ b/usb_serial/usb_private.h
@@ -15,8 +15,12 @@ extern "C"{
 
 // You can change these to give your code its own name.  On Windows,
 // these are only used before an INF file (driver install) is loaded.
+#ifndef STR_MANUFACTURER
 #define STR_MANUFACTURER        L"Teensyduino"
+#endif
+#ifndef STR_PRODUCT
 #define STR_PRODUCT             L"USB Serial"
+#endif
 
 // Some operating systems, especially Windows, may cache USB device
 // info.  Changes to the device name may not update on the same
@@ -39,7 +43,9 @@ extern "C"{
 // Udev rules (in /etc/udev/rules.d) can define persistent device
 // names linked to this serial number, as well as permissions, owner
 // and group settings.
+#ifndef STR_SERIAL_NUMBER
 #define STR_SERIAL_NUMBER       L"12345"
+#endif
 
 // Mac OS-X and Linux automatically load the correct drivers.  On
 // Windows, even though the driver is supplied by Microsoft, an

--- a/usb_serial_hid/usb_private.h
+++ b/usb_serial_hid/usb_private.h
@@ -15,9 +15,16 @@ extern "C"{
 
 // You can change these to give your code its own name.  On Windows,
 // these are only used before an INF file (driver install) is loaded.
+  
+#ifndef STR_MANUFACTURER
 #define STR_MANUFACTURER        L"Teensyduino"
+#endif
+#ifndef STR_PRODUCT
 #define STR_PRODUCT             L"Serial+Keyboard+Mouse+Joystick"
+#endif
+#ifndef STR_SERIAL
 #define STR_SERIAL		L"Serial"
+#endif
 
 // Some operating systems, especially Windows, may cache USB device
 // info.  Changes to the device name may not update on the same
@@ -40,7 +47,9 @@ extern "C"{
 // Udev rules (in /etc/udev/rules.d) can define persistent device
 // names linked to this serial number, as well as permissions, owner
 // and group settings.
+#ifndef STR_SERIAL_NUMBER
 #define STR_SERIAL_NUMBER       L"12345"
+#endif
 
 // Mac OS-X and Linux automatically load the correct drivers.  On
 // Windows, even though the driver is supplied by Microsoft, an


### PR DESCRIPTION
I added define guards all of the usb device private headers because (to my knowledge) there is no way to change these values for the Teensy 2.0(++) without making a system wide change. I think I added them to all relevant files and values within, but if I missed anything, please let me know. This change should allow a program to change any of the guarded values by passing it as a compiler flag to the program.