### PR TITLE
Allow SerialX.setTX to be called before SerialX.begin (with opendrain enabled)

### DIFF
--- a/teensy3/serial1.c
+++ b/teensy3/serial1.c
@@ -110,6 +110,8 @@ static uint8_t tx_pin_num = 1;
 
 void serial_begin(uint32_t divisor)
 {
+	uint32_t cfg;
+	
 	SIM_SCGC4 |= SIM_SCGC4_UART0;	// turn on clock, TODO: use bitband
 	rx_buffer_head = 0;
 	rx_buffer_tail = 0;
@@ -127,15 +129,20 @@ void serial_begin(uint32_t divisor)
 		case 27: CORE_PIN27_CONFIG = PORT_PCR_PE | PORT_PCR_PS | PORT_PCR_PFE | PORT_PCR_MUX(3); break;
 		#endif
 	}
-	switch (tx_pin_num) {
-		case 1:  CORE_PIN1_CONFIG = PORT_PCR_DSE | PORT_PCR_SRE | PORT_PCR_MUX(3); break;
-		case 5:  CORE_PIN5_CONFIG = PORT_PCR_DSE | PORT_PCR_SRE | PORT_PCR_MUX(3); break;
+	if (tx_pin_num & 128) {
+		cfg = PORT_PCR_DSE | PORT_PCR_ODE;
+	} else {
+		cfg = PORT_PCR_DSE | PORT_PCR_SRE;
+	}
+	switch (tx_pin_num & 127) {
+		case 1:  CORE_PIN1_CONFIG = cfg | PORT_PCR_MUX(3); break;
+		case 5:  CORE_PIN5_CONFIG = cfg | PORT_PCR_MUX(3); break;
 		#if defined(KINETISL)
-		case 4:  CORE_PIN4_CONFIG = PORT_PCR_DSE | PORT_PCR_SRE | PORT_PCR_MUX(2); break;
-		case 24: CORE_PIN24_CONFIG = PORT_PCR_DSE | PORT_PCR_SRE | PORT_PCR_MUX(4); break;
+		case 4:  CORE_PIN4_CONFIG = cfg | PORT_PCR_MUX(2); break;
+		case 24: CORE_PIN24_CONFIG = cfg | PORT_PCR_MUX(4); break;
 		#endif
 		#if defined(__MK64FX512__) || defined(__MK66FX1M0__)
-		case 26: CORE_PIN26_CONFIG = PORT_PCR_DSE | PORT_PCR_SRE | PORT_PCR_MUX(3); break;
+		case 26: CORE_PIN26_CONFIG = cfg | PORT_PCR_MUX(3); break;
 		#endif
 	}
 #if defined(HAS_KINETISK_UART0)

--- a/teensy3/serial3.c
+++ b/teensy3/serial3.c
@@ -108,23 +108,30 @@ static uint8_t tx_pin_num = 8;
 
 void serial3_begin(uint32_t divisor)
 {
+	uint32_t cfg;
+	
 	SIM_SCGC4 |= SIM_SCGC4_UART2;	// turn on clock, TODO: use bitband
 	rx_buffer_head = 0;
 	rx_buffer_tail = 0;
 	tx_buffer_head = 0;
 	tx_buffer_tail = 0;
 	transmitting = 0;
+	if (tx_pin_num & 128) {
+		cfg = PORT_PCR_DSE | PORT_PCR_ODE;
+	} else {
+		cfg = PORT_PCR_DSE | PORT_PCR_SRE;
+	}
 #if defined(KINETISK)
 	CORE_PIN7_CONFIG = PORT_PCR_PE | PORT_PCR_PS | PORT_PCR_PFE | PORT_PCR_MUX(3);
-	CORE_PIN8_CONFIG = PORT_PCR_DSE | PORT_PCR_SRE | PORT_PCR_MUX(3);
+	CORE_PIN8_CONFIG = cfg | PORT_PCR_MUX(3);
 #elif defined(KINETISL)
 	switch (rx_pin_num) {
 		case 7: CORE_PIN7_CONFIG = PORT_PCR_PE | PORT_PCR_PS | PORT_PCR_PFE | PORT_PCR_MUX(3); break;
 		case 6: CORE_PIN6_CONFIG = PORT_PCR_PE | PORT_PCR_PS | PORT_PCR_PFE | PORT_PCR_MUX(3); break;
 	}
-	switch (tx_pin_num) {
-		case 8:  CORE_PIN8_CONFIG = PORT_PCR_DSE | PORT_PCR_SRE | PORT_PCR_MUX(3); break;
-		case 20: CORE_PIN20_CONFIG = PORT_PCR_DSE | PORT_PCR_SRE | PORT_PCR_MUX(3); break;
+	switch (tx_pin_num & 127) {
+		case 8:  CORE_PIN8_CONFIG = cfg | PORT_PCR_MUX(3); break;
+		case 20: CORE_PIN20_CONFIG = cfg | PORT_PCR_MUX(3); break;
 	}
 #endif
 #if defined(HAS_KINETISK_UART2)

--- a/teensy3/serial4.c
+++ b/teensy3/serial4.c
@@ -98,6 +98,8 @@ static uint8_t tx_pin_num = 32;
 
 void serial4_begin(uint32_t divisor)
 {
+	uint32_t cfg;
+	
 	SIM_SCGC4 |= SIM_SCGC4_UART3;	// turn on clock, TODO: use bitband
 	rx_buffer_head = 0;
 	rx_buffer_tail = 0;
@@ -108,9 +110,14 @@ void serial4_begin(uint32_t divisor)
 		case 31: CORE_PIN31_CONFIG = PORT_PCR_PE | PORT_PCR_PS | PORT_PCR_PFE | PORT_PCR_MUX(3); break;
 		case 63: CORE_PIN63_CONFIG = PORT_PCR_PE | PORT_PCR_PS | PORT_PCR_PFE | PORT_PCR_MUX(3); break;
 	}
-	switch (tx_pin_num) {
-		case 32: CORE_PIN32_CONFIG = PORT_PCR_DSE | PORT_PCR_SRE | PORT_PCR_MUX(3); break;
-		case 62: CORE_PIN62_CONFIG = PORT_PCR_DSE | PORT_PCR_SRE | PORT_PCR_MUX(3); break;
+	if (tx_pin_num & 128) {
+		cfg = PORT_PCR_DSE | PORT_PCR_ODE;
+	} else {
+		cfg = PORT_PCR_DSE | PORT_PCR_SRE;
+	}
+	switch (tx_pin_num & 127) {
+		case 32: CORE_PIN32_CONFIG = cfg | PORT_PCR_MUX(3); break;
+		case 62: CORE_PIN62_CONFIG = cfg | PORT_PCR_MUX(3); break;
 	}
 	UART3_BDH = (divisor >> 13) & 0x1F;
 	UART3_BDL = (divisor >> 5) & 0xFF;

--- a/teensy3/serial5.c
+++ b/teensy3/serial5.c
@@ -104,7 +104,11 @@ void serial5_begin(uint32_t divisor)
 	tx_buffer_tail = 0;
 	transmitting = 0;
 	CORE_PIN34_CONFIG = PORT_PCR_PE | PORT_PCR_PS | PORT_PCR_PFE | PORT_PCR_MUX(3);
-	CORE_PIN33_CONFIG = PORT_PCR_DSE | PORT_PCR_SRE | PORT_PCR_MUX(3);
+	if (tx_pin_num & 128) {
+		CORE_PIN33_CONFIG = PORT_PCR_DSE | PORT_PCR_ODE | PORT_PCR_MUX(3);
+	} else {
+		CORE_PIN33_CONFIG = PORT_PCR_DSE | PORT_PCR_SRE | PORT_PCR_MUX(3);
+	}
 	UART4_BDH = (divisor >> 13) & 0x1F;
 	UART4_BDL = (divisor >> 5) & 0xFF;
 	UART4_C4 = divisor & 0x1F;

--- a/teensy3/serial6.c
+++ b/teensy3/serial6.c
@@ -104,7 +104,11 @@ void serial6_begin(uint32_t divisor)
 	tx_buffer_tail = 0;
 	transmitting = 0;
 	CORE_PIN47_CONFIG = PORT_PCR_PE | PORT_PCR_PS | PORT_PCR_PFE | PORT_PCR_MUX(3);
-	CORE_PIN48_CONFIG = PORT_PCR_DSE | PORT_PCR_SRE | PORT_PCR_MUX(3);
+	if (tx_pin_num & 128) {
+		CORE_PIN48_CONFIG = PORT_PCR_DSE | PORT_PCR_ODE | PORT_PCR_MUX(3);
+	} else {
+		CORE_PIN48_CONFIG = PORT_PCR_DSE | PORT_PCR_SRE | PORT_PCR_MUX(3);
+	}
 	UART5_BDH = (divisor >> 13) & 0x1F;
 	UART5_BDL = (divisor >> 5) & 0xFF;
 	UART5_C4 = divisor & 0x1F;

--- a/teensy3/serial6_lpuart.c
+++ b/teensy3/serial6_lpuart.c
@@ -185,7 +185,11 @@ void serial6_begin(uint32_t desiredBaudRate)
 	tx_buffer_tail = 0;
 	transmitting = 0;
 	CORE_PIN47_CONFIG = PORT_PCR_PE | PORT_PCR_PS | PORT_PCR_PFE | PORT_PCR_MUX(5);
-	CORE_PIN48_CONFIG = PORT_PCR_DSE | PORT_PCR_SRE | PORT_PCR_MUX(5);
+	if (tx_pin_num & 128) {
+		CORE_PIN48_CONFIG = PORT_PCR_DSE | PORT_PCR_ODE | PORT_PCR_MUX(5);
+	} else {
+		CORE_PIN48_CONFIG = PORT_PCR_DSE | PORT_PCR_SRE | PORT_PCR_MUX(5);
+	}
 	LPUART0_CTRL = 0;
 	LPUART0_MATCH = 0;
 	LPUART0_STAT = 0;


### PR DESCRIPTION
```
void setup() {
  delay(1000);
  Serial1.setTX(1,1);
  Serial1.begin(9600);
  Serial1.write(0xC0); 
  Serial.println(CORE_PIN1_CONFIG,BIN);
}

void loop() {
}
```

does not work with TD 1.36 beta 4. _CORE_PIN1_CONFIG_ is 0.