### PR TITLE
Fix for GCC generating bad code for DMAChannel TCD access when it can…

### DIFF
--- a/teensy3/DMAChannel.h
+++ b/teensy3/DMAChannel.h
@@ -41,7 +41,7 @@ extern uint16_t dma_channel_allocated_mask;
 
 class DMABaseClass {
 public:
-	typedef struct __attribute__((packed)) {
+	typedef struct __attribute__((packed, aligned(4))) {
 		volatile const void * volatile SADDR;
 		int16_t SOFF;
 		union { uint16_t ATTR;
@@ -589,7 +589,7 @@ void DMAPriorityOrder(DMAChannel &ch1, DMAChannel &ch2, DMAChannel &ch3, DMAChan
 
 class DMABaseClass {
 public:
-	typedef struct __attribute__((packed)) {
+	typedef struct __attribute__((packed, aligned(4))) {
 		volatile const void * volatile SAR;
 		volatile void * volatile       DAR;
 		volatile uint32_t              DSR_BCR;


### PR DESCRIPTION
…'t prove alignment.

The test code below was compiled for Teensy LC. The byte access crashes the CPU.

```
#include <DMAChannel.h>

auto& serial = Serial;

void setup() {
    serial.begin(115200);
    delay(2000);

    DMAChannel dma;
    serial.printf("CFG: %x\n", (uint32_t) dma.CFG);

    asm volatile ("dmb" ::: "memory");
    *(uint32_t*) &dma.CFG->DAR = NULL;
    asm volatile ("dmb" ::: "memory");
    
    serial.printf("*(uint32_t*) &dma.CFG->DAR = NULL;  worked\n");

    asm volatile ("dmb" ::: "memory");
    dma.CFG->DAR = NULL;
    asm volatile ("dmb" ::: "memory");

    serial.printf("dma.CFG->DAR = NULL;  worked\n");
}

void loop() {}
```

`*(uint32_t*) &dma.CFG->DAR = NULL;`
```
     496:	f3bf 8f5f 	dmb	sy
     49a:	9b00      	ldr	r3, [sp, #0]
     49c:	605c      	str	r4, [r3, #4]
     49e:	f3bf 8f5f 	dmb	sy
```

`dma.CFG->DAR = NULL;`
```
     4aa:	f3bf 8f5f 	dmb	sy
     4ae:	9b00      	ldr	r3, [sp, #0]
     4b0:	791a      	ldrb	r2, [r3, #4]
     4b2:	711c      	strb	r4, [r3, #4]
     4b4:	795a      	ldrb	r2, [r3, #5]
     4b6:	715c      	strb	r4, [r3, #5]
     4b8:	799a      	ldrb	r2, [r3, #6]
     4ba:	719c      	strb	r4, [r3, #6]
     4bc:	79da      	ldrb	r2, [r3, #7]
     4be:	71dc      	strb	r4, [r3, #7]
     4c0:	f3bf 8f5f 	dmb	sy
```