### PR TITLE
Transfercount plus TNI's aligned attribute

### DIFF
--- a/teensy3/DMAChannel.h
+++ b/teensy3/DMAChannel.h
@@ -41,7 +41,7 @@ extern uint16_t dma_channel_allocated_mask;
 
 class DMABaseClass {
 public:
-	typedef struct __attribute__((packed)) {
+	typedef struct __attribute__((packed, aligned(4))) {
 		volatile const void * volatile SADDR;
 		int16_t SOFF;
 		union { uint16_t ATTR;
@@ -312,7 +312,8 @@ public:
 	// Set the number of transfers (number of triggers until complete)
 	void transferCount(unsigned int len) {
 		if (len > 32767) return;
-		if (len >= 512) {
+//		if (len >= 512) {
+		if (!(TCD->BITER & DMA_TCD_BITER_ELINK)) {
 			TCD->BITER = len;
 			TCD->CITER = len;
 		} else {
@@ -589,7 +590,7 @@ void DMAPriorityOrder(DMAChannel &ch1, DMAChannel &ch2, DMAChannel &ch3, DMAChan
 
 class DMABaseClass {
 public:
-	typedef struct __attribute__((packed)) {
+	typedef struct __attribute__((packed, aligned(4))) {
 		volatile const void * volatile SAR;
 		volatile void * volatile       DAR;
 		volatile uint32_t              DSR_BCR;

--- a/teensy3/kinetis.h
+++ b/teensy3/kinetis.h
@@ -479,8 +479,8 @@ enum IRQ_NUMBER_t {
 #define DMAMUX_SOURCE_I2S0_TX		13
 #define DMAMUX_SOURCE_SPI0_RX		14
 #define DMAMUX_SOURCE_SPI0_TX		15
-#define DMAMUX_SOURCE_SPI1_RX		16
-#define DMAMUX_SOURCE_SPI1_TX		17
+#define DMAMUX_SOURCE_SPI1			16  // Either RX or TX (but not both at same time)
+#define DMAMUX_SOURCE_SPI2			17  // Either RX or TX (but not both at same time)
 #define DMAMUX_SOURCE_I2C0		18
 #define DMAMUX_SOURCE_I2C1		19
 #define DMAMUX_SOURCE_I2C2		19


### PR DESCRIPTION
I inclded TNI's aligned attribute fix as it is needed for DMA to work at
all with T-LC...

The new fix with this delta, is there is a problem with the
transferCount method of the DMABase class for T3.x boards.

In particular it checks to see if the count < 512 and does somethig
different which can screw up.   It assmes that if the count is under 512
you are using the ELINK version of the output, which is fine as long as
your previous calls were also under 512.

But with current code, if You call this function in an order like:
Count 6  - Biter and Citer will be set to 6
Count 512 - Biter and Citer will be set to 512
Count 6 - Biter and Citer will be set to 518

Fix is to instead of check for >= 512 to instead check for the ELINK bit
being set then use the 15 bit version else the 7 bit.

Note: potentially should check in the ELINK case that value is < 512,
else it won't work... But not sure what to do in error case?  Currently
if you call with > 32767 it just returns without doing somehing,

But again function does not return any error status, so app will also
likely hang or at best not transfer...