### PR TITLE
Add missing SPCR definitions.

### DIFF
--- a/teensy3/avr_emulation.cpp
+++ b/teensy3/avr_emulation.cpp
@@ -33,12 +33,16 @@
 #include "SPIFIFO.h"
 
 uint8_t SPCRemulation::pinout = 0;
+SPCRemulation SPCR;
 #if defined(KINETISL)
 uint8_t SPCR1emulation::pinout = 0;
+SPCR1emulation SPCR1;
 #endif
 #if defined(__MK64FX512__) || defined(__MK66FX1M0__)
 uint8_t SPCR1emulation::pinout = 0;
+SPCR1emulation SPCR1;
 uint8_t SPCR2emulation::pinout = 0;
+SPCR2emulation SPCR2;
 #endif
 #ifdef HAS_SPIFIFO
 


### PR DESCRIPTION
The missing definitions can causes link failures:
https://forum.pjrc.com/threads/43836-Question-about-Teensy3-1-with-Makefile-(no-Arduino-IDE)