### PR TITLE
micros() modification that allows to tuning SysTick.

### DIFF
--- a/teensy3/pins_teensy.c
+++ b/teensy3/pins_teensy.c
@@ -1163,24 +1163,24 @@ volatile uint32_t systick_millis_count = 0;
 
 uint32_t micros(void)
 {
-	uint32_t count, current, istatus;
+	uint32_t count, current, istatus, reload;
 
 	__disable_irq();
 	current = SYST_CVR;
 	count = systick_millis_count;
 	istatus = SCB_ICSR;	// bit 26 indicates if systick exception pending
+	reload = SYST_RVR;
 	__enable_irq();
 	 //systick_current = current;
 	 //systick_count = count;
 	 //systick_istatus = istatus & SCB_ICSR_PENDSTSET ? 1 : 0;
 	if ((istatus & SCB_ICSR_PENDSTSET) && current > 50) count++;
-	current = ((F_CPU / 1000) - 1) - current;
 #if defined(KINETISL) && F_CPU == 48000000
-	return count * 1000 + ((current * (uint32_t)87381) >> 22);
+	return count * 1000 + (((reload - current) * (uint32_t)87381) >> 22);
 #elif defined(KINETISL) && F_CPU == 24000000
-	return count * 1000 + ((current * (uint32_t)174763) >> 22);
+	return count * 1000 + (((reload - current) * (uint32_t)174763) >> 22);
 #endif
-	return count * 1000 + current / (F_CPU / 1000000);
+	return count * 1000 + (reload - current) * 1000 / (reload + 1);
 }
 
 void delay(uint32_t ms)


### PR DESCRIPTION
I have about -23 ppm crystal drift for my T3.5 at 120 MHz (SYST_RVR = 119999 by default). When SYST_RVR = 119996 crystal drift in 0...1 range.