### PR TITLE
T3.5/6 - Has PCS5

### DIFF
--- a/teensy3/kinetis.h
+++ b/teensy3/kinetis.h
@@ -4414,7 +4414,7 @@ typedef struct {
 #define SPI_PUSHR_CTAS(n)		(((n) & 7) << 28)		//
 #define SPI_PUSHR_EOQ			((uint32_t)0x08000000)		//
 #define SPI_PUSHR_CTCNT			((uint32_t)0x04000000)		//
-#define SPI_PUSHR_PCS(n)		(((n) & 31) << 16)		//
+#define SPI_PUSHR_PCS(n)		(((n) & 0x3f) << 16)		//
 #define SPI0_PUSHR_SLAVE	(KINETISK_SPI0.PUSHR)	// DSPI PUSH TX FIFO Register In Slave Mode
 #define SPI0_POPR		(KINETISK_SPI0.POPR)	// DSPI POP RX FIFO Register
 #define SPI0_TXFR0		(KINETISK_SPI0.TXFR[0])	// DSPI Transmit FIFO Registers


### PR DESCRIPTION
As per liljaywalker member

Teensy 3.5/6 on Pin 45 have PCS5,
which the current Macro
SPI-PUSHR_PCS(n) will not work with.