### PR TITLE
USB Serial cable disconnect w/ active session fix

### DIFF
--- a/teensy3/usb_dev.c
+++ b/teensy3/usb_dev.c
@@ -1088,6 +1088,8 @@ void usb_isr(void)
 	if ((status & USB_ISTAT_SLEEP /* 10 */ )) {
 		//serial_print("sleep\n");
 		USB0_ISTAT = USB_ISTAT_SLEEP;
+        usb_cdc_line_rtsdtr_millis = systick_millis_count;
+        usb_cdc_line_rtsdtr = setup.wValue;
 	}
 
 }


### PR DESCRIPTION
Pertaining from forum thread here: [https://forum.pjrc.com/threads/48883-quot-while-(!Serial)-quot-USB-Disconnect-Issue](https://forum.pjrc.com/threads/48883-quot-while-(!Serial)-quot-USB-Disconnect-Issue)

I think this fixes that issue so "Serial" maintains the correct "setup.wValue" when the cable is pulled w/ an active session and the SLEEP bit is set and handled in the usb_isr().
  