### PR TITLE
Fix Warning (GCC 7-2017-q4-major) warning: argument 1 null where non-null expected 

### DIFF
--- a/teensy3/Stream.cpp
+++ b/teensy3/Stream.cpp
@@ -76,7 +76,7 @@ void Stream::setTimeout(unsigned long timeout)  // sets the maximum number of mi
  // find returns true if the target string is found
 bool  Stream::find(const char *target)
 {
-  return findUntil(target, NULL);
+  return findUntil(target, strlen(target), NULL, 0);	
 }
 
 // reads data from the stream until the target string of given length is found


### PR DESCRIPTION
Warning was: 
C:\Arduino\hardware\teensy\avr\cores\teensy3\Stream.cpp: In member function 'bool Stream::find(const char*)':

C:\Arduino\hardware\teensy\avr\cores\teensy3\Stream.cpp:92:19: warning: argument 1 null where non-null expected [-Wnonnull]

   return findUntil(target, strlen(target), terminator, strlen(terminator));

          ~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

In file included from c:\arduino\hardware\tools\arm7\arm-none-eabi\include\stdlib.h:11:0,

                 from c:\arduino\hardware\tools\arm7\arm-none-eabi\include\c++\7.2.1\cstdlib:75,

                 from c:\arduino\hardware\tools\arm7\arm-none-eabi\include\c++\7.2.1\stdlib.h:36,

                 from C:\Arduino\hardware\teensy\avr\cores\teensy3/WProgram.h:34,

                 from C:\Arduino\hardware\teensy\avr\cores\teensy3/Arduino.h:6,

                 from C:\Arduino\hardware\teensy\avr\cores\teensy3\Stream.cpp:23:

c:\arduino\hardware\tools\arm7\arm-none-eabi\include\string.h:41:9: note: in a call to function 'size_t strlen(const char*)' declared here

 size_t  _EXFUN(strlen,(const char *));