### PR TITLE
Only enable C++ set_media API if KEYMEDIA_INTERFACE is defined.

### DIFF
--- a/teensy3/usb_keyboard.h
+++ b/teensy3/usb_keyboard.h
@@ -87,6 +87,7 @@ public:
 	void set_key4(uint8_t c) { keyboard_keys[3] = c; }
 	void set_key5(uint8_t c) { keyboard_keys[4] = c; }
 	void set_key6(uint8_t c) { keyboard_keys[5] = c; }
+#ifdef KEYMEDIA_INTERFACE
 	void set_media(uint16_t c) {
 		if (c == 0) {
 			usb_keymedia_release_all();
@@ -94,6 +95,7 @@ public:
 			press(c);
 		}
 	}
+#endif
 	void send_now(void) { usb_keyboard_send(); }
 	void press(uint16_t n) { usb_keyboard_press_keycode(n); }
 	void release(uint16_t n) { usb_keyboard_release_keycode(n); }


### PR DESCRIPTION
If I try to build with KEYBOARD but without KEYMEDIA, `set_media` fails to compile due to the call to `usb_keymedia_release_all`.  This change simply wraps the whole function in a check for `KEYMEDIA_INTERFACE`.