### PR TITLE
USB user includes

### DIFF
--- a/teensy3/usb_desc.h
+++ b/teensy3/usb_desc.h
@@ -115,6 +115,9 @@ If these instructions are missing steps or could be improved, please
 let me know?  http://forum.pjrc.com/forums/4-Suggestions-amp-Bug-Reports
 */
 
+#if defined(INCLUDE_USB_USER_DESC)
+  #include "usb_user_desc.h"
+#endif
 
 #if defined(USB_SERIAL)
   #define VENDOR_ID		0x16C0

--- a/teensy3/usb_desc.h
+++ b/teensy3/usb_desc.h
@@ -58,6 +58,12 @@ the "endpoints" are the actual communication channels.  Most
 interfaces use 1, 2 or 3 endpoints.  By editing only this file,
 you can customize the USB Types to be any collection of interfaces.
 
+Or, if so desired, your project can provide its own usb_user_desc.h
+header file with all of the pertinent definitions for your custom
+USB interface.  Your custom usb_user_desc.h header file will be
+included when this code is compiled with INCLUDE_USB_USER_DESC.
+Please see the usb_user_desc.h.template file as a starting point.
+
 To modify a USB Type, delete the XYZ_INTERFACE lines for any
 interfaces you wish to remove, and copy them from another USB Type
 for any you want to add.

--- a/teensy3/usb_undef.h
+++ b/teensy3/usb_undef.h
@@ -38,6 +38,9 @@
 #ifdef _usb_desc_h_
 #undef _usb_desc_h_
 #endif
+#ifdef _usb_user_desc_h_
+#undef _usb_user_desc_h_
+#endif
 #ifdef ENDPOINT_UNUSED
 #undef ENDPOINT_UNUSED
 #endif

--- a/teensy3/usb_user_desc.h.template
+++ b/teensy3/usb_user_desc.h.template
@@ -1,0 +1,16 @@
+// PLEASE NOTE:  This file MUST use the specific header guard below
+// for consistency with usb_undef.h.
+
+#ifndef _usb_user_desc_h_
+#define _usb_user_desc_h_
+
+// To get started, copy this file into your project and remove the
+// .template extension.  Copy the contents from one or more
+// interface sections of usb_desc.h, such as USB_HID_TOUCHSCREEN,
+// and paste and edit them here as desired:  Please see usb_desc.h
+// for detailed editing instructions.  Finally, build your project
+// with INCLUDE_USB_USER_DESC defined at compile time.
+
+// INSERT DEFINITIONS HERE.
+
+#endif


### PR DESCRIPTION
This change allows a client project to implement its own `usb_user_desc.h` file and command the USB stack to include it by defining `INCLUDE_USB_USER_DESC` at compile time.

The goal is to simplify overall project management for those that wish to define custom USB interfaces.  With this change, projects have the option of defining custom USB interfaces without having to modify any files that live in the Teensy cores library.

A template header file is included with some instructions to help folks get started with it.  I'm not terribly picky about the wording here - let me know if it needs to be wordsmithed or anything.

Thanks!