### PR TITLE
Change `getIsrTable` from `inline` to `static inline`

### DIFF
--- a/teensy3/pins_teensy.c
+++ b/teensy3/pins_teensy.c
@@ -166,7 +166,7 @@ voidFuncPtr isr_table_portE[CORE_MAX_PIN_PORTE+1] = { [0 ... CORE_MAX_PIN_PORTE]
 
 // The Pin Config Register is used to look up the correct interrupt table
 // for the corresponding port.
-inline voidFuncPtr* getIsrTable(volatile uint32_t *config) {
+static inline voidFuncPtr* getIsrTable(volatile uint32_t *config) {
 	voidFuncPtr* isr_table = NULL;
 	if(&PORTA_PCR0 <= config && config <= &PORTA_PCR31) isr_table = isr_table_portA;
 	else if(&PORTB_PCR0 <= config && config <= &PORTB_PCR31) isr_table = isr_table_portB;


### PR DESCRIPTION
Newer versions of GCC (8.1.0 in my case) default to `-std=gnu11` (I believe), which expects `inline` to have an external definition. The `Makefile` (I ran it with `NO_ARDUINO` set) doesn't specify any C_FLAGS. Therefore gcc uses the new default value, instead of the old C99 standard. In this case you'll get a linker error for `getIsrTable` not being defined. This change allows the code to successfully compile with new versions of gcc. This change works with the old default std of gcc. For much older versions of gcc it might be better to explicitly set the `std` in `CFLAGS` within the `Makefile`.