### PR TITLE
Work-around for C++ tools that do not support type_traits.

### DIFF
--- a/teensy3/Makefile
+++ b/teensy3/Makefile
@@ -55,6 +55,10 @@ OPTIONS = -DF_CPU=48000000 -DUSB_SERIAL -DLAYOUT_US_ENGLISH -DUSING_MAKEFILE
 # options needed by many Arduino libraries to configure for Teensy 3.x
 OPTIONS += -D__$(MCU)__ -DARDUINO=10805 -DTEENSYDUINO=143
 
+ifdef NO_TYPE_TRAITS
+OPTIONS += -DNO_TYPE_TRAITS
+endif
+
 # use "cortex-m4" for Teensy 3.x
 # use "cortex-m0plus" for Teensy LC
 CPUARCH = cortex-m4

--- a/teensy3/wiring.h
+++ b/teensy3/wiring.h
@@ -40,7 +40,8 @@
 // type_traits interferes with min() and other defines
 // include it early, so we can define these later
 // for Arduino compatibility
-#ifdef __cplusplus
+
+#if __cplusplus && !NO_TYPE_TRAITS
 #include <type_traits>
 // when the input number is an integer type, do all math as 32 bit signed long
 template <class T, class A, class B, class C, class D>
@@ -75,7 +76,7 @@ template<class A, class B>
 constexpr auto max(A&& a, B&& b) -> decltype(a < b ? std::forward<A>(a) : std::forward<B>(b)) {
   return a >= b ? std::forward<A>(a) : std::forward<B>(b);
 }
-#else // not C++
+#else // not C++, or NO_TYPE_TRAITS was defined
 #define min(a, b) ({ \
   typeof(a) _a = (a); \
   typeof(b) _b = (b); \


### PR DESCRIPTION
The following C++ cross-compiler does not seem to support type_traits
on Debian systems:
   arm-none-eabi-g++ (15:6.3.1+svn253039-1+b1) 6.3.1 20170620

This patch contains a trivial work-around that gets enabled when the
NO_TYPE_TRAITS environment variable is set (to anything) before
running make.