### PR TITLE
adding bypass functionality to audiostream, to be later used in effec…

### DIFF
--- a/teensy3/AudioStream.h
+++ b/teensy3/AudioStream.h
@@ -128,6 +128,7 @@ public:
 	AudioStream(unsigned char ninput, audio_block_t **iqueue) :
 		num_inputs(ninput), inputQueue(iqueue) {
 			active = false;
+			bypass = false;
 			destination_list = NULL;
 			for (int i=0; i < num_inputs; i++) {
 				inputQueue[i] = NULL;
@@ -151,6 +152,8 @@ public:
 	int processorUsageMax(void) { return CYCLE_COUNTER_APPROX_PERCENT(cpu_cycles_max); }
 	void processorUsageMaxReset(void) { cpu_cycles_max = cpu_cycles; }
 	bool isActive(void) { return active; }
+	bool isBypass(void) { return bypass; }
+	void setBypass(bool new_bypass) {bypass = new_bypass;}
 	uint16_t cpu_cycles;
 	uint16_t cpu_cycles_max;
 	static uint16_t cpu_cycles_total;
@@ -159,6 +162,7 @@ public:
 	static uint16_t memory_used_max;
 protected:
 	bool active;
+	bool bypass;
 	unsigned char num_inputs;
 	static audio_block_t * allocate(void);
 	static void release(audio_block_t * block);


### PR DESCRIPTION
Please consider this PR that allows effects derived from AudioStream to be bypassed, and effectively disabled at runtime.  This enables a very rich effects structure, where effects can be added or removed at runtime.  I've tested this with AudioEffectReverb, and will submit a corresponding PR for your reference.  Ultimately I'd like to see this applied to all effects.  In a nutshell, effects will do this...

```
void
AudioEffectReverb::update(void)
{
  audio_block_t *block;

  if (!(block = receiveWritable()))
    return;

  if (!block->data)
    return;

  if (!bypass) {
    // Alter data block only when active.
  }

  transmit(block, 0);
  release(block);
}
```