### PR TITLE
 r0-r7 only for thumb-1 (Bugfix)

### DIFF
--- a/teensy3/core_pins.h
+++ b/teensy3/core_pins.h
@@ -2062,12 +2062,14 @@ static inline void delayMicroseconds(uint32_t usec)
 		"nop"					"\n\t"
 #endif
 #ifdef KINETISL
-		"sub    %0, #1"				"\n\t"
+        "sub    %0, #1"                "\n\t"
+        "bne    L_%=_delayMicroseconds"        "\n"
+        : "+l" (n) :            
 #else
-		"subs   %0, #1"				"\n\t"
+        "subs   %0, #1"                "\n\t"
+        "bne    L_%=_delayMicroseconds"        "\n"
+        : "+r" (n) :    
 #endif
-		"bne    L_%=_delayMicroseconds"		"\n"
-		: "+r" (n) :
 	);
 }
 


### PR DESCRIPTION
Fixes https://forum.pjrc.com/threads/53976-LTO-fails-(Arduino-1-8-5-amp-1-8-7-Teensyduino-1-44)-with-certain-libraries
- might fix https://github.com/PaulStoffregen/cores/issues/102 (wrong description?)