### PR TITLE
Cycle Counter no longer running on exit

### DIFF
--- a/teensy4/startup.c
+++ b/teensy4/startup.c
@@ -232,6 +232,8 @@ void usb_pll_start()
 			CCM_ANALOG_PLL_USB1_SET = CCM_ANALOG_PLL_USB1_EN_USB_CLKS;
 			continue;
 		}
+		ARM_DEMCR |= ARM_DEMCR_TRCENA;
+  		ARM_DWT_CTRL |= ARM_DWT_CTRL_CYCCNTENA; // turn on cycle counter
 		return; // everything is as it should be  :-)
 	}
 }


### PR DESCRIPTION
Restart Cycle counter

This is done in configure_systick()
But the counter reads ZERO after current call to usb_pll_start()

I didn't read why - but empirically tested moving it through the code to work

https://forum.pjrc.com/threads/54711-Teensy-4-0-First-Beta-Test?p=194008&viewfull=1#post194008