### PR TITLE
Add delayNanoseconds()

### DIFF
--- a/teensy4/core_pins.h
+++ b/teensy4/core_pins.h
@@ -692,6 +692,13 @@ static inline void delayMicroseconds(uint32_t usec)
 	while (ARM_DWT_CYCCNT - begin < cycles) ; // wait
 }
 
+static inline void delayNanoseconds(uint32_t) __attribute__((always_inline, unused));
+static inline void delayNanoseconds(uint32_t nsec)
+{
+	uint32_t begin = ARM_DWT_CYCCNT;
+	uint32_t cycles =  ((uint64_t)F_CPU_ACTUAL * nsec) / 1000000000UL;
+	while (ARM_DWT_CYCCNT - begin < cycles) ; // wait
+}
 
 
 unsigned long rtc_get(void);


### PR DESCRIPTION
This makes sense now, and would be useful for shorter wait-times. Could be used for PulseIn etc.  where we need defined very short delays.