### PR TITLE
allow high values for usec

### DIFF
--- a/teensy4/core_pins.h
+++ b/teensy4/core_pins.h
@@ -749,7 +749,7 @@ static inline void delayMicroseconds(uint32_t) __attribute__((always_inline, unu
 static inline void delayMicroseconds(uint32_t usec)
 {
 	uint32_t begin = ARM_DWT_CYCCNT;
-	uint32_t cycles = F_CPU_ACTUAL / 1000000 * usec;
+	uint32_t cycles = (F_CPU_ACTUAL>>9) / (1000000UL>>9) * usec;
 	// TODO: check if cycles is large, do a wait with yield calls until it's smaller
 	while (ARM_DWT_CYCCNT - begin < cycles) ; // wait
 }


### PR DESCRIPTION
allows max usec to be 512 times higher
OK for F_CPU as low as 2MHz