### PR TITLE
void (* _VectorsRam[160+16])(void);

### DIFF
--- a/teensy4/startup.c
+++ b/teensy4/startup.c
@@ -16,7 +16,7 @@ extern unsigned long _ebss;
 
 
 __attribute__ ((used, aligned(1024)))
-void (* _VectorsRam[160+16])(void);
+void (* _VectorsRam[NVIC_NUM_INTERRUPTS+16])(void);
 
 static void memory_copy(uint32_t *dest, const uint32_t *src, uint32_t *dest_end);
 static void memory_clear(uint32_t *dest, uint32_t *dest_end);


### PR DESCRIPTION
..use NVIC_NUM_INTERRUPTS instead 
i know, very minor documentational issue :)