### PR TITLE
update FASTRUN

### DIFF
--- a/teensy4/WProgram.h
+++ b/teensy4/WProgram.h
@@ -46,7 +46,7 @@
 #include "HardwareSerial.h"
 
 #define DMAMEM __attribute__ ((section(".dmabuffers"), used))
-#define FASTRUN __attribute__ ((section(".fastrun"), noinline, noclone ))
+#define FASTRUN __attribute__ ((section(".fastrun") ))
 
 #ifdef __cplusplus
 


### PR DESCRIPTION
"noinline, noclone" has the opposite effect of beeing faster now on T4
Maye it would be best to use an empty define ? Then we can remove the section in the linker-file, too.

#define FASTRUN