### PR TITLE
Enabled temp monitor in startup

### DIFF
--- a/teensy4/core_pins.h
+++ b/teensy4/core_pins.h
@@ -769,6 +769,9 @@ unsigned long rtc_get(void);
 void rtc_set(unsigned long t);
 void rtc_compensate(int adjust);
 
+void tempmon_init(void);
+float tempmonGetTemp(void);
+
 #ifdef __cplusplus
 }
 

--- a/teensy4/core_pins.h
+++ b/teensy4/core_pins.h
@@ -589,7 +589,15 @@ static inline void digitalWriteFast(uint8_t pin, uint8_t val)
 			}
 		}
 	} else {
-		*portClearRegister(pin) = digitalPinToBitMask(pin);
+		if (val) {
+
+			*portSetRegister(pin) = digitalPinToBitMask(pin);
+
+		} else {
+
+			*portClearRegister(pin) = digitalPinToBitMask(pin);
+
+		}
 	}
 }
 
@@ -771,6 +779,9 @@ void rtc_compensate(int adjust);
 
 void tempmon_init(void);
 float tempmonGetTemp(void);
+void tempmon_Start();
+void tempmon_Stop();
+void tempmon_PwrDwn();
 
 #ifdef __cplusplus
 }

--- a/teensy4/startup.c
+++ b/teensy4/startup.c
@@ -28,9 +28,9 @@ void unused_interrupt_vector(void);
 void usb_pll_start();
 extern void analog_init(void); // analog.c
 extern void pwm_init(void); // pwm.c
+extern void tempmon_init(void);  //tempmon.c
 uint32_t set_arm_clock(uint32_t frequency); // clockspeed.c
 extern void __libc_init_array(void); // C++ standard library
-
 
 __attribute__((section(".startup"), optimize("no-tree-loop-distribute-patterns")))
 void ResetHandler(void)
@@ -82,6 +82,7 @@ void ResetHandler(void)
 	usb_init();
 	analog_init();
 	pwm_init();
+	tempmon_init();
 
 	while (millis() < 300) ; // wait at least 300ms before calling user code
 	printf("before C++ constructors\n");
@@ -89,7 +90,7 @@ void ResetHandler(void)
 	printf("after C++ constructors\n");
 	printf("before setup\n");
 	setup();
-	printf("after setup\n");
+	printf("after setup\n");	
 	while (1) {
 		//printf("loop\n");
 		loop();

--- a/teensy4/tempmon.c
+++ b/teensy4/tempmon.c
@@ -1,0 +1,70 @@
+#include "imxrt.h"
+#include "core_pins.h"
+#include "debug/printf.h"
+
+
+static uint16_t frequency = 0x03U;
+static uint32_t highAlarmTemp   = 85U;
+static uint32_t lowAlarmTemp    = 25U;
+static uint32_t panicAlarmTemp  = 90U;
+
+static uint32_t s_hotTemp, s_hotCount, roomCount, s_roomC_hotC;
+static float s_hot_ROOM;
+
+void tempmon_init(void)
+{
+  // Notes:
+  //    TEMPMON_TEMPSENSE0 &= ~0x2U;  Stops temp monitoring
+  //    TEMPMON_TEMPSENSE0 |= 0x1U;   Powers down temp monitoring 
+  uint32_t calibrationData;
+  uint32_t roomCount;
+  uint32_t tempCodeVal;
+      
+  //first power on the temperature sensor - no register change
+  TEMPMON_TEMPSENSE0 &= ~0x1U;
+
+  //set monitoring frequency - no register change
+  TEMPMON_TEMPSENSE1 = (((uint32_t)(((uint32_t)(frequency)) << 0U)) & 0xFFFFU);
+  
+  //read calibration data - this works
+  calibrationData = HW_OCOTP_ANA1;
+    s_hotTemp = (uint32_t)(calibrationData & 0xFFU) >> 0x00U;
+    s_hotCount = (uint32_t)(calibrationData & 0xFFF00U) >> 0X08U;
+    roomCount = (uint32_t)(calibrationData & 0xFFF00000U) >> 0x14U;
+    s_hot_ROOM = s_hotTemp - 25.0f;
+    s_roomC_hotC = roomCount - s_hotCount;
+
+    //time to set alarm temperatures
+  //Set High Alarm Temp
+  tempCodeVal = (uint32_t)(s_hotCount + (s_hotTemp - highAlarmTemp) * s_roomC_hotC / s_hot_ROOM);
+    TEMPMON_TEMPSENSE0 |= (((uint32_t)(((uint32_t)(tempCodeVal)) << 20U)) & 0xFFF00000U);
+  
+  //Set Panic Alarm Temp
+  tempCodeVal = (uint32_t)(s_hotCount + (s_hotTemp - panicAlarmTemp) * s_roomC_hotC / s_hot_ROOM);
+    TEMPMON_TEMPSENSE2 |= (((uint32_t)(((uint32_t)(tempCodeVal)) << 16U)) & 0xFFF0000U);
+  
+  // Set Low Temp Alarm Temp
+  tempCodeVal = (uint32_t)(s_hotCount + (s_hotTemp - lowAlarmTemp) * s_roomC_hotC / s_hot_ROOM);
+    TEMPMON_TEMPSENSE2 |= (((uint32_t)(((uint32_t)(tempCodeVal)) << 0U)) & 0xFFFU);
+  
+  //Start temp monitoring
+  TEMPMON_TEMPSENSE0 |= 0x2U;   //starts temp monitoring
+}
+
+
+float tempmonGetTemp(void)
+{
+    uint32_t nmeas;
+    float tmeas;
+
+    while (!(TEMPMON_TEMPSENSE0 & 0x4U))
+    {
+    }
+
+    /* ready to read temperature code value */
+    nmeas = (TEMPMON_TEMPSENSE0 & 0xFFF00U) >> 8U;
+    /* Calculate temperature */
+    tmeas = s_hotTemp - (float)((nmeas - s_hotCount) * s_hot_ROOM / s_roomC_hotC);
+
+    return tmeas;
+}

--- a/teensy4/tempmon.c
+++ b/teensy4/tempmon.c
@@ -8,7 +8,7 @@ static uint32_t highAlarmTemp   = 85U;
 static uint32_t lowAlarmTemp    = 25U;
 static uint32_t panicAlarmTemp  = 90U;
 
-static uint32_t s_hotTemp, s_hotCount, roomCount, s_roomC_hotC;
+static uint32_t s_hotTemp, s_hotCount, s_roomC_hotC;
 static float s_hot_ROOM;
 
 void tempmon_init(void)
@@ -67,4 +67,19 @@ float tempmonGetTemp(void)
     tmeas = s_hotTemp - (float)((nmeas - s_hotCount) * s_hot_ROOM / s_roomC_hotC);
 
     return tmeas;
+}
+
+void tempmon_Start()
+{
+    TEMPMON_TEMPSENSE0 |= 0x2U;
+}
+
+void tempmon_Stop()
+{
+    TEMPMON_TEMPSENSE0 &= ~0x2U;
+}
+
+void tempmon_PwrDwn()
+{
+    TEMPMON_TEMPSENSE0 |= 0x1U;
 }


### PR DESCRIPTION
Boiled down the whole temp monitoring sketch to 2 functions,  tempmon_init() and tempmonGetTemp().  The temp monitor gets turned on in startup and then any sketch can just call tempmonGetTemp() to monitor the core temperature as the sketch is running.

One WARNING though the panic temperature is set to 90C, and if exceeded will reset the chip, its easy enough to change though.  Nothing else is done at this point.