### PR TITLE
CCmicros - micros version using Cycle counter

### DIFF
--- a/teensy4/EventResponder.cpp
+++ b/teensy4/EventResponder.cpp
@@ -336,8 +336,10 @@ void MillisTimer::runFromTimer()
 
 // TODO: this doesn't work for IMXRT - no longer using predefined names
 extern "C" volatile uint32_t systick_millis_count;
+extern "C" volatile uint32_t systick_cycle_count;
 extern "C" void systick_isr(void)
 {
+	systick_cycle_count += F_CPU_ACTUAL/1000;
 	systick_millis_count++;
 	MillisTimer::runFromTimer();
 }


### PR DESCRIPTION
Alternate micros() extends millis() using ARM_DWT_CYCCNT

Also makes unused_interrupt_vector() weak to allow user override like Teensy3

Startup is CycCnt dependent to match millis() in significant digits - but once running offset to last systick_isr is true based on Cycle Counter