### PR TITLE
Fix PLL2-PFD

### DIFF
--- a/teensy4/startup.c
+++ b/teensy4/startup.c
@@ -76,6 +76,9 @@ void ResetHandler(void)
 	configure_systick();
 	usb_pll_start();
 
+	CCM_ANALOG_PFD_528_SET = (1 << 31) | (1 << 23) | (1 << 15) | (1 << 7);
+	CCM_ANALOG_PFD_528 = 0x2018101B; // PFD0:352, PFD1:594, PFD2:396, PFD3:297 MHz 
+	
 	set_arm_clock(600000000);
 	//set_arm_clock(984000000); Ludicrous Speed
 


### PR DESCRIPTION
This fixes the PFDs for PLL2 - by default, it has totally wrong values. This sets the frequencies according to the diagram on Page 676.

The same fix is needed for PLL3 - I have code (same structure), but it does not work - Do have have any hints for me?
Is PLL3 even running? I not, can we start it? Or, if i is running - at which frequency, and  is there any non-std config?