### PR TITLE
Changed operator bool to explicit rather than implicit conversion

### DIFF
--- a/teensy3/HardwareSerial.h
+++ b/teensy3/HardwareSerial.h
@@ -282,7 +282,7 @@ public:
 					  serial_write((const uint8_t *)str, len);
 					  return len; }
 	virtual size_t write9bit(uint32_t c)	{ serial_putchar(c); return 1; }
-	operator bool()			{ return true; }
+	constexpr explicit operator bool()			{ return true; }
 };
 extern HardwareSerial Serial1;
 extern void serialEvent1(void);
@@ -319,7 +319,7 @@ public:
 					  serial2_write((const uint8_t *)str, len);
 					  return len; }
 	virtual size_t write9bit(uint32_t c)	{ serial2_putchar(c); return 1; }
-	operator bool()			{ return true; }
+   constexpr explicit operator bool()     { return true; }
 };
 extern HardwareSerial2 Serial2;
 extern void serialEvent2(void);
@@ -356,7 +356,7 @@ public:
 					  serial3_write((const uint8_t *)str, len);
 					  return len; }
 	virtual size_t write9bit(uint32_t c)	{ serial3_putchar(c); return 1; }
-	operator bool()			{ return true; }
+   constexpr explicit operator bool()     { return true; }
 };
 extern HardwareSerial3 Serial3;
 extern void serialEvent3(void);
@@ -393,7 +393,7 @@ public:
 					  serial4_write((const uint8_t *)str, len);
 					  return len; }
 	virtual size_t write9bit(uint32_t c)	{ serial4_putchar(c); return 1; }
-	operator bool()			{ return true; }
+	constexpr explicit operator bool()		{ return true; }
 };
 extern HardwareSerial4 Serial4;
 extern void serialEvent4(void);
@@ -430,7 +430,7 @@ public:
 					  serial5_write((const uint8_t *)str, len);
 					  return len; }
 	virtual size_t write9bit(uint32_t c)	{ serial5_putchar(c); return 1; }
-	operator bool()			{ return true; }
+	constexpr explicit operator bool()			{ return true; }
 };
 extern HardwareSerial5 Serial5;
 extern void serialEvent5(void);
@@ -474,7 +474,7 @@ public:
 					  serial6_write((const uint8_t *)str, len);
 					  return len; }
 	virtual size_t write9bit(uint32_t c)	{ serial6_putchar(c); return 1; }
-	operator bool()			{ return true; }
+   constexpr explicit operator bool()			{ return true; }
 };
 extern HardwareSerial6 Serial6;
 extern void serialEvent6(void);

--- a/teensy4/HardwareSerial.h
+++ b/teensy4/HardwareSerial.h
@@ -190,7 +190,7 @@ public:
 					  serial_format(format); }
 	*/
 
-	operator bool()			{ return true; }
+	constexpr explicit operator bool()			{ return true; }
 private:
 	IMXRT_LPUART_t * const port;
 	const hardware_t * const hardware;


### PR DESCRIPTION
In the file
https://github.com/PaulStoffregen/cores/blob/master/teensy3/HardwareSerial.h
If you were to notice that in every HardwareSerial based Class, HardwareSerial0, 1 etc. we have a function with the type
`operator bool() { return true; }` 

By writing explicit, we can ensure that there is no form of implicit conversion or otherwise.
For further details view https://stackoverflow.com/questions/39995573/when-can-i-use-explicit-operator-bool-without-a-cast

This would ensure that `bool b = Serial1; `would not result in b getting a value

For example, comparing the following codes:-
```
struct T {
    operator bool() const { return true; }
};
int main()
{
    T t;
    bool B = t;
}
```
Does not result in an error due to an absence of explicit.
However, adding explicit we get an error that the conversion cannot be performed in the following sample.

```
struct T {
    explicit operator bool() const { return true; }
};
int main()
{
    T t;
    bool B = t; // error cannot convert t from bool
}
```

An Operator bool with explicit would render it compatible with [only these statements](https://stackoverflow.com/a/39995574)

For example
```
while(Serial);
if(Serial)
for(;Serial;)
```

**CONSTEXPR**

Further, I have marked these statements as `constexpr `given they indeed are constant compile time expressions and their values will not change dynamically at runtime