### PR TITLE
Add meson support

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -178,21 +178,21 @@ ldscript = ['-T' + join_paths(meson.current_source_dir(), teensy_core,
 
 ### Teensy USB RawHID ###
 
-teensy_usb_rawhid_incdir = teensy_core_incdir
+#teensy_usb_rawhid_incdir = teensy_core_incdir
 #teensy_usb_rawhid_incdir += teensy2_core_incdir
-teensy_usb_rawhid_incdir += 'usb_rawhid'
+#teensy_usb_rawhid_incdir += 'usb_rawhid'
 
-teensy_usb_rawhid_src = [
-    'usb_rawhid/usb.c',
-    'usb_rawhid/usb_api.cpp',
-]
+#teensy_usb_rawhid_src = [
+#    'usb_rawhid/usb.c',
+#    'usb_rawhid/usb_api.cpp',
+#]
 
-teensy_usb_rawhid_lib = static_library('teensy-usb-rawid', teensy_usb_rawhid_src,
-                                        include_directories: include_directories(teensy_usb_rawhid_incdir),
-                                        dependencies: teensy_core_dep
-)
+#teensy_usb_rawhid_lib = static_library('teensy-usb-rawid', teensy_usb_rawhid_src,
+#                                        include_directories: include_directories(teensy_usb_rawhid_incdir),
+#                                        dependencies: teensy_core_dep
+#)
 
-teensy_usb_rawhid_dep = declare_dependency(
-    link_with: teensy_usb_rawhid_lib,
-    include_directories: include_directories(teensy_usb_rawhid_incdir),
-)
+#teensy_usb_rawhid_dep = declare_dependency(
+#    link_with: teensy_usb_rawhid_lib,
+#    include_directories: include_directories(teensy_usb_rawhid_incdir),
+#)

--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,198 @@
+project('teensy-cores', 'c', 'cpp',
+    version: '1.44',
+    default_options: [
+        'b_staticpic=false',
+    ]
+)
+
+assert(meson.is_cross_build(), 'Teensy projects can only be built in a cross build environment.')
+
+pkg_mod = import('pkgconfig')
+
+### Teensy Core ###
+
+teensy2_core_incdir = 'teensy'
+
+teensy2_core_src = [
+    'teensy/HardwareSerial.cpp',
+    'teensy/IPAddress.cpp',
+    'teensy/Print.cpp',
+    'teensy/Stream.cpp',
+    'teensy/Tone.cpp',
+    'teensy/WInterrupts.c',
+    'teensy/WMath.cpp',
+    'teensy/WString.cpp',
+    'teensy/keylayouts.c',
+    'teensy/main.cpp',
+    'teensy/malloc.c',
+    'teensy/new.cpp',
+    'teensy/pins_teensy.c',
+    'teensy/usb.c',
+    'teensy/usb_api.cpp',
+    'teensy/wiring.c',
+    'teensy/yield.cpp',
+]
+
+### Teensy 3 Core ###
+
+teensy3_core_incdir = [
+    'teensy3',
+    'teensy3/avr',
+    'teensy3/util',
+]
+
+teensy3_core_src = [
+    'teensy3/analog.c',
+    'teensy3/AudioStream.cpp',
+    'teensy3/avr_emulation.cpp',
+    'teensy3/DMAChannel.cpp',
+    'teensy3/eeprom.c',
+    'teensy3/HardwareSerial1.cpp',
+    'teensy3/HardwareSerial2.cpp',
+    'teensy3/HardwareSerial3.cpp',
+    'teensy3/HardwareSerial4.cpp',
+    'teensy3/HardwareSerial5.cpp',
+    'teensy3/HardwareSerial6.cpp',
+    'teensy3/IntervalTimer.cpp',
+    'teensy3/IPAddress.cpp',
+    'teensy3/keylayouts.c',
+    'teensy3/main.cpp',
+    'teensy3/math_helper.c',
+    'teensy3/memcpy-armv7m.S',
+    'teensy3/memset.S',
+    'teensy3/mk20dx128.c',
+    'teensy3/new.cpp',
+    'teensy3/nonstd.c',
+    'teensy3/pins_teensy.c',
+    'teensy3/Print.cpp',
+    'teensy3/serial1.c',
+    'teensy3/serial2.c',
+    'teensy3/serial3.c',
+    'teensy3/serial4.c',
+    'teensy3/serial5.c',
+    'teensy3/serial6.c',
+    'teensy3/serial6_lpuart.c',
+    'teensy3/ser_print.c',
+    'teensy3/Stream.cpp',
+    'teensy3/Tone.cpp',
+    'teensy3/touch.c',
+    'teensy3/usb_audio.cpp',
+    'teensy3/usb_desc.c',
+    'teensy3/usb_dev.c',
+    'teensy3/usb_flightsim.cpp',
+    'teensy3/usb_inst.cpp',
+    'teensy3/usb_joystick.c',
+    'teensy3/usb_keyboard.c',
+    'teensy3/usb_mem.c',
+    'teensy3/usb_midi.c',
+    'teensy3/usb_mouse.c',
+    'teensy3/usb_mtp.c',
+    'teensy3/usb_rawhid.c',
+    'teensy3/usb_seremu.c',
+    'teensy3/usb_serial.c',
+    'teensy3/usb_touch.c',
+    'teensy3/WMath.cpp',
+    'teensy3/WString.cpp',
+    'teensy3/yield.cpp',
+]
+
+### Teensy 4 Core ###
+
+teensy4_core_incdir = [
+    'teensy4',
+    'teensy4/avr',
+    'teensy4/util',
+]
+
+teensy4_core_src = [
+    'teensy4/analog.c',
+    'teensy4/AudioStream.cpp',
+    'teensy4/Blink.cc',
+    'teensy4/bootdata.c',
+    'teensy4/clockspeed.c',
+    'teensy4/DMAChannel.cpp',
+    'teensy4/debugprintf.c',
+    'teensy4/delay.c',
+    'teensy4/digital.c',
+    'teensy4/HardwareSerial.cpp',
+    'teensy4/HardwareSerial1.cpp',
+    'teensy4/HardwareSerial2.cpp',
+    'teensy4/HardwareSerial3.cpp',
+    'teensy4/HardwareSerial4.cpp',
+    'teensy4/HardwareSerial5.cpp',
+    'teensy4/HardwareSerial6.cpp',
+    'teensy4/HardwareSerial7.cpp',
+    'teensy4/HardwareSerial8.cpp',
+    'teensy4/interrupt.c',
+    'teensy4/IntervalTimer.cpp',
+    'teensy4/IPAddress.cpp',
+    'teensy4/keylayouts.c',
+    'teensy4/libc.c',
+    'teensy4/memcpy-armv7m.S',
+    'teensy4/memset.S',
+    'teensy4/new.cpp',
+    'teensy4/nonstd.c',
+    'teensy4/Print.cpp',
+    'teensy4/pwm.c',
+    'teensy4/startup.c',
+    'teensy4/Stream.cpp',
+    'teensy4/tempmon.c',
+    'teensy4/Tone.cpp',
+    'teensy4/usb_desc.c',
+    'teensy4/usb_inst.cpp',
+    'teensy4/usb_serial.c',
+    'teensy4/WMath.cpp',
+    'teensy4/WString.cpp',
+    'teensy4/yield.cpp',
+]
+
+teensy_core = meson.get_cross_property('teensy_core') # Which teensy core treee to use
+
+teensy_core_src =  []
+teensy_core_incdir = []
+
+if teensy_core == 'teensy' # Teensy(++) 2.0
+    teensy_core_src = teensy2_core_src
+    teensy_core_incdir = teensy2_core_incdir
+elif teensy_core == 'teensy3'
+    teensy_core_src = teensy3_core_src
+    teensy_core_incdir = teensy3_core_incdir
+elif teensy_core == 'teensy4'
+    teensy_core_src = teensy4_core_src
+    teensy_core_incdir = teensy4_core_incdir
+endif
+
+teensy_core_lib = static_library('teensy-core', teensy_core_src,
+                                 cpp_args: '-Wno-non-virtual-dtor',
+                                 include_directories: include_directories(teensy_core_incdir)
+)
+
+teensy_core_dep = declare_dependency(
+    link_with: teensy_core_lib,
+    include_directories: include_directories(teensy_core_incdir),
+)
+
+ldscript = ['-T' + join_paths(meson.current_source_dir(), teensy_core,
+                              meson.get_cross_property('teensy_mcu') + '.ld')]
+
+
+### Teensy USB RawHID ###
+
+teensy_usb_rawhid_incdir = teensy_core_incdir
+#teensy_usb_rawhid_incdir += teensy2_core_incdir
+teensy_usb_rawhid_incdir += 'usb_rawhid'
+
+teensy_usb_rawhid_src = [
+    'usb_rawhid/usb.c',
+    'usb_rawhid/usb_api.cpp',
+]
+
+teensy_usb_rawhid_lib = static_library('teensy-usb-rawid', teensy_usb_rawhid_src,
+                                        include_directories: include_directories(teensy_usb_rawhid_incdir),
+                                        dependencies: teensy_core_dep
+)
+
+teensy_usb_rawhid_dep = declare_dependency(
+    link_with: teensy_usb_rawhid_lib,
+    include_directories: include_directories(teensy_usb_rawhid_incdir),
+)

--- a/meson.build
+++ b/meson.build
@@ -172,8 +172,8 @@ teensy_core_dep = declare_dependency(
     include_directories: include_directories(teensy_core_incdir),
 )
 
-ldscript = ['-T' + join_paths(meson.current_source_dir(), teensy_core,
-                              meson.get_cross_property('teensy_mcu') + '.ld')]
+ldscript = join_paths(meson.current_source_dir(), teensy_core,
+                      meson.get_cross_property('teensy_mcu') + '.ld')
 
 
 ### Teensy USB RawHID ###

--- a/teensy-3.2-cross.txt
+++ b/teensy-3.2-cross.txt
@@ -1,0 +1,72 @@
+[binaries]
+c = 'arm-none-eabi-gcc'
+cpp = 'arm-none-eabi-g++'
+ar = 'arm-none-eabi-ar'
+strip = 'arm-none-eabi-strip'
+objcopy = 'arm-none-eabi-objcopy'
+
+[host_machine]
+system = 'bare-metal'
+cpu_family = 'arm'
+cpu = 'cortex-m4'
+endian = 'little'
+
+[properties]
+
+teensy_core = 'teensy3'
+teensy_mcu = 'mk20dx256'
+
+c_args = [
+    '-DF_CPU=72000000',
+    '-DUSB_SERIAL',
+    '-DLAYOUT_US_ENGLISH',
+    '-mthumb',
+    '-ffunction-sections',
+    '-fdata-sections',
+    '-nostdlib',
+    '-DTEENSYDUINO=138',
+    '-D__MK20DX256__',
+    '-DARDUINO=10804',
+    '-mcpu=cortex-m4',
+    '-mfloat-abi=hard',
+    '-mfpu=fpv4-sp-d16'
+    ]
+
+cpp_args = [
+    '-DF_CPU=72000000',
+    '-DUSB_SERIAL',
+    '-DLAYOUT_US_ENGLISH',
+    '-mthumb',
+    '-ffunction-sections',
+    '-fdata-sections',
+    '-nostdlib',
+    '-DTEENSYDUINO=138',
+    '-D__MK20DX256__',
+    '-DARDUINO=10804',
+    '-mcpu=cortex-m4',
+    '-mfloat-abi=hard',
+    '-mfpu=fpv4-sp-d16',
+    '-std=gnu++11',
+    '-felide-constructors',
+    '-fno-exceptions',
+    '-fno-rtti'
+    ]
+
+c_link_args = [
+    '-Os',
+    '-Wl,--gc-sections',
+    '-mthumb',
+    '-mcpu=cortex-m4',
+    '-mfloat-abi=hard',
+    '-mfpu=fpv4-sp-d16'
+    ]
+
+cpp_link_args = [
+    '-Os',
+    '-Wl,--gc-sections',
+    '-mthumb',
+    '-mcpu=cortex-m4',
+    '-mfloat-abi=hard',
+    '-mfpu=fpv4-sp-d16',
+    ]
+

--- a/teensy-3.5-cross.txt
+++ b/teensy-3.5-cross.txt
@@ -1,0 +1,71 @@
+[binaries]
+c = 'arm-none-eabi-gcc'
+cpp = 'arm-none-eabi-g++'
+ar = 'arm-none-eabi-ar'
+strip = 'arm-none-eabi-strip'
+objcopy = 'arm-none-eabi-objcopy'
+
+[host_machine]
+system = 'bare-metal'
+cpu_family = 'arm'
+cpu = 'cortex-m4'
+endian = 'little'
+
+[properties]
+
+teensy_core = 'teensy3'
+teensy_mcu = 'mk64fx512'
+
+c_args = [
+    '-DF_CPU=120000000',
+    '-DUSB_SERIAL',
+    '-DLAYOUT_US_ENGLISH',
+    '-mthumb',
+    '-ffunction-sections',
+    '-fdata-sections',
+    '-nostdlib',
+    '-DTEENSYDUINO=138',
+    '-D__MK64FX512__',
+    '-DARDUINO=10804',
+    '-mcpu=cortex-m4',
+    '-mfloat-abi=hard',
+    '-mfpu=fpv4-sp-d16'
+    ]
+
+cpp_args = [
+    '-DF_CPU=120000000',
+    '-DUSB_SERIAL',
+    '-DLAYOUT_US_ENGLISH',
+    '-mthumb',
+    '-ffunction-sections',
+    '-fdata-sections',
+    '-nostdlib',
+    '-DTEENSYDUINO=138',
+    '-D__MK64FX512__',
+    '-DARDUINO=10804',
+    '-mcpu=cortex-m4',
+    '-mfloat-abi=hard',
+    '-mfpu=fpv4-sp-d16',
+    '-std=gnu++11',
+    '-felide-constructors',
+    '-fno-exceptions',
+    '-fno-rtti'
+    ]
+
+c_link_args = [
+    '-Os',
+    '-Wl,--gc-sections',
+    '-mthumb',
+    '-mcpu=cortex-m4',
+    '-mfloat-abi=hard',
+    '-mfpu=fpv4-sp-d16'
+    ]
+
+cpp_link_args = [
+    '-Os',
+    '-Wl,--gc-sections',
+    '-mthumb',
+    '-mcpu=cortex-m4',
+    '-mfloat-abi=hard',
+    '-mfpu=fpv4-sp-d16'
+    ]


### PR DESCRIPTION
-- WIP, Do not merge

This patches add meson suport. This allow us to have a simple full terminal write, build, deploy environment.

Based on https://github.com/leroilion/teensy-core

Now, to the actual issues...

Meson generates the command:
```
arm-none-eabi-g++  -o blink 'blink@exe/src_blink.cpp.o' -Wl,--no-undefined -Wl,--as-needed -Wl,--start-group subprojects/cores/libteensy-core.a -Wl,--end-group -T/home/anubis/git/blink/subprojects/cores/teensy3/mk20dx256.ld '-Wl,-rpath,$ORIGIN/subprojects/cores' -Wl,-rpath-link,/home/anubis/git/blink/build/subprojects/cores -Os -Wl,--gc-sections -mthumb -mcpu=cortex-m4 -mfloat-abi=hard -mfpu=fpv4-sp-d16
```

And we get the following linking error:
```
/usr/lib/gcc/arm-none-eabi/8.2.0/../../../../arm-none-eabi/bin/ld: subprojects/cores/libteensy-core.a(teensy3_mk20dx128.c.o): in function `ResetHandler':
/home/anubis/git/blink/build/../subprojects/cores/teensy3/mk20dx128.c:769: undefined reference to `__rtc_localtime'
/usr/lib/gcc/arm-none-eabi/8.2.0/../../../../arm-none-eabi/bin/ld: subprojects/cores/libteensy-core.a(teensy3_mk20dx128.c.o):(.vectors+0x3c): undefined reference to `systick_isr'
/usr/lib/gcc/arm-none-eabi/8.2.0/../../../../arm-none-eabi/bin/ld: subprojects/cores/libteensy-core.a(teensy3_yield.cpp.o): in function `yield':
/home/anubis/git/blink/build/../subprojects/cores/teensy3/EventResponder.h:198: undefined reference to `EventResponder::firstYield'
/usr/lib/gcc/arm-none-eabi/8.2.0/../../../../arm-none-eabi/bin/ld: /home/anubis/git/blink/build/../subprojects/cores/teensy3/EventResponder.h:198: undefined reference to `EventResponder::runningFromYield'
/usr/lib/gcc/arm-none-eabi/8.2.0/../../../../arm-none-eabi/bin/ld: /home/anubis/git/blink/build/../subprojects/cores/teensy3/EventResponder.h:198: undefined reference to `EventResponder::lastYield'
```
Any thoughts?