### PR TITLE
Set pad configs: disable keeper

### DIFF
--- a/teensy4/analog.c
+++ b/teensy4/analog.c
@@ -115,6 +115,7 @@ void analogReadAveraging(unsigned int num)
 
 #define MAX_ADC_CLOCK 20000000
 
+__attribute__((section(".progmem")))
 void analog_init(void)
 {
 	uint32_t mode, avg=0;

--- a/teensy4/analog.c
+++ b/teensy4/analog.c
@@ -115,13 +115,20 @@ void analogReadAveraging(unsigned int num)
 
 #define MAX_ADC_CLOCK 20000000
 
-__attribute__((section(".progmem")))
 void analog_init(void)
 {
 	uint32_t mode, avg=0;
+	const struct digital_pin_bitband_and_config_table_struct *p;
 
 	printf("analogInit\n");
-
+	
+	//Initialize analog pad configs, keeper disabled
+	for(uint8_t i = 14; i < 24; i++){
+	  p = digital_pin_to_info_PGM + i;
+	  *(p->pad) &=  ~IOMUXC_PAD_PKE;
+	}
+	
+	
 	CCM_CCGR1 |= CCM_CCGR1_ADC1(CCM_CCGR_ON);
 
 	if (analog_config_bits == 8) {

--- a/teensy4/analog.c
+++ b/teensy4/analog.c
@@ -51,13 +51,17 @@ static void wait_for_cal(void)
 
 int analogRead(uint8_t pin)
 {
-	if (pin > sizeof(pin_to_channel)) return 0;
-	if (calibrating) wait_for_cal();
-	uint8_t ch = pin_to_channel[pin];
-	if (ch > 15) return 0;
-	ADC1_HC0 = ch;
-	while (!(ADC1_HS & ADC_HS_COCO0)) ; // wait
-	return ADC1_R0;
+    const struct digital_pin_bitband_and_config_table_struct *p;
+
+    if (pin > sizeof(pin_to_channel)) return 0;
+    if (calibrating) wait_for_cal();
+    uint8_t ch = pin_to_channel[pin];
+    if (ch > 15) return 0;
+    p = digital_pin_to_info_PGM + pin;
+    *(p->pad) = IOMUXC_PAD_DSE(7);    // disable PKE
+    ADC1_HC0 = ch;
+    while (!(ADC1_HS & ADC_HS_COCO0)) ; // wait
+    return ADC1_R0;
 }
 
 void analogReference(uint8_t type)

--- a/teensy4/imxrt1052.ld
+++ b/teensy4/imxrt1052.ld
@@ -1,0 +1,89 @@
+MEMORY
+{
+	ITCM (rwx):  ORIGIN = 0x00000000, LENGTH = 128K
+	DTCM (rwx):  ORIGIN = 0x20000000, LENGTH = 128K
+	RAM (rwx):   ORIGIN = 0x20200000, LENGTH = 256K
+	FLASH (rwx): ORIGIN = 0x60000000, LENGTH = 1536K
+}
+
+ENTRY(ImageVectorTable)
+
+SECTIONS
+{
+	.text.progmem : {
+		KEEP(*(.flashconfig))
+		FILL(0xFF)
+		. = ORIGIN(FLASH) + 0x1000;
+		KEEP(*(.ivt))
+		KEEP(*(.bootdata))
+		KEEP(*(.vectors))
+		KEEP(*(.startup))
+		*(.progmem*)
+                . = ALIGN(4);
+                KEEP(*(.init))
+                __preinit_array_start = .;
+                KEEP (*(.preinit_array))
+                __preinit_array_end = .;
+                __init_array_start = .;
+                KEEP (*(.init_array))
+                __init_array_end = .;
+		. = ALIGN(16);
+	} > FLASH
+
+	.text : {
+		. = . + 32; /* MPU to trap NULL pointer deref */
+		*(.fastrun)
+		*(.text*)
+		. = ALIGN(16);
+	} > ITCM  AT> FLASH
+
+	.vectorsRAM (NOLOAD) : {
+		. = ALIGN(4);
+		*(.vectorsRAM*)
+	} > DTCM 
+	
+	.data : {
+		*(.rodata*)
+		*(.data*)
+		. = ALIGN(16);
+	} > DTCM  AT> FLASH
+
+	.bss ALIGN(4) : {
+		*(.bss*)
+		*(COMMON)
+		. = ALIGN(32);
+		. = . + 32; /* MPU to trap stack overflow */
+	} > DTCM
+
+	.bss.dma (NOLOAD) : {
+		*(.dmabuffers)
+		. = ALIGN(16);
+	} > RAM
+
+	_stext = ADDR(.text);
+	_etext = ADDR(.text) + SIZEOF(.text);
+	_stextload = LOADADDR(.text);
+
+	_sdata = ADDR(.data);
+	_edata = ADDR(.data) + SIZEOF(.data);
+	_sdataload = LOADADDR(.data);
+
+	_estack = ORIGIN(DTCM) + LENGTH(DTCM);
+
+	_sbss = ADDR(.bss);
+	_ebss = ADDR(.bss) + SIZEOF(.bss);
+
+	_heap_start = ADDR(.bss.dma) + SIZEOF(.bss.dma);
+	_heap_end = ORIGIN(RAM) + LENGTH(RAM);
+
+	_flashimagelen = SIZEOF(.text.progmem) + SIZEOF(.text) + SIZEOF(.data);
+	_teensy_model_identifier = 0x23;
+
+	.debug_info     0 : { *(.debug_info) }
+	.debug_abbrev   0 : { *(.debug_abbrev) }
+	.debug_line     0 : { *(.debug_line) }
+	.debug_frame    0 : { *(.debug_frame) }
+	.debug_str      0 : { *(.debug_str) }
+	.debug_loc      0 : { *(.debug_loc) }
+
+}

--- a/teensy4/imxrt1062.ld
+++ b/teensy4/imxrt1062.ld
@@ -1,0 +1,89 @@
+MEMORY
+{
+	ITCM (rwx):  ORIGIN = 0x00000000, LENGTH = 128K
+	DTCM (rwx):  ORIGIN = 0x20000000, LENGTH = 128K
+	RAM (rwx):   ORIGIN = 0x20200000, LENGTH = 256K
+	FLASH (rwx): ORIGIN = 0x60000000, LENGTH = 1536K
+}
+
+ENTRY(ImageVectorTable)
+
+SECTIONS
+{
+	.text.progmem : {
+		KEEP(*(.flashconfig))
+		FILL(0xFF)
+		. = ORIGIN(FLASH) + 0x1000;
+		KEEP(*(.ivt))
+		KEEP(*(.bootdata))
+		KEEP(*(.vectors))
+		KEEP(*(.startup))
+		*(.progmem*)
+                . = ALIGN(4);
+                KEEP(*(.init))
+                __preinit_array_start = .;
+                KEEP (*(.preinit_array))
+                __preinit_array_end = .;
+                __init_array_start = .;
+                KEEP (*(.init_array))
+                __init_array_end = .;
+		. = ALIGN(16);
+	} > FLASH
+
+	.text : {
+		. = . + 32; /* MPU to trap NULL pointer deref */
+		*(.fastrun)
+		*(.text*)
+		. = ALIGN(16);
+	} > ITCM  AT> FLASH
+
+	.vectorsRAM (NOLOAD) : {
+		. = ALIGN(4);
+		*(.vectorsRAM*)
+	} > DTCM 
+	
+	.data : {
+		*(.rodata*)
+		*(.data*)
+		. = ALIGN(16);
+	} > DTCM  AT> FLASH
+
+	.bss ALIGN(4) : {
+		*(.bss*)
+		*(COMMON)
+		. = ALIGN(32);
+		. = . + 32; /* MPU to trap stack overflow */
+	} > DTCM
+
+	.bss.dma (NOLOAD) : {
+		*(.dmabuffers)
+		. = ALIGN(16);
+	} > RAM
+
+	_stext = ADDR(.text);
+	_etext = ADDR(.text) + SIZEOF(.text);
+	_stextload = LOADADDR(.text);
+
+	_sdata = ADDR(.data);
+	_edata = ADDR(.data) + SIZEOF(.data);
+	_sdataload = LOADADDR(.data);
+
+	_estack = ORIGIN(DTCM) + LENGTH(DTCM);
+
+	_sbss = ADDR(.bss);
+	_ebss = ADDR(.bss) + SIZEOF(.bss);
+
+	_heap_start = ADDR(.bss.dma) + SIZEOF(.bss.dma);
+	_heap_end = ORIGIN(RAM) + LENGTH(RAM);
+
+	_flashimagelen = SIZEOF(.text.progmem) + SIZEOF(.text) + SIZEOF(.data);
+	_teensy_model_identifier = 0x24;
+
+	.debug_info     0 : { *(.debug_info) }
+	.debug_abbrev   0 : { *(.debug_abbrev) }
+	.debug_line     0 : { *(.debug_line) }
+	.debug_frame    0 : { *(.debug_frame) }
+	.debug_str      0 : { *(.debug_str) }
+	.debug_loc      0 : { *(.debug_loc) }
+
+}


### PR DESCRIPTION
Paul
This addresses the issue identified in post 1782 and 1789 regarding the issue that keeper should be disabled before starting ADC.  This is the easiest way I could think of to implement it.

Mike