### PR TITLE
bug fix, No blind USB irq enable

### DIFF
--- a/teensy3/avr_emulation.h
+++ b/teensy3/avr_emulation.h
@@ -2195,7 +2195,7 @@ class SREGemulation
 public:
 	operator int () const __attribute__((always_inline)) {
 		uint32_t primask;
-		asm volatile("mrs %0, primask\n" : "=r" (primask)::);
+		__irq_status(primask);
 		if (primask) return 0;
 		return (1<<7);
 	}

--- a/teensy3/kinetis.h
+++ b/teensy3/kinetis.h
@@ -5671,8 +5671,11 @@ typedef struct __attribute__((packed)) {
 
 
 
-#define __disable_irq() __asm__ volatile("CPSID i":::"memory");
-#define __enable_irq()	__asm__ volatile("CPSIE i":::"memory");
+#define __disable_irq()  __asm__ volatile("CPSID i":::"memory");
+#define __enable_irq()   __asm__ volatile("CPSIE i":::"memory");
+// assigns 1 if irqs are disabled (exceptions are prevented), 0 if enabled
+// use int or uint32_t or the compiler will clear the full register after
+#define __irq_status(irq_disabled) __asm__ volatile("mrs %0, primask\n" : "=r" (irq_disabled)::);
 
 // System Control Space (SCS), ARMv7 ref manual, B3.2, page 708
 #define SCB_CPUID		(*(const    uint32_t *)0xE000ED00) // CPUID Base Register

--- a/teensy3/usb_desc.c
+++ b/teensy3/usb_desc.c
@@ -1459,8 +1459,9 @@ struct usb_string_descriptor_struct usb_string_mtp = {
 void usb_init_serialnumber(void)
 {
 	char buf[11];
-	uint32_t i, num;
+	uint32_t i, num, irq_disabled;
 
+	__irq_status(irq_disabled);
 	__disable_irq();
 #if defined(HAS_KINETIS_FLASH_FTFA) || defined(HAS_KINETIS_FLASH_FTFL)
 	FTFL_FSTAT = FTFL_FSTAT_RDCOLERR | FTFL_FSTAT_ACCERR | FTFL_FSTAT_FPVIOL;
@@ -1478,7 +1479,9 @@ void usb_init_serialnumber(void)
 	num = *(uint32_t *)&FTFL_FCCOBB;
 	kinetis_hsrun_enable();
 #endif
-	__enable_irq();
+	if(!irq_disabled) {
+		__enable_irq();
+	}
 	// add extra zero to work around OS-X CDC-ACM driver bug
 	if (num < 10000000) num = num * 10;
 	ultoa(num, buf, 10);

--- a/teensy3/usb_dev.c
+++ b/teensy3/usb_dev.c
@@ -671,16 +671,20 @@ static void usb_control(uint32_t stat)
 
 usb_packet_t *usb_rx(uint32_t endpoint)
 {
+	uint32_t irq_disabled;
 	usb_packet_t *ret;
 	endpoint--;
 	if (endpoint >= NUM_ENDPOINTS) return NULL;
+	__irq_status(irq_disabled);
 	__disable_irq();
 	ret = rx_first[endpoint];
 	if (ret) {
 		rx_first[endpoint] = ret->next;
 		usb_rx_byte_count_data[endpoint] -= ret->len;
 	}
-	__enable_irq();
+	if(!irq_disabled) {
+		__enable_irq();
+	}
 	//serial_print("rx, epidx=");
 	//serial_phex(endpoint);
 	//serial_print(", packet=");
@@ -691,13 +695,16 @@ usb_packet_t *usb_rx(uint32_t endpoint)
 
 static uint32_t usb_queue_byte_count(const usb_packet_t *p)
 {
-	uint32_t count=0;
+	uint32_t count=0, irq_disabled;
 
+	__irq_status(irq_disabled);
 	__disable_irq();
 	for ( ; p; p = p->next) {
 		count += p->len;
 	}
-	__enable_irq();
+	if(!irq_disabled) {
+		__enable_irq();
+	}
 	return count;
 }
 
@@ -722,13 +729,16 @@ uint32_t usb_tx_byte_count(uint32_t endpoint)
 uint32_t usb_tx_packet_count(uint32_t endpoint)
 {
 	const usb_packet_t *p;
-	uint32_t count=0;
+	uint32_t count=0, irq_disabled;
 
 	endpoint--;
 	if (endpoint >= NUM_ENDPOINTS) return 0;
+	__irq_status(irq_disabled);
 	__disable_irq();
 	for (p = tx_first[endpoint]; p; p = p->next) count++;
-	__enable_irq();
+	if(!irq_disabled) {
+		__enable_irq();
+	}
 	return count;
 }
 
@@ -745,9 +755,11 @@ void usb_rx_memory(usb_packet_t *packet)
 {
 	unsigned int i;
 	const uint8_t *cfg;
+	uint32_t irq_disabled;
 
 	cfg = usb_endpoint_config_table;
 	//serial_print("rx_mem:");
+	__irq_status(irq_disabled);
 	__disable_irq();
 	for (i=1; i <= NUM_ENDPOINTS; i++) {
 #ifdef AUDIO_INTERFACE
@@ -758,7 +770,9 @@ void usb_rx_memory(usb_packet_t *packet)
 				table[index(i, RX, EVEN)].addr = packet->buf;
 				table[index(i, RX, EVEN)].desc = BDT_DESC(64, 0);
 				usb_rx_memory_needed--;
-				__enable_irq();
+				if(!irq_disabled) {
+					__enable_irq();
+				}
 				//serial_phex(i);
 				//serial_print(",even\n");
 				return;
@@ -767,14 +781,18 @@ void usb_rx_memory(usb_packet_t *packet)
 				table[index(i, RX, ODD)].addr = packet->buf;
 				table[index(i, RX, ODD)].desc = BDT_DESC(64, 1);
 				usb_rx_memory_needed--;
-				__enable_irq();
+				if(!irq_disabled) {
+					__enable_irq();
+				}
 				//serial_phex(i);
 				//serial_print(",odd\n");
 				return;
 			}
 		}
 	}
-	__enable_irq();
+	if(!irq_disabled) {
+		__enable_irq();
+	}
 	// we should never reach this point.  If we get here, it means
 	// usb_rx_memory_needed was set greater than zero, but no memory
 	// was actually needed.
@@ -788,11 +806,13 @@ void usb_rx_memory(usb_packet_t *packet)
 
 void usb_tx(uint32_t endpoint, usb_packet_t *packet)
 {
+	uint32_t irq_disabled;
 	bdt_t *b = &table[index(endpoint, TX, EVEN)];
 	uint8_t next;
 
 	endpoint--;
 	if (endpoint >= NUM_ENDPOINTS) return;
+	__irq_status(irq_disabled);
 	__disable_irq();
 	//serial_print("txstate=");
 	//serial_phex(tx_state[endpoint]);
@@ -819,13 +839,17 @@ void usb_tx(uint32_t endpoint, usb_packet_t *packet)
 			tx_last[endpoint]->next = packet;
 		}
 		tx_last[endpoint] = packet;
-		__enable_irq();
+		if(!irq_disabled) {
+			__enable_irq();
+		}
 		return;
 	}
 	tx_state[endpoint] = next;
 	b->addr = packet->buf;
 	b->desc = BDT_DESC(packet->len, ((uint32_t)b & 8) ? DATA1 : DATA0);
-	__enable_irq();
+	if(!irq_disabled) {
+		__enable_irq();
+	}
 }
 
 void usb_tx_isochronous(uint32_t endpoint, void *data, uint32_t len)


### PR DESCRIPTION
I have a program that's receiving data over USB serial and consuming that data as timers expire (two interrupt routines). I'm having data corruption, hangs, and other odd problems. I disabled interrupts in my routines, but I'm calling the usb_serial routines and they unconditionally enable interrupts. Here are corrected versions of the usb routines that will only enable interrupts if interrupts were previously enabled. This fixed the problems I was seeing.