### PR TITLE
Code cleanup for compiler warnings etc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *.d
 *.hex
 *.o
+*.lst
 nbproject
 *~
 *.bak

--- a/teensy3/AudioStream.cpp
+++ b/teensy3/AudioStream.cpp
@@ -29,7 +29,7 @@
  */
 
 
-#include <Arduino.h>
+#include "Arduino.h"
 #include "AudioStream.h"
 
 #if defined(__MKL26Z64__)

--- a/teensy3/Client.h
+++ b/teensy3/Client.h
@@ -41,7 +41,7 @@ public:
   virtual uint8_t connected() = 0;
   virtual operator bool() = 0;
 protected:
-  uint8_t* rawIPAddress(IPAddress& addr) { return addr.raw_address(); };
+  uint8_t* rawIPAddress(IPAddress& addr) { return addr.raw_address(); }
 };
 
 #endif

--- a/teensy3/Client.h
+++ b/teensy3/Client.h
@@ -17,7 +17,7 @@
   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 */
 
-#if ARDUINO >= 100
+#if defined(ARDUINO) && ARDUINO >= 100
 
 #ifndef client_h
 #define client_h

--- a/teensy3/EventResponder.cpp
+++ b/teensy3/EventResponder.cpp
@@ -31,7 +31,6 @@
  *     https://forum.pjrc.com/threads/44723-Arduino-Events
  */
 
-#include <Arduino.h>
 #include "EventResponder.h"
 
 EventResponder * EventResponder::firstYield = nullptr;

--- a/teensy3/EventResponder.h
+++ b/teensy3/EventResponder.h
@@ -34,7 +34,7 @@
 #if !defined(EventResponder_h) && defined(__cplusplus)
 #define EventResponder_h
 
-#include <Arduino.h>
+#include "Arduino.h"
 
 /* EventResponder lets you control how your program responds to an event.
  * Imagine a basketball or football (American soccer) player who gets the

--- a/teensy3/HardwareSerial1.cpp
+++ b/teensy3/HardwareSerial1.cpp
@@ -28,7 +28,7 @@
  * SOFTWARE.
  */
 
-#include <Arduino.h>
+#include "Arduino.h"
 #include "HardwareSerial.h"
 
 HardwareSerial Serial1;

--- a/teensy3/HardwareSerial2.cpp
+++ b/teensy3/HardwareSerial2.cpp
@@ -28,7 +28,7 @@
  * SOFTWARE.
  */
 
-#include <Arduino.h>
+#include "Arduino.h"
 #include "HardwareSerial.h"
 
 HardwareSerial2 Serial2;

--- a/teensy3/HardwareSerial3.cpp
+++ b/teensy3/HardwareSerial3.cpp
@@ -28,7 +28,7 @@
  * SOFTWARE.
  */
 
-#include <Arduino.h>
+#include "Arduino.h"
 #include "HardwareSerial.h"
 
 HardwareSerial3 Serial3;

--- a/teensy3/HardwareSerial4.cpp
+++ b/teensy3/HardwareSerial4.cpp
@@ -28,7 +28,7 @@
  * SOFTWARE.
  */
 
-#include <Arduino.h>
+#include "Arduino.h"
 #include "HardwareSerial.h"
 
 #ifdef HAS_KINETISK_UART3

--- a/teensy3/HardwareSerial5.cpp
+++ b/teensy3/HardwareSerial5.cpp
@@ -28,7 +28,7 @@
  * SOFTWARE.
  */
 
-#include <Arduino.h>
+#include "Arduino.h"
 #include "HardwareSerial.h"
 
 #ifdef HAS_KINETISK_UART4

--- a/teensy3/HardwareSerial6.cpp
+++ b/teensy3/HardwareSerial6.cpp
@@ -28,7 +28,7 @@
  * SOFTWARE.
  */
 
-#include <Arduino.h>
+#include "Arduino.h"
 #include "HardwareSerial.h"
 
 #if defined(HAS_KINETISK_UART5) || defined (HAS_KINETISK_LPUART0)

--- a/teensy3/IPAddress.cpp
+++ b/teensy3/IPAddress.cpp
@@ -17,7 +17,7 @@
   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 */
 
-#include <Arduino.h>
+#include "Arduino.h"
 #include "IPAddress.h"
 
 size_t IPAddress::printTo(Print& p) const

--- a/teensy3/IPAddress.h
+++ b/teensy3/IPAddress.h
@@ -26,8 +26,8 @@
 #ifndef IPAddress_h
 #define IPAddress_h
 
-#include <Printable.h>
-#include <WString.h>
+#include "Printable.h"
+#include "WString.h"
 
 // A class to make it easier to handle and pass around IP addresses
 

--- a/teensy3/IPAddress.h
+++ b/teensy3/IPAddress.h
@@ -42,7 +42,7 @@ private:
 	// to the internal structure rather than a copy of the address this function should only
 	// be used when you know that the usage of the returned uint8_t* will be transient and not
 	// stored.
-	uint8_t * raw_address() { return _address.bytes; };
+	uint8_t * raw_address() { return _address.bytes; }
 
 public:
 	// Constructors
@@ -90,10 +90,10 @@ public:
 	// Overloaded index operator to allow getting and setting individual octets of the address
 	uint8_t operator[](int index) const {
 		return _address.bytes[index];
-	};
+	}
 	uint8_t& operator[](int index) {
 		return _address.bytes[index];
-	};
+	}
 
 	// Overloaded copy operators to allow initialisation of IPAddress objects from other types
 	IPAddress& operator=(const uint8_t *address) {

--- a/teensy3/Print.cpp
+++ b/teensy3/Print.cpp
@@ -34,7 +34,7 @@
 // developed for Teensyduino have made their way back into
 // Arduino's code base.  :-)
 
-#include <Arduino.h>
+#include "Arduino.h"
 
 
 size_t Print::write(const uint8_t *buffer, size_t size)

--- a/teensy3/Server.h
+++ b/teensy3/Server.h
@@ -17,7 +17,7 @@
   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 */
 
-#if ARDUINO >= 100
+#if defined(ARDUINO) && ARDUINO >= 100
 
 #ifndef server_h
 #define server_h

--- a/teensy3/Stream.cpp
+++ b/teensy3/Stream.cpp
@@ -20,7 +20,7 @@
  parsing functions based on TextFinder library by Michael Margolis
  */
 
-#include <Arduino.h>
+#include "Arduino.h"
 
 #define PARSE_TIMEOUT 1000  // default number of milli-seconds to wait
 #define NO_SKIP_CHAR  1  // a magic char not found in a valid ASCII numeric field

--- a/teensy3/Tone.cpp
+++ b/teensy3/Tone.cpp
@@ -28,7 +28,7 @@
  * SOFTWARE.
  */
 
-#include <Arduino.h>
+#include "Arduino.h"
 
 // IntervalTimer based tone.  This allows tone() to share the timers with other
 // libraries, rather than permanently hogging one PIT timer even for projects

--- a/teensy3/Udp.h
+++ b/teensy3/Udp.h
@@ -37,8 +37,8 @@
 #ifndef udp_h
 #define udp_h
 
-#include <Stream.h>
-#include <IPAddress.h>
+#include "Stream.h"
+#include "IPAddress.h"
 
 class UDP : public Stream {
 

--- a/teensy3/Udp.h
+++ b/teensy3/Udp.h
@@ -32,7 +32,7 @@
  * bjoern@cs.stanford.edu 12/30/2008
  */
 
-#if ARDUINO >= 100
+#if defined(ARDUINO) && ARDUINO >= 100
 
 #ifndef udp_h
 #define udp_h

--- a/teensy3/WProgram.h
+++ b/teensy3/WProgram.h
@@ -38,8 +38,8 @@
 // some libraries and sketches depend on this
 // AVR stuff, assuming Arduino.h or WProgram.h
 // automatically includes it...
-#include <avr/pgmspace.h>
-#include <avr/interrupt.h>
+#include "avr/pgmspace.h"
+#include "avr/interrupt.h"
 
 #include "avr_functions.h"
 #include "wiring.h"

--- a/teensy3/WString.cpp
+++ b/teensy3/WString.cpp
@@ -19,7 +19,7 @@
   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 */
 
-#include <Arduino.h>
+#include "Arduino.h"
 
 
 /*********************************************/

--- a/teensy3/avr_emulation.cpp
+++ b/teensy3/avr_emulation.cpp
@@ -29,7 +29,7 @@
  */
 
 
-#include <Arduino.h>
+#include "Arduino.h"
 #include "SPIFIFO.h"
 
 uint8_t SPCRemulation::pinout = 0;

--- a/teensy3/core_cm4.h
+++ b/teensy3/core_cm4.h
@@ -151,9 +151,9 @@
 #endif
 
 #include <stdint.h>                      /* standard types definitions                      */
-#include <core_cmInstr.h>                /* Core Instruction Access                         */
-#include <core_cmFunc.h>                 /* Core Function Access                            */
-#include <core_cm4_simd.h>               /* Compiler specific SIMD Intrinsics               */
+#include "core_cmInstr.h"                /* Core Instruction Access                         */
+#include "core_cmFunc.h"                 /* Core Function Access                            */
+#include "core_cm4_simd.h"               /* Compiler specific SIMD Intrinsics               */
 
 #endif /* __CORE_CM4_H_GENERIC */
 

--- a/teensy3/eeprom.c
+++ b/teensy3/eeprom.c
@@ -37,7 +37,7 @@
 // know what you're doing.
 
 #include "kinetis.h"
-#include <avr/eeprom.h>
+#include "avr/eeprom.h"
 //#include "HardwareSerial.h"
 #if F_CPU > 120000000 && defined(__MK66FX1M0__)
 #include "core_pins.h"	// delayMicroseconds()

--- a/teensy3/elapsedMillis.h
+++ b/teensy3/elapsedMillis.h
@@ -25,7 +25,7 @@
 #define elapsedMillis_h
 #ifdef __cplusplus
 
-#if ARDUINO >= 100
+#if defined(ARDUINO) && ARDUINO >= 100
 #include "Arduino.h"
 #else
 #include "WProgram.h"

--- a/teensy3/keylayouts.c
+++ b/teensy3/keylayouts.c
@@ -28,7 +28,6 @@
  * SOFTWARE.
  */
 
-#include <avr/pgmspace.h>
 #include <stdint.h>
 
 #include "keylayouts.h"

--- a/teensy3/keylayouts.h
+++ b/teensy3/keylayouts.h
@@ -32,7 +32,6 @@
 #define KEYLAYOUTS_H__
 
 #include <stdint.h>
-#include <avr/pgmspace.h>
 
 #ifdef __cplusplus
 extern "C"{

--- a/teensy3/main.cpp
+++ b/teensy3/main.cpp
@@ -28,7 +28,7 @@
  * SOFTWARE.
  */
 
-#include <Arduino.h>
+#include "Arduino.h"
 
 extern "C" int main(void)
 {

--- a/teensy3/mk20dx128.c
+++ b/teensy3/mk20dx128.c
@@ -1120,7 +1120,7 @@ void ResetHandler(void)
 		// flag into the VBAT register file indicating the
 		// RTC is set with known-stale time and should be
 		// updated when fresh time is known.
-		#if ARDUINO >= 10600
+		#if defined(ARDUINO) && ARDUINO >= 10600
 		rtc_set((uint32_t)&__rtc_localtime);
 		#else
 		rtc_set(TIME_T);
@@ -1134,7 +1134,7 @@ void ResetHandler(void)
 		// the RTC with this, and clear the VBAT resister file
 		// data so we don't mess with the time after it's been
 		// set well.
-		#if ARDUINO >= 10600
+		#if defined(ARDUINO) && ARDUINO >= 10600
 		rtc_set((uint32_t)&__rtc_localtime);
 		#else
 		rtc_set(TIME_T);

--- a/teensy3/mk20dx128.c
+++ b/teensy3/mk20dx128.c
@@ -1224,7 +1224,7 @@ void _exit(int status)
 }
 
 __attribute__((weak)) 
-void __cxa_pure_virtual()
+void __cxa_pure_virtual(void)
 {
 	while (1);
 }

--- a/teensy3/mk20dx128.c
+++ b/teensy3/mk20dx128.c
@@ -1106,7 +1106,6 @@ void ResetHandler(void)
 	SYST_CSR = SYST_CSR_CLKSOURCE | SYST_CSR_TICKINT | SYST_CSR_ENABLE;
 	SCB_SHPR3 = 0x20200000;  // Systick = priority 32
 
-	//init_pins();
 	__enable_irq();
 
 	_init_Teensyduino_internal_();

--- a/teensy3/pgmspace.h
+++ b/teensy3/pgmspace.h
@@ -1,2 +1,2 @@
 // For compatibility with some ESP8266 programs
-#include <avr/pgmspace.h>
+#include "avr/pgmspace.h"

--- a/teensy3/pins_teensy.c
+++ b/teensy3/pins_teensy.c
@@ -140,7 +140,7 @@ const struct digital_pin_bitband_and_config_table_struct digital_pin_to_info_PGM
 
 #endif
 
-static void dummy_isr() {};
+static void dummy_isr(void) {};
 
 typedef void (*voidFuncPtr)(void);
 #if defined(KINETISK)

--- a/teensy3/usb_audio.cpp
+++ b/teensy3/usb_audio.cpp
@@ -28,7 +28,7 @@
  * SOFTWARE.
  */
 
-#include <Arduino.h>
+#include "Arduino.h"
 #include "usb_dev.h"
 
 #ifdef AUDIO_INTERFACE // defined by usb_dev.h -> usb_desc.h

--- a/teensy3/usb_inst.cpp
+++ b/teensy3/usb_inst.cpp
@@ -28,7 +28,7 @@
  * SOFTWARE.
  */
 
-#include <Arduino.h>
+#include "Arduino.h"
 #include "usb_desc.h"
 
 #if F_CPU >= 20000000

--- a/teensy3/usb_seremu.h
+++ b/teensy3/usb_seremu.h
@@ -65,8 +65,8 @@ class usb_seremu_class : public Stream
 {
 public:
 	constexpr usb_seremu_class() {}
-        void begin(long) { /* TODO: call a function that tries to wait for enumeration */ };
-        void end() { /* TODO: flush output and shut down USB port */ };
+        void begin(long) { /* TODO: call a function that tries to wait for enumeration */ }
+        void end() { /* TODO: flush output and shut down USB port */ }
         virtual int available() { return usb_seremu_available(); }
         virtual int read() { return usb_seremu_getchar(); }
         virtual int peek() { return usb_seremu_peekchar(); }
@@ -79,7 +79,7 @@ public:
         size_t write(int n) { return write((uint8_t)n); }
 	virtual int availableForWrite() { return usb_seremu_write_buffer_free(); }
 	using Print::write;
-        void send_now(void) { usb_seremu_flush_output(); };
+        void send_now(void) { usb_seremu_flush_output(); }
         uint32_t baud(void) { return 9600; }
         uint8_t stopbits(void) { return 1; }
         uint8_t paritytype(void) { return 0; }
@@ -103,8 +103,8 @@ class usb_seremu_class : public Stream
 {
 public:
 	constexpr usb_seremu_class() {}
-	void begin(long) { };
-	void end() { };
+	void begin(long) { }
+	void end() { }
 	virtual int available() { return 0; }
 	virtual int read() { return -1; }
 	virtual int peek() { return -1; }

--- a/teensy3/usb_serial.h
+++ b/teensy3/usb_serial.h
@@ -67,6 +67,7 @@ extern volatile uint8_t usb_configuration;
 
 // C++ interface
 #ifdef __cplusplus
+#include "core_pins.h" // for millis()
 #include "Stream.h"
 class usb_serial_class : public Stream
 {

--- a/teensy3/usb_serial.h
+++ b/teensy3/usb_serial.h
@@ -86,7 +86,7 @@ public:
 			//if ((uint32_t)(systick_millis_count - millis_begin) > 2500) break;
 		//}
 	}
-        void end() { /* TODO: flush output and shut down USB port */ };
+        void end() { /* TODO: flush output and shut down USB port */ }
         virtual int available() { return usb_serial_available(); }
         virtual int read() { return usb_serial_getchar(); }
         virtual int peek() { return usb_serial_peekchar(); }


### PR DESCRIPTION
G++ warms on the following when ARDUINO isn't defined, check first.
#if ARDUINO >= 100
void to C function prototypes
use #include "" when the file is relative, otherwise it could get the wrong file