### PR TITLE
drop out code when no print_debug_stuff

### DIFF
--- a/teensy4/debug/printf.h
+++ b/teensy4/debug/printf.h
@@ -16,5 +16,6 @@ void printf_debug(const char *format, ...);
 #define printf_init()
 #define printf(...)
 #define printf_debug_init()
+#define printf_debug(...)
 
 #endif


### PR DESCRIPTION
this is (ab)used in HardFault_HandlerC() not under #ifdef