### PR TITLE
T4 Serial5 support setTx and setRx to pins 38, 39

### DIFF
--- a/teensy4/HardwareSerial.h
+++ b/teensy4/HardwareSerial.h
@@ -130,6 +130,15 @@ typedef void(*SerialEventCheckingFunctionPointer)();
 class HardwareSerial : public Stream
 {
 public:
+	static const uint8_t cnt_tx_pins = 2;
+	static const uint8_t cnt_rx_pins = 2;
+	typedef struct {
+		const uint8_t 		pin;		// The pin number
+		const uint32_t 		mux_val;	// Value to set for mux;
+		volatile uint32_t	*select_input_register; // Which register controls the selection
+		const uint32_t		select_val;	// Value for that selection
+	} pin_info_t;
+
 	typedef struct {
 		uint8_t serial_index;	// which object are we? 0 based
 		IRQ_NUMBER_t irq;
@@ -137,14 +146,10 @@ public:
 		void (*serial_event_handler_check)(void);
 		volatile uint32_t &ccm_register;
 		const uint32_t ccm_value;
-		const uint8_t rx_pin;
-		const uint8_t tx_pin;
+		pin_info_t rx_pins[cnt_tx_pins];
+		pin_info_t tx_pins[cnt_tx_pins];
 		const uint8_t cts_pin;
-		volatile uint32_t &rx_select_input_register;
-		const uint8_t rx_mux_val;
-		const uint8_t tx_mux_val;
 		const uint8_t cts_mux_val;
-		const uint8_t rx_select_val;
 		const uint16_t irq_priority;
 		const uint16_t rts_low_watermark;
 		const uint16_t rts_high_watermark;
@@ -197,6 +202,8 @@ public:
 private:
 	IMXRT_LPUART_t * const port;
 	const hardware_t * const hardware;
+	uint8_t				rx_pin_index_ = 0x0;	// default is always first item
+	uint8_t				tx_pin_index_ = 0x0;
 
 	volatile BUFTYPE 	*tx_buffer_;
 	volatile BUFTYPE 	*rx_buffer_;

--- a/teensy4/HardwareSerial1.cpp
+++ b/teensy4/HardwareSerial1.cpp
@@ -56,14 +56,10 @@ static BUFTYPE rx_buffer1[SERIAL1_RX_BUFFER_SIZE];
 const HardwareSerial::hardware_t UART6_Hardware = {
 	0, IRQ_LPUART6, &IRQHandler_Serial1, &serial_event_check_serial1,
 	CCM_CCGR3, CCM_CCGR3_LPUART6(CCM_CCGR_ON),
-	0, //IOMUXC_SW_MUX_CTL_PAD_GPIO_AD_B0_03, // pin 0
-	1, //IOMUXC_SW_MUX_CTL_PAD_GPIO_AD_B0_02, // pin 1
+	{{0,2, &IOMUXC_LPUART6_RX_SELECT_INPUT, 1}, {0xff, 0xff, nullptr, 0}},
+	{{1,2, nullptr, 0}, {0xff, 0xff, nullptr, 0}},
 	0xff, // No CTS pin
-	IOMUXC_LPUART6_RX_SELECT_INPUT,
-	2, // page 473
-	2, // page 472
 	0, // No CTS
-	1, // page 861
 	IRQ_PRIORITY, 38, 24, // IRQ, rts_low_watermark, rts_high_watermark
 };
 HardwareSerial Serial1(&IMXRT_LPUART6, &UART6_Hardware, tx_buffer1, SERIAL1_TX_BUFFER_SIZE,

--- a/teensy4/HardwareSerial2.cpp
+++ b/teensy4/HardwareSerial2.cpp
@@ -59,18 +59,14 @@ static HardwareSerial::hardware_t UART4_Hardware = {
 	1, IRQ_LPUART4, &IRQHandler_Serial2, &serial_event_check_serial2,
 	CCM_CCGR1, CCM_CCGR1_LPUART4(CCM_CCGR_ON),
 	#if defined(__IMXRT1052__)   
-	6, //IOMUXC_SW_MUX_CTL_PAD_GPIO_B1_01, // pin 6
-	7, // IOMUXC_SW_MUX_CTL_PAD_GPIO_B1_00, // pin 7
+	{{6,2, &IOMUXC_LPUART4_RX_SELECT_INPUT, 2}, {0xff, 0xff, nullptr, 0}},
+	{{7,2, nullptr, 0}, {0xff, 0xff, nullptr, 0}},
 	#elif defined(__IMXRT1062__)
-	7, //IOMUXC_SW_MUX_CTL_PAD_GPIO_B1_01, // pin 6
-	8, // IOMUXC_SW_MUX_CTL_PAD_GPIO_B1_00, // pin 7
+	{{7,2, &IOMUXC_LPUART4_RX_SELECT_INPUT, 2}, {0xff, 0xff, nullptr, 0}},
+	{{8,2, nullptr, 0}, {0xff, 0xff, nullptr, 0}},
 	#endif
 	0xff, // No CTS pin
-	IOMUXC_LPUART4_RX_SELECT_INPUT,
-	2, // page 521
-	2, // page 520
 	0, // No CTS
-	2, // page 858
 	IRQ_PRIORITY, 38, 24, // IRQ, rts_low_watermark, rts_high_watermark
 };
 HardwareSerial Serial2(&IMXRT_LPUART4, &UART4_Hardware, tx_buffer2, SERIAL2_TX_BUFFER_SIZE, 

--- a/teensy4/HardwareSerial3.cpp
+++ b/teensy4/HardwareSerial3.cpp
@@ -56,14 +56,10 @@ static BUFTYPE rx_buffer3[SERIAL3_RX_BUFFER_SIZE];
 static HardwareSerial::hardware_t UART2_Hardware = {
 	2, IRQ_LPUART2, &IRQHandler_Serial3, &serial_event_check_serial3, 
 	CCM_CCGR0, CCM_CCGR0_LPUART2(CCM_CCGR_ON),
-	15, //IOMUXC_SW_MUX_CTL_PAD_GPIO_AD_B1_03, // pin 15
-	14, //IOMUXC_SW_MUX_CTL_PAD_GPIO_AD_B1_02, // pin 14
+	{{15,2, &IOMUXC_LPUART2_RX_SELECT_INPUT, 1}, {0xff, 0xff, nullptr, 0}},
+	{{14,2, nullptr, 0}, {0xff, 0xff, nullptr, 0}},
 	18, //IOMUXC_SW_MUX_CTL_PAD_GPIO_AD_B1_01, // 18
-	IOMUXC_LPUART2_RX_SELECT_INPUT,
-	2, // page 491
-	2, // page 490
 	2, // page 473 
-	1, // Page 855
 	IRQ_PRIORITY, 38, 24, // IRQ, rts_low_watermark, rts_high_watermark
 };
 HardwareSerial Serial3(&IMXRT_LPUART2, &UART2_Hardware,tx_buffer3, SERIAL3_TX_BUFFER_SIZE,

--- a/teensy4/HardwareSerial4.cpp
+++ b/teensy4/HardwareSerial4.cpp
@@ -57,14 +57,10 @@ static BUFTYPE rx_buffer4[SERIAL4_RX_BUFFER_SIZE];
 static HardwareSerial::hardware_t UART3_Hardware = {
 	3, IRQ_LPUART3, &IRQHandler_Serial4, &serial_event_check_serial4,
 	CCM_CCGR0, CCM_CCGR0_LPUART3(CCM_CCGR_ON),
-	16, //IOMUXC_SW_MUX_CTL_PAD_GPIO_AD_B1_07, // pin 16
-	17, //IOMUXC_SW_MUX_CTL_PAD_GPIO_AD_B1_06, // pin 17
+	{{16,2, &IOMUXC_LPUART3_RX_SELECT_INPUT, 0}, {0xff, 0xff, nullptr, 0}},
+	{{17,2, nullptr, 0}, {0xff, 0xff, nullptr, 0}},
 	0xff, // No CTS pin
-	IOMUXC_LPUART3_RX_SELECT_INPUT,
-	2, // page 495
-	2, // page 494
 	0, // No CTS
-	0, // Page 857
 	IRQ_PRIORITY, 38, 24, // IRQ, rts_low_watermark, rts_high_watermark
 };
 HardwareSerial Serial4(&IMXRT_LPUART3, &UART3_Hardware, tx_buffer4, SERIAL4_TX_BUFFER_SIZE,

--- a/teensy4/HardwareSerial5.cpp
+++ b/teensy4/HardwareSerial5.cpp
@@ -57,14 +57,10 @@ static BUFTYPE rx_buffer5[SERIAL5_RX_BUFFER_SIZE];
 static HardwareSerial::hardware_t UART8_Hardware = {
 	4, IRQ_LPUART8, &IRQHandler_Serial5, &serial_event_check_serial5,
 	CCM_CCGR6, CCM_CCGR6_LPUART8(CCM_CCGR_ON),
-	21, //IOMUXC_SW_MUX_CTL_PAD_GPIO_AD_B1_11, // pin 21
-	20, //IOMUXC_SW_MUX_CTL_PAD_GPIO_AD_B1_10, // pin 20
+	{{21,2, &IOMUXC_LPUART8_RX_SELECT_INPUT, 1}, {38, 2, &IOMUXC_LPUART8_RX_SELECT_INPUT, 0}},
+	{{20,2, &IOMUXC_LPUART8_TX_SELECT_INPUT, 1}, {39, 2, &IOMUXC_LPUART8_TX_SELECT_INPUT, 0}},
 	0xff, // No CTS pin
-	IOMUXC_LPUART8_RX_SELECT_INPUT,
-	2, // page 499
-	2, // page 498
 	0, // No CTS
-	1, // Page 864-5
 	IRQ_PRIORITY, 38, 24, // IRQ, rts_low_watermark, rts_high_watermark
 };
 HardwareSerial Serial5(&IMXRT_LPUART8, &UART8_Hardware, tx_buffer5, SERIAL5_TX_BUFFER_SIZE,

--- a/teensy4/HardwareSerial6.cpp
+++ b/teensy4/HardwareSerial6.cpp
@@ -53,19 +53,14 @@ void serial_event_check_serial6()
 // Serial6
 static BUFTYPE tx_buffer6[SERIAL6_TX_BUFFER_SIZE];
 static BUFTYPE rx_buffer6[SERIAL6_RX_BUFFER_SIZE];
-uint32_t IOMUXC_LPUART1_RX_SELECT_INPUT;		// bugbug - does not exist so hack
 
 static HardwareSerial::hardware_t UART1_Hardware = {
 	5, IRQ_LPUART1, &IRQHandler_Serial6, &serial_event_check_serial6,
 	CCM_CCGR5, CCM_CCGR5_LPUART1(CCM_CCGR_ON),
-	25, //IOMUXC_SW_MUX_CTL_PAD_GPIO_AD_B0_13, // pin 25
-	24, //IOMUXC_SW_MUX_CTL_PAD_GPIO_AD_B0_12, // pin 24
+	{{25,2, nullptr, 0}, {0xff, 0xff, nullptr, 0}},
+	{{24,2, nullptr, 0}, {0xff, 0xff, nullptr, 0}},
 	0xff, // No CTS pin
-	IOMUXC_LPUART1_RX_SELECT_INPUT,
-	2, // page 486
-	2, // page 485
 	0, // No CTS
-	0, // ??? Does not have one ???
 	IRQ_PRIORITY, 38, 24, // IRQ, rts_low_watermark, rts_high_watermark
 
 };

--- a/teensy4/HardwareSerial7.cpp
+++ b/teensy4/HardwareSerial7.cpp
@@ -57,15 +57,10 @@ static BUFTYPE rx_buffer7[SERIAL7_RX_BUFFER_SIZE];
 static HardwareSerial::hardware_t UART7_Hardware = {
 	6, IRQ_LPUART7, &IRQHandler_Serial7, &serial_event_check_serial7,
 	CCM_CCGR5, CCM_CCGR5_LPUART7(CCM_CCGR_ON),
-	28, //IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_32, // pin 28
-	29, //IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_31, // pin 29
+	{{28,2, &IOMUXC_LPUART7_RX_SELECT_INPUT, 1}, {0xff, 0xff, nullptr, 0}},
+	{{29,2, nullptr, 0}, {0xff, 0xff, nullptr, 0}},
 	0xff, // No CTS pin
-	IOMUXC_LPUART7_RX_SELECT_INPUT,
-	2, // page 458
-	2, // page 457
 	0, // No CTS
-	1, // Page 863
-
 	IRQ_PRIORITY, 38, 24, // IRQ, rts_low_watermark, rts_high_watermark
 };
 HardwareSerial Serial7(&IMXRT_LPUART7, &UART7_Hardware, tx_buffer7, SERIAL7_TX_BUFFER_SIZE,

--- a/teensy4/HardwareSerial8.cpp
+++ b/teensy4/HardwareSerial8.cpp
@@ -59,14 +59,10 @@ static BUFTYPE rx_buffer8[SERIAL8_RX_BUFFER_SIZE];
 static HardwareSerial::hardware_t UART5_Hardware = {
 	7, IRQ_LPUART5, &IRQHandler_Serial8, &serial_event_check_serial8,
 	CCM_CCGR3, CCM_CCGR3_LPUART5(CCM_CCGR_ON),
-	30, //IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_24, // pin 30
-	31, // IOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_23, // pin 31
+	{{30,2, &IOMUXC_LPUART5_RX_SELECT_INPUT, 0}, {0xff, 0xff, nullptr, 0}},
+	{{31,2, nullptr, 0}, {0xff, 0xff, nullptr, 0}},
 	0xff, // No CTS pin
-	IOMUXC_LPUART5_RX_SELECT_INPUT,
-	2, // page 450
-	2, // page 449
 	0, // No CTS
-	0,
 	IRQ_PRIORITY, 38, 24, // IRQ, rts_low_watermark, rts_high_watermark
 };
 HardwareSerial Serial8(&IMXRT_LPUART5, &UART5_Hardware, tx_buffer8, SERIAL8_TX_BUFFER_SIZE,


### PR DESCRIPTION
Hi Paul, 

I updated the tables, to allow multiple TX and RX pins to be defined for hardware serial ports. 
I defined a new internal structure for them...

So far it appears to be working.  At least I was able to set tx and rx to 38, 39, using SD card adapter and did get an echo to go through. :D 