### PR TITLE
Added the ability to parametrize Teensy 3 core USB init delays

### DIFF
--- a/teensy3/pins_teensy.c
+++ b/teensy3/pins_teensy.c
@@ -583,18 +583,30 @@ void _init_Teensyduino_internal_(void)
 	TPM1_SC = FTM_SC_CLKS(1) | FTM_SC_PS(0);
 #endif
 	analog_init();
+
+#if !defined(TEENSY_INIT_USB_DELAY_BEFORE)
+	#if TEENSYDUINO >= 142
+		#define TEENSY_INIT_USB_DELAY_BEFORE 25
+	#else
+		#define TEENSY_INIT_USB_DELAY_BEFORE 50
+	#endif
+#endif
+
+#if !defined(TEENSY_INIT_USB_DELAY_AFTER)
+	#if TEENSYDUINO >= 142
+		#define TEENSY_INIT_USB_DELAY_AFTER 275
+	#else
+		#define TEENSY_INIT_USB_DELAY_AFTER 350
+	#endif
+#endif
+
 	// for background about this startup delay, please see these conversations
 	// https://forum.pjrc.com/threads/36606-startup-time-(400ms)?p=113980&viewfull=1#post113980
 	// https://forum.pjrc.com/threads/31290-Teensey-3-2-Teensey-Loader-1-24-Issues?p=87273&viewfull=1#post87273
-#if TEENSYDUINO >= 142
-	delay(25);
+
+	delay(TEENSY_INIT_USB_DELAY_BEFORE);
 	usb_init();
-	delay(275);
-#else
-	delay(50);
-	usb_init();
-	delay(350);
-#endif
+	delay(TEENSY_INIT_USB_DELAY_AFTER);
 }
 
 


### PR DESCRIPTION
Introduced compiler defines: `TEENSY_INIT_USB_DELAY_BEFORE` and `TEENSY_INIT_USB_DELAY_AFTER`; to be able to change the `delay()` values before and after `usb_init();` in `_init_Teensyduino_internal_()` for those who know what they are doing.

This came up as we were developing an application that critically depended on the platform bootup speed (every milisecond was important), and after some search on why does Teensy start up so slowly, we found aforementioned delays. Understandable that lack of those delays causes problems for some people due to their hardware setup, ability to parametrize the delays for those "who know what they're doing" is beneficial.