### PR TITLE
Teensy3: Fixed a bug with serial internal ring buffer head and tail

### DIFF
--- a/teensy3/serial1.c
+++ b/teensy3/serial1.c
@@ -79,20 +79,29 @@ static volatile uint8_t transmitting = 0;
   #define rts_assert()        *(rts_pin+8) = rts_mask;
   #define rts_deassert()      *(rts_pin+4) = rts_mask;
 #endif
-#if SERIAL1_TX_BUFFER_SIZE > 255
+
+#if SERIAL1_TX_BUFFER_SIZE <= UINT8_MAX
+static volatile uint8_t tx_buffer_head = 0;
+static volatile uint8_t tx_buffer_tail = 0;
+#elif SERIAL1_TX_BUFFER_SIZE <= UINT16_MAX
 static volatile uint16_t tx_buffer_head = 0;
 static volatile uint16_t tx_buffer_tail = 0;
 #else
-static volatile uint8_t tx_buffer_head = 0;
-static volatile uint8_t tx_buffer_tail = 0;
+static volatile uint32_t tx_buffer_head = 0;
+static volatile uint32_t tx_buffer_tail = 0;
 #endif
-#if SERIAL1_RX_BUFFER_SIZE > 255
+
+#if SERIAL1_RX_BUFFER_SIZE <= UINT8_MAX
+static volatile uint8_t rx_buffer_head = 0;
+static volatile uint8_t rx_buffer_tail = 0;
+#elif SERIAL1_RX_BUFFER_SIZE <= UINT16_MAX
 static volatile uint16_t rx_buffer_head = 0;
 static volatile uint16_t rx_buffer_tail = 0;
 #else
-static volatile uint8_t rx_buffer_head = 0;
-static volatile uint8_t rx_buffer_tail = 0;
+static volatile uint32_t rx_buffer_head = 0;
+static volatile uint32_t rx_buffer_tail = 0;
 #endif
+
 static uint8_t rx_pin_num = 0;
 static uint8_t tx_pin_num = 1;
 

--- a/teensy3/serial2.c
+++ b/teensy3/serial2.c
@@ -78,20 +78,29 @@ static volatile uint8_t transmitting = 0;
   #define rts_assert()        *(rts_pin+8) = rts_mask;
   #define rts_deassert()      *(rts_pin+4) = rts_mask;
 #endif
-#if SERIAL2_TX_BUFFER_SIZE > 255
+
+#if SERIAL2_TX_BUFFER_SIZE <= UINT8_MAX
+static volatile uint8_t tx_buffer_head = 0;
+static volatile uint8_t tx_buffer_tail = 0;
+#elif SERIAL2_TX_BUFFER_SIZE <= UINT16_MAX
 static volatile uint16_t tx_buffer_head = 0;
 static volatile uint16_t tx_buffer_tail = 0;
 #else
-static volatile uint8_t tx_buffer_head = 0;
-static volatile uint8_t tx_buffer_tail = 0;
+static volatile uint32_t tx_buffer_head = 0;
+static volatile uint32_t tx_buffer_tail = 0;
 #endif
-#if SERIAL2_RX_BUFFER_SIZE > 255
+
+#if SERIAL2_RX_BUFFER_SIZE <= UINT8_MAX
+static volatile uint8_t rx_buffer_head = 0;
+static volatile uint8_t rx_buffer_tail = 0;
+#elif SERIAL2_RX_BUFFER_SIZE <= UINT16_MAX
 static volatile uint16_t rx_buffer_head = 0;
 static volatile uint16_t rx_buffer_tail = 0;
 #else
-static volatile uint8_t rx_buffer_head = 0;
-static volatile uint8_t rx_buffer_tail = 0;
+static volatile uint32_t rx_buffer_head = 0;
+static volatile uint32_t rx_buffer_tail = 0;
 #endif
+
 #if defined(KINETISK)
 static uint8_t rx_pin_num = 9;
 static uint8_t tx_pin_num = 10;

--- a/teensy3/serial3.c
+++ b/teensy3/serial3.c
@@ -79,20 +79,29 @@ static volatile uint8_t transmitting = 0;
   #define rts_assert()        *(rts_pin+8) = rts_mask;
   #define rts_deassert()      *(rts_pin+4) = rts_mask;
 #endif
-#if SERIAL3_TX_BUFFER_SIZE > 255
+
+#if SERIAL3_TX_BUFFER_SIZE <= UINT8_MAX
+static volatile uint8_t tx_buffer_head = 0;
+static volatile uint8_t tx_buffer_tail = 0;
+#elif SERIAL3_TX_BUFFER_SIZE <= UINT16_MAX
 static volatile uint16_t tx_buffer_head = 0;
 static volatile uint16_t tx_buffer_tail = 0;
 #else
-static volatile uint8_t tx_buffer_head = 0;
-static volatile uint8_t tx_buffer_tail = 0;
+static volatile uint32_t tx_buffer_head = 0;
+static volatile uint32_t tx_buffer_tail = 0;
 #endif
-#if SERIAL3_RX_BUFFER_SIZE > 255
+
+#if SERIAL3_RX_BUFFER_SIZE <= UINT8_MAX
+static volatile uint8_t rx_buffer_head = 0;
+static volatile uint8_t rx_buffer_tail = 0;
+#elif SERIAL3_RX_BUFFER_SIZE <= UINT16_MAX
 static volatile uint16_t rx_buffer_head = 0;
 static volatile uint16_t rx_buffer_tail = 0;
 #else
-static volatile uint8_t rx_buffer_head = 0;
-static volatile uint8_t rx_buffer_tail = 0;
+static volatile uint32_t rx_buffer_head = 0;
+static volatile uint32_t rx_buffer_tail = 0;
 #endif
+
 #if defined(KINETISL)
 static uint8_t rx_pin_num = 7;
 #endif

--- a/teensy3/serial4.c
+++ b/teensy3/serial4.c
@@ -70,19 +70,27 @@ static volatile uint8_t *transmit_pin=NULL;
 static volatile uint8_t *rts_pin=NULL;
 #define rts_assert()        *rts_pin = 0
 #define rts_deassert()      *rts_pin = 1
-#if SERIAL4_TX_BUFFER_SIZE > 255
+
+#if SERIAL4_TX_BUFFER_SIZE <= UINT8_MAX
+static volatile uint8_t tx_buffer_head = 0;
+static volatile uint8_t tx_buffer_tail = 0;
+#elif SERIAL4_TX_BUFFER_SIZE <= UINT16_MAX
 static volatile uint16_t tx_buffer_head = 0;
 static volatile uint16_t tx_buffer_tail = 0;
 #else
-static volatile uint8_t tx_buffer_head = 0;
-static volatile uint8_t tx_buffer_tail = 0;
+static volatile uint32_t tx_buffer_head = 0;
+static volatile uint32_t tx_buffer_tail = 0;
 #endif
-#if SERIAL4_RX_BUFFER_SIZE > 255
+
+#if SERIAL4_RX_BUFFER_SIZE <= UINT8_MAX
+static volatile uint8_t rx_buffer_head = 0;
+static volatile uint8_t rx_buffer_tail = 0;
+#elif SERIAL4_RX_BUFFER_SIZE <= UINT16_MAX
 static volatile uint16_t rx_buffer_head = 0;
 static volatile uint16_t rx_buffer_tail = 0;
 #else
-static volatile uint8_t rx_buffer_head = 0;
-static volatile uint8_t rx_buffer_tail = 0;
+static volatile uint32_t rx_buffer_head = 0;
+static volatile uint32_t rx_buffer_tail = 0;
 #endif
 
 static uint8_t rx_pin_num = 31;

--- a/teensy3/serial5.c
+++ b/teensy3/serial5.c
@@ -70,19 +70,27 @@ static volatile uint8_t *transmit_pin=NULL;
 static volatile uint8_t *rts_pin=NULL;
 #define rts_assert()        *rts_pin = 0
 #define rts_deassert()      *rts_pin = 1
-#if SERIAL5_TX_BUFFER_SIZE > 255
+
+#if SERIAL5_TX_BUFFER_SIZE <= UINT8_MAX
+static volatile uint8_t tx_buffer_head = 0;
+static volatile uint8_t tx_buffer_tail = 0;
+#elif SERIAL5_TX_BUFFER_SIZE <= UINT16_MAX
 static volatile uint16_t tx_buffer_head = 0;
 static volatile uint16_t tx_buffer_tail = 0;
 #else
-static volatile uint8_t tx_buffer_head = 0;
-static volatile uint8_t tx_buffer_tail = 0;
+static volatile uint32_t tx_buffer_head = 0;
+static volatile uint32_t tx_buffer_tail = 0;
 #endif
-#if SERIAL5_RX_BUFFER_SIZE > 255
+
+#if SERIAL5_RX_BUFFER_SIZE <= UINT8_MAX
+static volatile uint8_t rx_buffer_head = 0;
+static volatile uint8_t rx_buffer_tail = 0;
+#elif SERIAL5_RX_BUFFER_SIZE <= UINT16_MAX
 static volatile uint16_t rx_buffer_head = 0;
 static volatile uint16_t rx_buffer_tail = 0;
 #else
-static volatile uint8_t rx_buffer_head = 0;
-static volatile uint8_t rx_buffer_tail = 0;
+static volatile uint32_t rx_buffer_head = 0;
+static volatile uint32_t rx_buffer_tail = 0;
 #endif
 
 static uint8_t tx_pin_num = 33;

--- a/teensy3/serial6.c
+++ b/teensy3/serial6.c
@@ -70,19 +70,27 @@ static volatile uint8_t *transmit_pin=NULL;
 static volatile uint8_t *rts_pin=NULL;
 #define rts_assert()        *rts_pin = 0
 #define rts_deassert()      *rts_pin = 1
-#if SERIAL6_TX_BUFFER_SIZE > 255
+
+#if SERIAL6_TX_BUFFER_SIZE <= UINT8_MAX
+static volatile uint8_t tx_buffer_head = 0;
+static volatile uint8_t tx_buffer_tail = 0;
+#elif SERIAL6_TX_BUFFER_SIZE <= UINT16_MAX
 static volatile uint16_t tx_buffer_head = 0;
 static volatile uint16_t tx_buffer_tail = 0;
 #else
-static volatile uint8_t tx_buffer_head = 0;
-static volatile uint8_t tx_buffer_tail = 0;
+static volatile uint32_t tx_buffer_head = 0;
+static volatile uint32_t tx_buffer_tail = 0;
 #endif
-#if SERIAL6_RX_BUFFER_SIZE > 255
+
+#if SERIAL6_RX_BUFFER_SIZE <= UINT8_MAX
+static volatile uint8_t rx_buffer_head = 0;
+static volatile uint8_t rx_buffer_tail = 0;
+#elif SERIAL6_RX_BUFFER_SIZE <= UINT16_MAX
 static volatile uint16_t rx_buffer_head = 0;
 static volatile uint16_t rx_buffer_tail = 0;
 #else
-static volatile uint8_t rx_buffer_head = 0;
-static volatile uint8_t rx_buffer_tail = 0;
+static volatile uint32_t rx_buffer_head = 0;
+static volatile uint32_t rx_buffer_tail = 0;
 #endif
 
 static uint8_t tx_pin_num = 48;

--- a/teensy3/serial6_lpuart.c
+++ b/teensy3/serial6_lpuart.c
@@ -78,19 +78,27 @@ static volatile uint8_t *transmit_pin=NULL;
 static volatile uint8_t *rts_pin=NULL;
 #define rts_assert()        *rts_pin = 0
 #define rts_deassert()      *rts_pin = 1
-#if SERIAL6_TX_BUFFER_SIZE > 255
+
+#if SERIAL6_TX_BUFFER_SIZE <= UINT8_MAX
+static volatile uint8_t tx_buffer_head = 0;
+static volatile uint8_t tx_buffer_tail = 0;
+#elif SERIAL6_TX_BUFFER_SIZE <= UINT16_MAX
 static volatile uint16_t tx_buffer_head = 0;
 static volatile uint16_t tx_buffer_tail = 0;
 #else
-static volatile uint8_t tx_buffer_head = 0;
-static volatile uint8_t tx_buffer_tail = 0;
+static volatile uint32_t tx_buffer_head = 0;
+static volatile uint32_t tx_buffer_tail = 0;
 #endif
-#if SERIAL6_RX_BUFFER_SIZE > 255
+
+#if SERIAL6_RX_BUFFER_SIZE <= UINT8_MAX
+static volatile uint8_t rx_buffer_head = 0;
+static volatile uint8_t rx_buffer_tail = 0;
+#elif SERIAL6_RX_BUFFER_SIZE <= UINT16_MAX
 static volatile uint16_t rx_buffer_head = 0;
 static volatile uint16_t rx_buffer_tail = 0;
 #else
-static volatile uint8_t rx_buffer_head = 0;
-static volatile uint8_t rx_buffer_tail = 0;
+static volatile uint32_t rx_buffer_head = 0;
+static volatile uint32_t rx_buffer_tail = 0;
 #endif
 
 static uint8_t tx_pin_num = 48;


### PR DESCRIPTION
Discovered with @jacobvartanian .

When defining serial buffer size larger than 65536, there would be periodic errors in the ring buffer between what was really sent and what has been received.

The culprit was head/tail type `uint16_t`. Added compiler switch to allow it to be `uint32_t` for large buffers.