### PR TITLE
Teensy4: Startup Hooks

### DIFF
--- a/teensy4/startup.c
+++ b/teensy4/startup.c
@@ -35,6 +35,10 @@ uint32_t set_arm_clock(uint32_t frequency); // clockspeed.c
 extern void __libc_init_array(void); // C++ standard library
 
 
+void startup_default_early_hook(void) {}
+void startup_early_hook(void)		__attribute__ ((weak, alias("startup_default_early_hook")));
+void startup_default_late_hook(void) {}
+void startup_late_hook(void)		__attribute__ ((weak, alias("startup_default_late_hook")));
 __attribute__((section(".startup"), optimize("no-tree-loop-distribute-patterns"), naked))
 void ResetHandler(void)
 {
@@ -105,12 +109,14 @@ void ResetHandler(void)
 	}
 	SNVS_HPCR |= SNVS_HPCR_RTC_EN | SNVS_HPCR_HP_TS;
 
+	startup_early_hook();
 	while (millis() < 20) ; // wait at least 20ms before starting USB
 	usb_init();
 	analog_init();
 	pwm_init();
 	tempmon_init();
 
+	startup_late_hook();
 	while (millis() < 300) ; // wait at least 300ms before calling user code
 	//printf("before C++ constructors\n");
 	__libc_init_array();


### PR DESCRIPTION
Edited here on the web - copied to local machine and it built as tested : https://forum.pjrc.com/threads/54711-Teensy-4-0-First-Beta-Test?p=209959&viewfull=1#post209959

Proposed add locations for  startup_early_hook(); and startup_late_hook(); just before two existing waiting while()'s.
With debug 'PRINT_DEBUG_STUFF' disabled the three T4B2's here hit the EARLY code about 1.2 ms and LATE at about 45.3 ms after the systick is started.

Where the current printf_debug_init() call is might be critical at some point adjust 'something' as you did enabling the Serial4 port for debug - before clocks and other things are started perhaps startup_reset_hook()