### PR TITLE
WIP: Teensy 3: Create USB Descriptors so we can emulate a Nintendo Switch Controller

### DIFF
--- a/teensy3/usb_desc.c
+++ b/teensy3/usb_desc.c
@@ -237,7 +237,63 @@ static uint8_t mouse_report_desc[] = {
 #endif
 
 #ifdef JOYSTICK_INTERFACE
-#if JOYSTICK_SIZE == 12
+
+#if JOYSTICK_SIZE == 8
+static uint8_t joystick_report_desc[] = {
+    0x05, 0x01,         // Usage Page (Generic Desktop)
+    0x09, 0x05,         // Usage (Joystick, Game Controls)
+    0xA1, 0x01,         // Collection (Application)
+        // Buttons (2 bytes)
+        0x15, 0x00,         // Logical Minimum (0)
+        0x25, 0x01,         // Logical Maximum (1)
+        0x35, 0x00,         // Physical Minimum (0)
+        0x45, 0x01,         // Physical Maximum (1)
+        0x75, 0x01,         // Report Size (1)
+        0x95, 0x10,         // Report Count (16)
+        0x05, 0x09,         // Usage Page (Button)
+        0x19, 0x01,         // Usage Minimum (Button #1)
+        0x29, 0x10,         // Usage Maximum (Button #16)
+        0x81, 0x02,         // Input (variable,absolute)
+        // HAT Switch (1 nibble)
+        0x05, 0x01,         // Usage Page (Generic Desktop)
+        0x25, 0x07,         // Logical Maximum (7)
+        0x46, 0x3B, 0x01,   // Physical Maximum (315)
+        0x75, 0x04,         // Report Size (4)
+        0x95, 0x01,         // Report Count (1)
+        0x65, 0x14,         // Unit (20)
+        0x09, 0x39,         // Usage (Hat switch)
+        0x81, 0x42,         // Input (variable,absolute,null_state)
+        // There's an additional nibble here that's utilized as part of the>
+        // I believe this -might- be separate U/D/L/R bits on the Switch Pr>
+        // as they're utilized as four button descriptors on the Switch Pro>
+        0x65, 0x00,         // Unit (0)
+        0x95, 0x01,         // Report Count (1)
+        0x81, 0x01,         // Input (constant)
+        // Joysticks (4 bytes)
+        0x25, 0xFF,         // Logical Maximum (255)
+        0x45, 0xFF,         // Physical Maximum (255)
+        0x09, 0x30,         // Usage (X)
+        0x09, 0x31,         // Usage (Y)
+        0x09, 0x32,         // Usage (RX)
+        0x09, 0x35,         // Usage (RY)
+        0x75, 0x08,         // Report Size (8)
+        0x95, 0x04,         // Report Count (4)
+        0x81, 0x02,         // Input (variable,absolute)
+        // ??? Vendor Specific (1 byte)
+        // This byte requires additional investigation.
+        0x06, 0x00, 0xFF,   // Usage Page (65280)
+        0x09, 0x20,         // Usage (32)
+        0x95, 0x01,         // Report Count (1)
+        0x81, 0x02,         // Input (variable,absolute)
+        // Output (8 bytes)
+        // Original observation of this suggests it to be a mirror of the i>
+        // The Switch requires us to have these descriptors available.
+        0x09, 0x21, 0x26,   // Usage (9761)
+        0x95, 0x08,         // Report Count (8)
+        0x91, 0x02,         // Output (variable,absolute)
+    0xC0                // End Collection
+};
+#elif JOYSTICK_SIZE == 12
 static uint8_t joystick_report_desc[] = {
         0x05, 0x01,                     // Usage Page (Generic Desktop)
         0x09, 0x04,                     // Usage (Joystick)

--- a/teensy3/usb_desc.h
+++ b/teensy3/usb_desc.h
@@ -261,6 +261,32 @@ let me know?  http://forum.pjrc.com/forums/4-Suggestions-amp-Bug-Reports
   #define ENDPOINT6_CONFIG	ENDPOINT_TRANSMIT_ONLY
   #define ENDPOINT7_CONFIG	ENDPOINT_TRANSMIT_ONLY
 
+#elif defined(USB_NS)
+  #define VENDOR_ID		0x0f0d
+  #define PRODUCT_ID		0x0092
+  #define MANUFACTURER_NAME     {'T','e','e','n','s','y','d','u','i','n','o'}
+  #define MANUFACTURER_NAME_LEN 11
+  #define PRODUCT_NAME     {'S','w','i','t','c','h',' ','C','o','n','t','r','o','l','l','e','r'}
+  #define PRODUCT_NAME_LEN 17
+  #define EP0_SIZE		64
+  #define NUM_ENDPOINTS         3
+  #define NUM_USB_BUFFERS	24
+  #define NUM_INTERFACE		2
+  #define SEREMU_INTERFACE      1	// Serial emulation
+  #define SEREMU_TX_ENDPOINT    1
+  #define SEREMU_TX_SIZE        64
+  #define SEREMU_TX_INTERVAL    1
+  #define SEREMU_RX_ENDPOINT    2
+  #define SEREMU_RX_SIZE        32
+  #define SEREMU_RX_INTERVAL    2
+  #define JOYSTICK_INTERFACE    0	// Joystick
+  #define JOYSTICK_ENDPOINT     3
+  #define JOYSTICK_SIZE         8
+  #define JOYSTICK_INTERVAL     2
+  #define ENDPOINT1_CONFIG	ENDPOINT_TRANSMIT_ONLY
+  #define ENDPOINT2_CONFIG	ENDPOINT_RECEIVE_ONLY
+  #define ENDPOINT3_CONFIG	ENDPOINT_TRANSMIT_ONLY
+
 #elif defined(USB_TOUCHSCREEN)
   #define VENDOR_ID		0x16C0
   #define PRODUCT_ID		0x04D3

--- a/teensy3/usb_joystick.h
+++ b/teensy3/usb_joystick.h
@@ -54,7 +54,47 @@ class usb_joystick_class
         public:
         void begin(void) { }
         void end(void) { }
-#if JOYSTICK_SIZE == 12
+#if JOYSTICK_SIZE == 8
+    void button(uint8_t button, bool val) {
+        if (--button >= 32) return;
+        if (val) usb_joystick_data[0] |= (1 << button);
+        else usb_joystick_data[0] &= ~(1 << button);
+        if (!manual_mode) usb_joystick_send();
+    }
+    void X(unsigned int val) {
+        if (val > 255) val = 255;
+        usb_joystick_data[0] = (usb_joystick_data[0] & 0x00FFFFFF) | (val << 24);
+        if (!manual_mode) usb_joystick_send();
+    }
+    void Y(unsigned int val) {
+        if (val > 255) val = 255;
+        usb_joystick_data[1] = (usb_joystick_data[1] & 0xFFFFFF00) | (val << 0);
+        if (!manual_mode) usb_joystick_send();
+    }
+    void RX(unsigned int val) {
+        if (val > 255) val = 255;
+        usb_joystick_data[1] = (usb_joystick_data[1] & 0xFFFF00FF) | (val << 8);
+        if (!manual_mode) usb_joystick_send();
+    }
+    void RY(unsigned int val) {
+        if (val > 255) val = 255;
+        usb_joystick_data[1] = (usb_joystick_data[1] & 0xFF00FFFF) | (val << 16);
+        if (!manual_mode) usb_joystick_send();
+    }
+    inline void hat(bool u, bool r, bool d, bool l) {
+        uint8_t val;
+        val = 8; // 8 means center position
+             if (u &&  r) val = 1;
+        else if (r && !d) val = 2;
+        else if (r &&  d) val = 3;
+        else if (d && !l) val = 4;
+        else if (d &&  l) val = 5;
+        else if (l && !u) val = 6;
+        else if (l &&  u) val = 7;
+        else if (u) val = 0;
+        usb_joystick_data[0] = (usb_joystick_data[0] & 0xFF00FFFF) | (val << 16);
+    }
+#elif JOYSTICK_SIZE == 12
 	void button(uint8_t button, bool val) {
 		if (--button >= 32) return;
 		if (val) usb_joystick_data[0] |= (1 << button);


### PR DESCRIPTION
(https://forum.pjrc.com/threads/54415-A-usb-controller-adapter-for-the-Nintendo-switch)

To get this to work, edit `boards.txt`

```
teensy31.menu.usb.ns=Nintendo Switch Controller
teensy31.menu.usb.ns.build.usbtype=USB_NS
teensy31.menu.usb.ns.fake_serial=teensy_gateway
```

(for each of the teensy 3s)

Then Just select "Nintendo Switch Controller" from the USB type menu.

The USB Descriptors are based on https://github.com/shinyquagsire23/Switch-Fightstick/blob/master/Descriptors.c (MIT Licensed). (translated by hand).

Joystick.X(value) takes values from 0 to 255.

This also adds Joystick.RX and Joystick.RY for the right control stick.

I changed the parameters for the hat switch: `Joystick.hat(up, right, down, left)` where all of the values are boolean. Nintendo uses a cross-shaped [D-pad](https://en.wikipedia.org/wiki/D-pad) on the Nintendo Switch Pro Controller, which this is mimicking.

Joystick.button should only accept 16 buttons.