### PR TITLE
Fixes a lockup issue of the T4 when running sample sketch

### DIFF
--- a/teensy4/startup.c
+++ b/teensy4/startup.c
@@ -83,14 +83,6 @@ void ResetHandler(void)
 	IOMUXC_GPR_GPR29 = 0xFFFFFFFF;
 #endif
 
-	// Undo PIT timer usage by ROM startup
-	CCM_CCGR1 |= CCM_CCGR1_PIT(CCM_CCGR_ON);
-	PIT_MCR = 0;
-	PIT_TCTRL0 = 0;
-	PIT_TCTRL1 = 0;
-	PIT_TCTRL2 = 0;
-	PIT_TCTRL3 = 0;
-
 	// must enable PRINT_DEBUG_STUFF in debug/print.h
 	printf_debug_init();
 	printf("\n***********IMXRT Startup**********\n");
@@ -104,6 +96,14 @@ void ResetHandler(void)
 	set_arm_clock(600000000);
 	//set_arm_clock(984000000); Ludicrous Speed
 
+	// Undo PIT timer usage by ROM startup
+	CCM_CCGR1 |= CCM_CCGR1_PIT(CCM_CCGR_ON);
+	PIT_MCR = 0;
+	PIT_TCTRL0 = 0;
+	PIT_TCTRL1 = 0;
+	PIT_TCTRL2 = 0;
+	PIT_TCTRL3 = 0;
+	
 	// initialize RTC
 	if (!(SNVS_LPCR & SNVS_LPCR_SRTC_ENV)) {
 		// if SRTC isn't running, start it with default Jan 1, 2019


### PR DESCRIPTION
Fixes a lockup issue of the T4.  See post https://forum.pjrc.com/threads/57609-Teensyduino-1-48-Beta-1?p=216441&viewfull=1#post216441.

It the current location where you inserted the PIT timer changes it locks up the T4 when you ran one of the example sketches (Demosauce.ino) for the ILI9341_t3, ILI9341_t3n and the ILI9488 libraries.  By moving the PIT time code to after setArmClock it avoids the lockup.