### PR TITLE
On Analog PWM write below or above Resolution - Output LOW or HIGH

### DIFF
--- a/teensy4/pwm.c
+++ b/teensy4/pwm.c
@@ -210,6 +210,16 @@ void analogWrite(uint8_t pin, int val)
 
 	if (pin >= CORE_NUM_DIGITAL) return;
 	//printf("analogWrite, pin %d, val %d\n", pin, val);
+	uint32_t max = 1 << analog_write_res;
+	if (val <= 0) {
+		pinMode(pin, OUTPUT);	// TODO: implement OUTPUT_LOW
+		digitalWriteFast(pin, LOW);
+		return;
+	} else if (val >= max) {
+		pinMode(pin, OUTPUT);	// TODO: implement OUTPUT_HIGH
+		digitalWriteFast(pin, HIGH);
+		return;
+	}
 	info = pwm_pin_info + pin;
 	if (info->type == 1) {
 		// FlexPWM pin


### PR DESCRIPTION
User set res to 8 bit and analogWrite(256,13) turned the LED pin #13 off
https://forum.pjrc.com/threads/57758-Teensy-4-0-and-PWM?p=216901&viewfull=1#post216901

Copied code from Teensy3