### PR TITLE
T4 - Can now handle sketches with main() instead of setup()/loop()

### DIFF
--- a/teensy4/main.cpp
+++ b/teensy4/main.cpp
@@ -1,0 +1,58 @@
+/* Teensyduino Core Library
+ * http://www.pjrc.com/teensy/
+ * Copyright (c) 2017 PJRC.COM, LLC.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * 1. The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * 2. If the Software is incorporated into a build system that allows
+ * selection among a list of target devices, then similar target
+ * devices manufactured by PJRC.COM must be included in the list of
+ * target devices and selectable in the same manner.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <Arduino.h>
+
+extern "C" int main(void)
+{
+#ifdef USING_MAKEFILE
+
+	// To use Teensy 4.0 without Arduino, simply put your code here.
+	// For example:
+
+	pinMode(13, OUTPUT);
+	while (1) {
+		digitalWriteFast(13, HIGH);
+		delay(500);
+		digitalWriteFast(13, LOW);
+		delay(500);
+	}
+
+
+#else
+	// Arduino's main() function just calls setup() and loop()....
+	setup();
+	while (1) {
+		loop();
+		yield();
+	}
+#endif
+}
+

--- a/teensy4/startup.c
+++ b/teensy4/startup.c
@@ -35,6 +35,7 @@ uint32_t set_arm_clock(uint32_t frequency); // clockspeed.c
 extern void __libc_init_array(void); // C++ standard library
 
 
+extern int main (void);
 void startup_default_early_hook(void) {}
 void startup_early_hook(void)		__attribute__ ((weak, alias("startup_default_early_hook")));
 void startup_default_late_hook(void) {}
@@ -132,13 +133,9 @@ void ResetHandler(void)
 	__libc_init_array();
 	//printf("after C++ constructors\n");
 	//printf("before setup\n");
-	setup();
-	//printf("after setup\n");
-	while (1) {
-		//printf("loop\n");
-		loop();
-		yield();
-	}
+	main();
+	
+	while (1) ;
 }
 
 


### PR DESCRIPTION
As per the Teensyduino 1.48 release thread.

T3.x sketches could compile that had int mai() {} and not void() and setup():

So simply copied over setup.cpp from T3 folder of cores, and then changed setup.c to call main, which simply calls setup and loops calling loop/yield.

Added another endless loop after the call to main() to hang there if the users main returns.

Tested with simple sketch
```
#include <arduino.h>
int main (void) {
  pinMode(13, OUTPUT);
  for(;;) {
    digitalWriteFast(13, HIGH);
    delay(250);
    digitalWriteFast(13, LOW);
    delay(250);
  }
}
```
tried it on T3.6 verified before compile failed and now works.  Also compiled and run a normal app to just make sure it was not totally busted