### PR TITLE
Drop corrupted UART RX data.

### DIFF
--- a/teensy3/serial1.c
+++ b/teensy3/serial1.c
@@ -516,6 +516,24 @@ void uart0_status_isr(void)
 {
 	uint32_t head, tail, n;
 	uint8_t c;
+
+	/*
+	UARTx_S1:
+		To clear a flag, the status register should be read followed by a read or write to D register,
+		depending on the interrupt flag type. Other instructions can be executed between the two
+		steps as long the handling of I/O is not compromised, but the order of operations is
+		important for flag clearing.
+
+		Reading an empty data register to clear one of the flags of
+		the S1 register causes the FIFO pointers to become
+		misaligned. A receive FIFO flush reinitializes the pointers.
+		A better way to prevent this situation is to always leave one
+		byte in FIFO and this byte will be read eventually in
+		clearing the flag bit.
+	*/
+	// Treat current data as corrupted if any of the following flags is set: noise detected, framing error, parity error
+	uint8_t isDataCorrupted = (UART0_S1 & (UART_S1_NF | UART_S1_FE | UART_S1_PF)) ? 1 : 0;
+
 #ifdef HAS_KINETISK_UART0_FIFO
 	uint32_t newhead;
 	uint8_t avail;
@@ -552,11 +570,13 @@ void uart0_status_isr(void)
 				} else {
 					n = UART0_D;
 				}
-				newhead = head + 1;
-				if (newhead >= SERIAL1_RX_BUFFER_SIZE) newhead = 0;
-				if (newhead != tail) {
-					head = newhead;
-					rx_buffer[head] = n;
+				if (!isDataCorrupted) {
+					newhead = head + 1;
+					if (newhead >= SERIAL1_RX_BUFFER_SIZE) newhead = 0;
+					if (newhead != tail) {
+						head = newhead;
+						rx_buffer[head] = n;
+					}
 				}
 			} while (--avail > 0);
 			rx_buffer_head = head;
@@ -590,11 +610,13 @@ void uart0_status_isr(void)
 		} else {
 			n = UART0_D;
 		}
-		head = rx_buffer_head + 1;
-		if (head >= SERIAL1_RX_BUFFER_SIZE) head = 0;
-		if (head != rx_buffer_tail) {
-			rx_buffer[head] = n;
-			rx_buffer_head = head;
+		if (!isDataCorrupted) {
+			head = rx_buffer_head + 1;
+			if (head >= SERIAL1_RX_BUFFER_SIZE) head = 0;
+			if (head != rx_buffer_tail) {
+				rx_buffer[head] = n;
+				rx_buffer_head = head;
+			}
 		}
 	}
 	c = UART0_C2;

--- a/teensy3/serial3.c
+++ b/teensy3/serial3.c
@@ -419,17 +419,37 @@ void uart2_status_isr(void)
 	uint32_t head, tail, n;
 	uint8_t c;
 
+	/*
+	UARTx_S1:
+		To clear a flag, the status register should be read followed by a read or write to D register,
+		depending on the interrupt flag type. Other instructions can be executed between the two
+		steps as long the handling of I/O is not compromised, but the order of operations is
+		important for flag clearing.
+
+		Reading an empty data register to clear one of the flags of
+		the S1 register causes the FIFO pointers to become
+		misaligned. A receive FIFO flush reinitializes the pointers.
+		A better way to prevent this situation is to always leave one
+		byte in FIFO and this byte will be read eventually in
+		clearing the flag bit.
+	*/
+	// Treat current data as corrupted if any of the following flags is set: noise detected, framing error, parity error
+	uint8_t isDataCorrupted = (UART2_S1 & (UART_S1_NF | UART_S1_FE | UART_S1_PF)) ? 1 : 0;
+
 	if (UART2_S1 & UART_S1_RDRF) {
 		if (use9Bits && (UART2_C3 & 0x80)) {
 			n = UART2_D | 0x100;
 		} else {
 			n = UART2_D;
 		}
-		head = rx_buffer_head + 1;
-		if (head >= SERIAL3_RX_BUFFER_SIZE) head = 0;
-		if (head != rx_buffer_tail) {
-			rx_buffer[head] = n;
-			rx_buffer_head = head;
+		head = rx_buffer_head;
+		if (!isDataCorrupted) {
+			head++;
+			if (head >= SERIAL3_RX_BUFFER_SIZE) head = 0;
+			if (head != rx_buffer_tail) {
+				rx_buffer[head] = n;
+				rx_buffer_head = head;
+			}
 		}
 		if (rts_pin) {
 			int avail;

--- a/teensy3/serial4.c
+++ b/teensy3/serial4.c
@@ -359,17 +359,37 @@ void uart3_status_isr(void)
 	uint32_t head, tail, n;
 	uint8_t c;
 
+	/*
+	UARTx_S1:
+		To clear a flag, the status register should be read followed by a read or write to D register,
+		depending on the interrupt flag type. Other instructions can be executed between the two
+		steps as long the handling of I/O is not compromised, but the order of operations is
+		important for flag clearing.
+
+		Reading an empty data register to clear one of the flags of
+		the S1 register causes the FIFO pointers to become
+		misaligned. A receive FIFO flush reinitializes the pointers.
+		A better way to prevent this situation is to always leave one
+		byte in FIFO and this byte will be read eventually in
+		clearing the flag bit.
+	*/
+	// Treat current data as corrupted if any of the following flags is set: noise detected, framing error, parity error
+	uint8_t isDataCorrupted = (UART3_S1 & (UART_S1_NF | UART_S1_FE | UART_S1_PF)) ? 1 : 0;
+
 	if (UART3_S1 & UART_S1_RDRF) {
 		if (use9Bits && (UART3_C3 & 0x80)) {
 			n = UART3_D | 0x100;
 		} else {
 			n = UART3_D;
 		}
-		head = rx_buffer_head + 1;
-		if (head >= SERIAL4_RX_BUFFER_SIZE) head = 0;
-		if (head != rx_buffer_tail) {
-			rx_buffer[head] = n;
-			rx_buffer_head = head;
+		head = rx_buffer_head;
+		if (!isDataCorrupted) {
+			head++;
+			if (head >= SERIAL4_RX_BUFFER_SIZE) head = 0;
+			if (head != rx_buffer_tail) {
+				rx_buffer[head] = n;
+				rx_buffer_head = head;
+			}
 		}
 		if (rts_pin) {
 			int avail;

--- a/teensy3/serial5.c
+++ b/teensy3/serial5.c
@@ -337,17 +337,37 @@ void uart4_status_isr(void)
 	uint32_t head, tail, n;
 	uint8_t c;
 
+	/*
+	UARTx_S1:
+		To clear a flag, the status register should be read followed by a read or write to D register,
+		depending on the interrupt flag type. Other instructions can be executed between the two
+		steps as long the handling of I/O is not compromised, but the order of operations is
+		important for flag clearing.
+
+		Reading an empty data register to clear one of the flags of
+		the S1 register causes the FIFO pointers to become
+		misaligned. A receive FIFO flush reinitializes the pointers.
+		A better way to prevent this situation is to always leave one
+		byte in FIFO and this byte will be read eventually in
+		clearing the flag bit.
+	*/
+	// Treat current data as corrupted if any of the following flags is set: noise detected, framing error, parity error
+	uint8_t isDataCorrupted = (UART4_S1 & (UART_S1_NF | UART_S1_FE | UART_S1_PF)) ? 1 : 0;
+
 	if (UART4_S1 & UART_S1_RDRF) {
 		if (use9Bits && (UART4_C3 & 0x80)) {
 			n = UART4_D | 0x100;
 		} else {
 			n = UART4_D;
 		}
-		head = rx_buffer_head + 1;
-		if (head >= SERIAL5_RX_BUFFER_SIZE) head = 0;
-		if (head != rx_buffer_tail) {
-			rx_buffer[head] = n;
-			rx_buffer_head = head;
+		head = rx_buffer_head;
+		if (!isDataCorrupted) {
+			head++;
+			if (head >= SERIAL5_RX_BUFFER_SIZE) head = 0;
+			if (head != rx_buffer_tail) {
+				rx_buffer[head] = n;
+				rx_buffer_head = head;
+			}
 		}
 		if (rts_pin) {
 			int avail;

--- a/teensy3/serial6.c
+++ b/teensy3/serial6.c
@@ -337,17 +337,37 @@ void uart5_status_isr(void)
 	uint32_t head, tail, n;
 	uint8_t c;
 
+	/*
+	UARTx_S1:
+		To clear a flag, the status register should be read followed by a read or write to D register,
+		depending on the interrupt flag type. Other instructions can be executed between the two
+		steps as long the handling of I/O is not compromised, but the order of operations is
+		important for flag clearing.
+
+		Reading an empty data register to clear one of the flags of
+		the S1 register causes the FIFO pointers to become
+		misaligned. A receive FIFO flush reinitializes the pointers.
+		A better way to prevent this situation is to always leave one
+		byte in FIFO and this byte will be read eventually in
+		clearing the flag bit.
+	*/
+	// Treat current data as corrupted if any of the following flags is set: noise detected, framing error, parity error
+	uint8_t isDataCorrupted = (UART5_S1 & (UART_S1_NF | UART_S1_FE | UART_S1_PF)) ? 1 : 0;
+
 	if (UART5_S1 & UART_S1_RDRF) {
 		if (use9Bits && (UART5_C3 & 0x80)) {
 			n = UART5_D | 0x100;
 		} else {
 			n = UART5_D;
 		}
-		head = rx_buffer_head + 1;
-		if (head >= SERIAL6_RX_BUFFER_SIZE) head = 0;
-		if (head != rx_buffer_tail) {
-			rx_buffer[head] = n;
-			rx_buffer_head = head;
+		head = rx_buffer_head;
+		if (!isDataCorrupted) {
+			head++;
+			if (head >= SERIAL6_RX_BUFFER_SIZE) head = 0;
+			if (head != rx_buffer_tail) {
+				rx_buffer[head] = n;
+				rx_buffer_head = head;
+			}
 		}
 		if (rts_pin) {
 			int avail;


### PR DESCRIPTION
> Treat current data as corrupted if any of the following flags is set: noise detected, framing error, parity error

I can make this a conditional compile through a `#define` if you want to.