### PR TITLE
Add missing serial string descriptors for composite USB devices

### DIFF
--- a/teensy3/usb_desc.c
+++ b/teensy3/usb_desc.c
@@ -1426,6 +1426,8 @@ extern struct usb_string_descriptor_struct usb_string_product_name
         __attribute__ ((weak, alias("usb_string_product_name_default")));
 extern struct usb_string_descriptor_struct usb_string_serial_number
         __attribute__ ((weak, alias("usb_string_serial_number_default")));
+extern struct usb_string_descriptor_struct usb_string_serial_name
+        __attribute__ ((weak, alias("usb_string_serial_name_default")));
 
 struct usb_string_descriptor_struct string0 = {
         4,
@@ -1448,6 +1450,13 @@ struct usb_string_descriptor_struct usb_string_serial_number_default = {
         3,
         {0,0,0,0,0,0,0,0,0,0}
 };
+#ifdef CDC_IAD_DESCRIPTOR
+struct usb_string_descriptor_struct usb_string_serial_name_default = {
+        2 + 6 * 2,
+        3,
+        {'S','e','r','i','a','l'}
+};
+#endif
 #ifdef MTP_INTERFACE
 struct usb_string_descriptor_struct usb_string_mtp = {
 	2 + 3 * 2,
@@ -1540,6 +1549,9 @@ const usb_descriptor_list_t usb_descriptor_list[] = {
         {0x0301, 0x0409, (const uint8_t *)&usb_string_manufacturer_name, 0},
         {0x0302, 0x0409, (const uint8_t *)&usb_string_product_name, 0},
         {0x0303, 0x0409, (const uint8_t *)&usb_string_serial_number, 0},
+#ifdef CDC_IAD_DESCRIPTOR
+        {0x0304, 0x0409, (const uint8_t *)&usb_string_serial_name, 0},
+#endif
 	{0, 0, NULL, 0}
 };
 

--- a/teensy4/usb_desc.c
+++ b/teensy4/usb_desc.c
@@ -2297,6 +2297,8 @@ extern struct usb_string_descriptor_struct usb_string_product_name
         __attribute__ ((weak, alias("usb_string_product_name_default")));
 extern struct usb_string_descriptor_struct usb_string_serial_number
         __attribute__ ((weak, alias("usb_string_serial_number_default")));
+extern struct usb_string_descriptor_struct usb_string_serial_name
+        __attribute__ ((weak, alias("usb_string_serial_name_default")));
 
 PROGMEM const struct usb_string_descriptor_struct string0 = {
         4,
@@ -2319,6 +2321,13 @@ struct usb_string_descriptor_struct usb_string_serial_number_default = {
         3,
         {0,0,0,0,0,0,0,0,0,0}
 };
+#ifdef CDC_IAD_DESCRIPTOR
+struct usb_string_descriptor_struct usb_string_serial_name_default = {
+        2 + 6 * 2,
+        3,
+        {'S','e','r','i','a','l'}
+};
+#endif
 #ifdef MTP_INTERFACE
 PROGMEM const struct usb_string_descriptor_struct usb_string_mtp = {
 	2 + 3 * 2,
@@ -2396,6 +2405,9 @@ const usb_descriptor_list_t usb_descriptor_list[] = {
         {0x0301, 0x0409, (const uint8_t *)&usb_string_manufacturer_name, 0},
         {0x0302, 0x0409, (const uint8_t *)&usb_string_product_name, 0},
         {0x0303, 0x0409, (const uint8_t *)&usb_string_serial_number, 0},
+#ifdef CDC_IAD_DESCRIPTOR
+        {0x0304, 0x0409, (const uint8_t *)&usb_string_serial_name, 0},
+#endif
 	{0, 0, NULL, 0}
 };
 


### PR DESCRIPTION
When creating a composite USB device containing a serial interface on
Teensy 3.2, "lsusb -v" reports an invalid string descriptor in the
serial interface's interface association descriptor:

    Interface Association:
      bLength                 8
      bDescriptorType        11
      bFirstInterface         0
      bInterfaceCount         2
      bFunctionClass          2 Communications
      bFunctionSubClass       2 Abstract (modem)
      bFunctionProtocol       1 AT-commands (v.25ter)
      iFunction               4 (error)

Indeed, usb_descriptor_list[] does not contain an entry for index 4.
Presumably the iFunction field was copied from usb_serial_hid/usb.c,
which does define the string descriptor.

Fix this by adding the missing string descriptor.
This changes the lsusb output like:

    -      iFunction               4 (error)
    +      iFunction               4 Serial

The same bug is present on Teensy 4.0, hence fix it there as well.

Signed-off-by: Geert Uytterhoeven <geert@linux-m68k.org>