### PR TITLE
T4 uart enhance

### DIFF
--- a/teensy3/HardwareSerial.h
+++ b/teensy3/HardwareSerial.h
@@ -101,6 +101,9 @@
 #define SERIAL_8N2_TXINV 0x24
 #define SERIAL_8N2_RXINV_TXINV 0x34
 #endif
+
+#define SERIAL_HALF_DUPLEX 0x200
+
 // bit0: parity, 0=even, 1=odd
 // bit1: parity, 0=disable, 1=enable
 // bit2: mode, 1=9bit, 0=8bit

--- a/teensy3/serial1.c
+++ b/teensy3/serial1.c
@@ -114,6 +114,12 @@ static uint8_t tx_pin_num = 1;
 #define C2_TX_COMPLETING	C2_ENABLE | UART_C2_TCIE
 #define C2_TX_INACTIVE		C2_ENABLE
 
+// BITBAND Support
+#define GPIO_BITBAND_ADDR(reg, bit) (((uint32_t)&(reg) - 0x40000000) * 32 + (bit) * 4 + 0x42000000)
+#define GPIO_BITBAND_PTR(reg, bit) ((uint32_t *)GPIO_BITBAND_ADDR((reg), (bit)))
+#define C3_TXDIR_BIT 5
+
+
 void serial_begin(uint32_t divisor)
 {
 	SIM_SCGC4 |= SIM_SCGC4_UART0;	// turn on clock, TODO: use bitband
@@ -198,6 +204,27 @@ void serial_format(uint32_t format)
 		UART0_BDL = bdl;		// Says BDH not acted on until BDL is written
 	}
 #endif
+	// process request for half duplex.
+	if ((format & SERIAL_HALF_DUPLEX) != 0) {
+		UART0_C1 |= UART_C1_LOOPS | UART_C1_RSRC;
+		volatile uint32_t *reg = portConfigRegister(tx_pin_num);
+		*reg = PORT_PCR_DSE | PORT_PCR_SRE | PORT_PCR_MUX(3) | PORT_PCR_PE | PORT_PCR_PS; // pullup on output pin;
+
+		// Lets try to make use of bitband address to set the direction for ue...
+		#if defined(KINETISL)
+		transmit_pin = &UART0_C3;
+		transmit_mask = UART_C3_TXDIR;
+		#else
+		transmit_pin = (uint8_t*)GPIO_BITBAND_PTR(UART0_C3, C3_TXDIR_BIT);
+		#endif
+
+	} else {
+		#if defined(KINETISL)
+		if (transmit_pin == &UART0_C3) transmit_pin = NULL;
+		#else
+		if (transmit_pin == (uint8_t*)GPIO_BITBAND_PTR(UART0_C3, C3_TXDIR_BIT)) transmit_pin = NULL;
+		#endif
+	}
 }
 
 void serial_end(void)

--- a/teensy3/serial2.c
+++ b/teensy3/serial2.c
@@ -115,6 +115,11 @@ static uint8_t tx_pin_num = 10;
 #define C2_TX_COMPLETING	C2_ENABLE | UART_C2_TCIE
 #define C2_TX_INACTIVE		C2_ENABLE
 
+// BITBAND Support
+#define GPIO_BITBAND_ADDR(reg, bit) (((uint32_t)&(reg) - 0x40000000) * 32 + (bit) * 4 + 0x42000000)
+#define GPIO_BITBAND_PTR(reg, bit) ((uint32_t *)GPIO_BITBAND_ADDR((reg), (bit)))
+#define C3_TXDIR_BIT 5
+
 void serial2_begin(uint32_t divisor)
 {
 	SIM_SCGC4 |= SIM_SCGC4_UART1;	// turn on clock, TODO: use bitband
@@ -198,6 +203,27 @@ void serial2_format(uint32_t format)
 		UART1_BDL = bdl;		// Says BDH not acted on until BDL is written
 	}
 #endif
+	// process request for half duplex.
+	if ((format & SERIAL_HALF_DUPLEX) != 0) {
+		UART1_C1 |= UART_C1_LOOPS | UART_C1_RSRC;
+		volatile uint32_t *reg = portConfigRegister(tx_pin_num);
+		*reg = PORT_PCR_DSE | PORT_PCR_SRE | PORT_PCR_MUX(3) | PORT_PCR_PE | PORT_PCR_PS; // pullup on output pin;
+
+		// Lets try to make use of bitband address to set the direction for ue...
+		#if defined(KINETISL)
+		transmit_pin = &UART1_C3;
+		transmit_mask = UART_C3_TXDIR;
+		#else
+		transmit_pin = (uint8_t*)GPIO_BITBAND_PTR(UART1_C3, C3_TXDIR_BIT);
+		#endif
+
+	} else {
+		#if defined(KINETISL)
+		if (transmit_pin == &UART1_C3) transmit_pin = NULL;
+		#else
+		if (transmit_pin == (uint8_t*)GPIO_BITBAND_PTR(UART1_C3, C3_TXDIR_BIT)) transmit_pin = NULL;
+		#endif
+	}
 }
 
 void serial2_end(void)

--- a/teensy3/serial4.c
+++ b/teensy3/serial4.c
@@ -102,6 +102,11 @@ static uint8_t tx_pin_num = 32;
 #define C2_TX_COMPLETING	C2_ENABLE | UART_C2_TCIE
 #define C2_TX_INACTIVE		C2_ENABLE
 
+// BITBAND Support
+#define GPIO_BITBAND_ADDR(reg, bit) (((uint32_t)&(reg) - 0x40000000) * 32 + (bit) * 4 + 0x42000000)
+#define GPIO_BITBAND_PTR(reg, bit) ((uint32_t *)GPIO_BITBAND_ADDR((reg), (bit)))
+#define C3_TXDIR_BIT 5
+
 void serial4_begin(uint32_t divisor)
 {
 	SIM_SCGC4 |= SIM_SCGC4_UART3;	// turn on clock, TODO: use bitband
@@ -158,6 +163,27 @@ void serial4_format(uint32_t format)
 		UART3_BDL = bdl;		// Says BDH not acted on until BDL is written
 	}
 #endif
+	// process request for half duplex.
+	if ((format & SERIAL_HALF_DUPLEX) != 0) {
+		UART3_C1 |= UART_C1_LOOPS | UART_C1_RSRC;
+		volatile uint32_t *reg = portConfigRegister(tx_pin_num);
+		*reg = PORT_PCR_DSE | PORT_PCR_SRE | PORT_PCR_MUX(3) | PORT_PCR_PE | PORT_PCR_PS; // pullup on output pin;
+
+		// Lets try to make use of bitband address to set the direction for ue...
+		#if defined(KINETISL)
+		transmit_pin = &UART3_C3;
+		transmit_mask = UART_C3_TXDIR;
+		#else
+		transmit_pin = (uint8_t*)GPIO_BITBAND_PTR(UART3_C3, C3_TXDIR_BIT);
+		#endif
+
+	} else {
+		#if defined(KINETISL)
+		if (transmit_pin == &UART3_C3) transmit_pin = NULL;
+		#else
+		if (transmit_pin == (uint8_t*)GPIO_BITBAND_PTR(UART3_C3, C3_TXDIR_BIT)) transmit_pin = NULL;
+		#endif
+	}
 }
 
 void serial4_end(void)

--- a/teensy3/serial5.c
+++ b/teensy3/serial5.c
@@ -101,6 +101,11 @@ static uint8_t tx_pin_num = 33;
 #define C2_TX_COMPLETING	C2_ENABLE | UART_C2_TCIE
 #define C2_TX_INACTIVE		C2_ENABLE
 
+// BITBAND Support
+#define GPIO_BITBAND_ADDR(reg, bit) (((uint32_t)&(reg) - 0x40000000) * 32 + (bit) * 4 + 0x42000000)
+#define GPIO_BITBAND_PTR(reg, bit) ((uint32_t *)GPIO_BITBAND_ADDR((reg), (bit)))
+#define C3_TXDIR_BIT 5
+
 void serial5_begin(uint32_t divisor)
 {
 	SIM_SCGC1 |= SIM_SCGC1_UART4;	// turn on clock, TODO: use bitband
@@ -149,6 +154,19 @@ void serial5_format(uint32_t format)
 		UART4_BDH |= UART_BDH_SBNS;		// Turn on 2 stop bits - was turned off by set baud
 		UART4_BDL = bdl;		// Says BDH not acted on until BDL is written
 	}
+	// process request for half duplex.
+	if ((format & SERIAL_HALF_DUPLEX) != 0) {
+		UART4_C1 |= UART_C1_LOOPS | UART_C1_RSRC;
+		volatile uint32_t *reg = portConfigRegister(tx_pin_num);
+		*reg = PORT_PCR_DSE | PORT_PCR_SRE | PORT_PCR_MUX(3) | PORT_PCR_PE | PORT_PCR_PS; // pullup on output pin;
+
+		// Lets try to make use of bitband address to set the direction for ue...
+		transmit_pin = (uint8_t*)GPIO_BITBAND_PTR(UART4_C3, C3_TXDIR_BIT);
+
+	} else {
+		if (transmit_pin == (uint8_t*)GPIO_BITBAND_PTR(UART4_C3, C3_TXDIR_BIT)) transmit_pin = NULL;
+	}
+
 }
 
 void serial5_end(void)

--- a/teensy3/serial6.c
+++ b/teensy3/serial6.c
@@ -101,6 +101,11 @@ static uint8_t tx_pin_num = 48;
 #define C2_TX_COMPLETING	C2_ENABLE | UART_C2_TCIE
 #define C2_TX_INACTIVE		C2_ENABLE
 
+// BITBAND Support
+#define GPIO_BITBAND_ADDR(reg, bit) (((uint32_t)&(reg) - 0x40000000) * 32 + (bit) * 4 + 0x42000000)
+#define GPIO_BITBAND_PTR(reg, bit) ((uint32_t *)GPIO_BITBAND_ADDR((reg), (bit)))
+#define C3_TXDIR_BIT 5
+
 void serial6_begin(uint32_t divisor)
 {
 	SIM_SCGC1 |= SIM_SCGC1_UART5;	// turn on clock, TODO: use bitband
@@ -148,6 +153,18 @@ void serial6_format(uint32_t format)
 		uint8_t bdl = UART5_BDL;
 		UART5_BDH |= UART_BDH_SBNS;		// Turn on 2 stop bits - was turned off by set baud
 		UART5_BDL = bdl;		// Says BDH not acted on until BDL is written
+	}
+	// process request for half duplex.
+	if ((format & SERIAL_HALF_DUPLEX) != 0) {
+		UART5_C1 |= UART_C1_LOOPS | UART_C1_RSRC;
+		volatile uint32_t *reg = portConfigRegister(tx_pin_num);
+		*reg = PORT_PCR_DSE | PORT_PCR_SRE | PORT_PCR_MUX(3) | PORT_PCR_PE | PORT_PCR_PS; // pullup on output pin;
+
+		// Lets try to make use of bitband address to set the direction for ue...
+		transmit_pin = (uint8_t*)GPIO_BITBAND_PTR(UART5_C3, C3_TXDIR_BIT);
+
+	} else {
+		if (transmit_pin == (uint8_t*)GPIO_BITBAND_PTR(UART5_C3, C3_TXDIR_BIT)) transmit_pin = NULL;
 	}
 }
 

--- a/teensy4/HardwareSerial.cpp
+++ b/teensy4/HardwareSerial.cpp
@@ -132,6 +132,9 @@ void HardwareSerial::begin(uint32_t baud, uint16_t format)
 
 //	uint32_t fastio = IOMUXC_PAD_SRE | IOMUXC_PAD_DSE(3) | IOMUXC_PAD_SPEED(3);
 
+	// Maybe different pin configs if half duplex
+	half_duplex_mode_ = (format & SERIAL_HALF_DUPLEX) != 0;
+	if (!half_duplex_mode_)  {
 	*(portControlRegister(hardware->rx_pins[rx_pin_index_].pin)) = IOMUXC_PAD_DSE(7) | IOMUXC_PAD_PKE | IOMUXC_PAD_PUE | IOMUXC_PAD_PUS(3) | IOMUXC_PAD_HYS;
 	*(portConfigRegister(hardware->rx_pins[rx_pin_index_].pin)) = hardware->rx_pins[rx_pin_index_].mux_val;
 	if (hardware->rx_pins[rx_pin_index_].select_input_register) {
@@ -140,6 +143,12 @@ void HardwareSerial::begin(uint32_t baud, uint16_t format)
 
 	*(portControlRegister(hardware->tx_pins[tx_pin_index_].pin)) =  IOMUXC_PAD_SRE | IOMUXC_PAD_DSE(3) | IOMUXC_PAD_SPEED(3);
 	*(portConfigRegister(hardware->tx_pins[tx_pin_index_].pin)) = hardware->tx_pins[tx_pin_index_].mux_val;
+	} else {
+		// Half duplex maybe different pin pad config like PU...		
+		*(portControlRegister(hardware->tx_pins[tx_pin_index_].pin)) =  IOMUXC_PAD_SRE | IOMUXC_PAD_DSE(3) | IOMUXC_PAD_SPEED(3) 
+				| IOMUXC_PAD_PKE | IOMUXC_PAD_PUE | IOMUXC_PAD_PUS(3);
+		*(portConfigRegister(hardware->tx_pins[tx_pin_index_].pin)) = hardware->tx_pins[tx_pin_index_].mux_val;
+	}
 	if (hardware->tx_pins[tx_pin_index_].select_input_register) {
 	 	*(hardware->tx_pins[tx_pin_index_].select_input_register) =  hardware->tx_pins[tx_pin_index_].select_val;		
 	}	
@@ -157,8 +166,8 @@ void HardwareSerial::begin(uint32_t baud, uint16_t format)
 	NVIC_ENABLE_IRQ(hardware->irq);
 	uint16_t tx_fifo_size = (((port->FIFO >> 4) & 0x7) << 2);
 	uint8_t tx_water = (tx_fifo_size < 16) ? tx_fifo_size >> 1 : 7;
-	uint16_t rx_fifo_size = (((port->FIFO >> 0) & 0x7) << 2);
-	uint8_t rx_water = (rx_fifo_size < 16) ? rx_fifo_size >> 1 : 7;
+	//uint16_t rx_fifo_size = (((port->FIFO >> 0) & 0x7) << 2);
+	uint8_t rx_water = 0; //(rx_fifo_size < 16) ? rx_fifo_size >> 1 : 7;
 	/*
 	Serial.printf("SerialX::begin stat:%x ctrl:%x fifo:%x water:%x\n", port->STAT, port->CTRL, port->FIFO, port->WATER );
 	Serial.printf("  FIFO sizes: tx:%d rx:%d\n",tx_fifo_size, rx_fifo_size);	
@@ -179,6 +188,9 @@ void HardwareSerial::begin(uint32_t baud, uint16_t format)
 
 	// Bit 5 TXINVERT
 	if (format & 0x20) ctrl |= LPUART_CTRL_TXINV;		// tx invert
+
+	// Now see if the user asked for Half duplex:
+	if (half_duplex_mode_) ctrl |= (LPUART_CTRL_LOOPS | LPUART_CTRL_RSRC);
 
 	// write out computed CTRL
 	port->CTRL = ctrl;
@@ -429,6 +441,12 @@ size_t HardwareSerial::write9bit(uint32_t c)
 	//digitalWrite(3, HIGH);
 	//digitalWrite(5, HIGH);
 	if (transmit_pin_baseReg_) DIRECT_WRITE_HIGH(transmit_pin_baseReg_, transmit_pin_bitmask_);
+	if(half_duplex_mode_) {		
+		__disable_irq();
+	    port->CTRL |= LPUART_CTRL_TXDIR;
+		__enable_irq();
+	}
+
 	head = tx_buffer_head_;
 	if (++head >= tx_buffer_total_size_) head = 0;
 	while (tx_buffer_tail_ == head) {
@@ -543,6 +561,11 @@ void HardwareSerial::IRQHandler()
 	{
 		transmitting_ = 0;
 		if (transmit_pin_baseReg_) DIRECT_WRITE_LOW(transmit_pin_baseReg_, transmit_pin_bitmask_);
+		if(half_duplex_mode_) {		
+			__disable_irq();
+		    port->CTRL &= ~LPUART_CTRL_TXDIR;
+			__enable_irq();
+		}
 
 		port->CTRL &= ~LPUART_CTRL_TCIE;
 	}

--- a/teensy4/HardwareSerial.cpp
+++ b/teensy4/HardwareSerial.cpp
@@ -140,6 +140,9 @@ void HardwareSerial::begin(uint32_t baud, uint16_t format)
 
 	*(portControlRegister(hardware->tx_pins[tx_pin_index_].pin)) =  IOMUXC_PAD_SRE | IOMUXC_PAD_DSE(3) | IOMUXC_PAD_SPEED(3);
 	*(portConfigRegister(hardware->tx_pins[tx_pin_index_].pin)) = hardware->tx_pins[tx_pin_index_].mux_val;
+	if (hardware->tx_pins[tx_pin_index_].select_input_register) {
+	 	*(hardware->tx_pins[tx_pin_index_].select_input_register) =  hardware->tx_pins[tx_pin_index_].select_val;		
+	}	
 
 	//hardware->rx_mux_register = hardware->rx_mux_val;
 	//hardware->tx_mux_register = hardware->tx_mux_val;

--- a/teensy4/HardwareSerial.h
+++ b/teensy4/HardwareSerial.h
@@ -92,6 +92,9 @@
 #define SERIAL_8N2_RXINV (SERIAL_8N1_RXINV | SERIAL_2STOP_BITS)
 #define SERIAL_8N2_TXINV (SERIAL_8N1_TXINV | SERIAL_2STOP_BITS)
 #define SERIAL_8N2_RXINV_TXINV (SERIAL_8N1_RXINV_TXINV | SERIAL_2STOP_BITS)
+
+#define SERIAL_HALF_DUPLEX 0x200
+
 // bit0: parity, 0=even, 1=odd
 // bit1: parity, 0=disable, 1=enable
 // bit2: mode, 1=9bit, 0=8bit
@@ -101,6 +104,8 @@
 // bit6: unused
 // bit7: actual data goes into 9th bit
 
+// bit8: 2 stop bits 
+// bit9: Half Duplex Mode
 
 #ifdef __cplusplus
 #include "Stream.h"
@@ -209,6 +214,7 @@ private:
 	const hardware_t * const hardware;
 	uint8_t				rx_pin_index_ = 0x0;	// default is always first item
 	uint8_t				tx_pin_index_ = 0x0;
+	uint8_t				half_duplex_mode_ = 0; // are we in half duplex mode?
 
 	volatile BUFTYPE 	*tx_buffer_;
 	volatile BUFTYPE 	*rx_buffer_;

--- a/teensy4/HardwareSerial1.cpp
+++ b/teensy4/HardwareSerial1.cpp
@@ -57,7 +57,7 @@ const HardwareSerial::hardware_t UART6_Hardware = {
 	0, IRQ_LPUART6, &IRQHandler_Serial1, &serial_event_check_serial1,
 	CCM_CCGR3, CCM_CCGR3_LPUART6(CCM_CCGR_ON),
 	{{0,2, &IOMUXC_LPUART6_RX_SELECT_INPUT, 1}, {0xff, 0xff, nullptr, 0}},
-	{{1,2, nullptr, 0}, {0xff, 0xff, nullptr, 0}},
+	{{1,2, &IOMUXC_LPUART6_TX_SELECT_INPUT, 1}, {0xff, 0xff, nullptr, 0}},
 	0xff, // No CTS pin
 	0, // No CTS
 	IRQ_PRIORITY, 38, 24, // IRQ, rts_low_watermark, rts_high_watermark

--- a/teensy4/HardwareSerial2.cpp
+++ b/teensy4/HardwareSerial2.cpp
@@ -63,7 +63,7 @@ static HardwareSerial::hardware_t UART4_Hardware = {
 	{{7,2, nullptr, 0}, {0xff, 0xff, nullptr, 0}},
 	#elif defined(__IMXRT1062__)
 	{{7,2, &IOMUXC_LPUART4_RX_SELECT_INPUT, 2}, {0xff, 0xff, nullptr, 0}},
-	{{8,2, nullptr, 0}, {0xff, 0xff, nullptr, 0}},
+	{{8,2, &IOMUXC_LPUART4_TX_SELECT_INPUT, 2}, {0xff, 0xff, nullptr, 0}},
 	#endif
 	0xff, // No CTS pin
 	0, // No CTS

--- a/teensy4/HardwareSerial3.cpp
+++ b/teensy4/HardwareSerial3.cpp
@@ -57,7 +57,7 @@ static HardwareSerial::hardware_t UART2_Hardware = {
 	2, IRQ_LPUART2, &IRQHandler_Serial3, &serial_event_check_serial3, 
 	CCM_CCGR0, CCM_CCGR0_LPUART2(CCM_CCGR_ON),
 	{{15,2, &IOMUXC_LPUART2_RX_SELECT_INPUT, 1}, {0xff, 0xff, nullptr, 0}},
-	{{14,2, nullptr, 0}, {0xff, 0xff, nullptr, 0}},
+	{{14,2, &IOMUXC_LPUART2_TX_SELECT_INPUT, 1}, {0xff, 0xff, nullptr, 0}},
 	19, //IOMUXC_SW_MUX_CTL_PAD_GPIO_AD_B1_00, // 19
 	2, // page 473 
 	IRQ_PRIORITY, 38, 24, // IRQ, rts_low_watermark, rts_high_watermark

--- a/teensy4/HardwareSerial4.cpp
+++ b/teensy4/HardwareSerial4.cpp
@@ -58,7 +58,7 @@ static HardwareSerial::hardware_t UART3_Hardware = {
 	3, IRQ_LPUART3, &IRQHandler_Serial4, &serial_event_check_serial4,
 	CCM_CCGR0, CCM_CCGR0_LPUART3(CCM_CCGR_ON),
 	{{16,2, &IOMUXC_LPUART3_RX_SELECT_INPUT, 0}, {0xff, 0xff, nullptr, 0}},
-	{{17,2, nullptr, 0}, {0xff, 0xff, nullptr, 0}},
+	{{17,2, &IOMUXC_LPUART3_TX_SELECT_INPUT, 0}, {0xff, 0xff, nullptr, 0}},
 	0xff, // No CTS pin
 	0, // No CTS
 	IRQ_PRIORITY, 38, 24, // IRQ, rts_low_watermark, rts_high_watermark

--- a/teensy4/HardwareSerial7.cpp
+++ b/teensy4/HardwareSerial7.cpp
@@ -58,7 +58,7 @@ static HardwareSerial::hardware_t UART7_Hardware = {
 	6, IRQ_LPUART7, &IRQHandler_Serial7, &serial_event_check_serial7,
 	CCM_CCGR5, CCM_CCGR5_LPUART7(CCM_CCGR_ON),
 	{{28,2, &IOMUXC_LPUART7_RX_SELECT_INPUT, 1}, {0xff, 0xff, nullptr, 0}},
-	{{29,2, nullptr, 0}, {0xff, 0xff, nullptr, 0}},
+	{{29,2, &IOMUXC_LPUART7_TX_SELECT_INPUT, 1}, {0xff, 0xff, nullptr, 0}},
 	0xff, // No CTS pin
 	0, // No CTS
 	IRQ_PRIORITY, 38, 24, // IRQ, rts_low_watermark, rts_high_watermark


### PR DESCRIPTION
@PaulStoffregen  - you may want to review this to see what you think.  

First part for T4 - set the RX Watermark to 0,  which fixed some issues people were running into when the last few bytes did not show up in SerialX.available() (nor read)... 

Half duplex support - if the format you pass in to SerialX.begin includes:
#define SERIAL_HALF_DUPLEX 0x200

The begin code, turn on LOOPS and the like, to set the TX pin to support half duplex.  I also enable PU resistor on the pin. 

On T4 - the code added another check  like transmitting pin
```
	if (transmit_pin_baseReg_) DIRECT_WRITE_HIGH(transmit_pin_baseReg_, transmit_pin_bitmask_);
	if(half_duplex_mode_) {		
		__disable_irq();
	    port->CTRL |= LPUART_CTRL_TXDIR;
		__enable_irq();
	}
```
And likewise to turn it back to RX mode.  For T3.x I added it, but I did not need to add the extra checks and the like in the code.  Instead, I use the bit band address.
		transmit_pin = (uint8_t*)GPIO_BITBAND_PTR(UART0_C3, C3_TXDIR_BIT);
And then the code already in place that looked at transmit pin like:
```
	if (transmit_pin) transmit_assert();
```

Took care of it for us... 

Note: So far T3.x I replicated the changes for Serial1-Serial6.  I have not yet done Serial6 of T3.6 as it uses LPUART instead of UART.  Thought I would get your input before I did that. 
