### PR TITLE
T4 IntervalTimer - change limit magic number

### DIFF
--- a/teensy4/IntervalTimer.h
+++ b/teensy4/IntervalTimer.h
@@ -50,7 +50,7 @@ public:
 	bool begin(void (*funct)(), unsigned int microseconds) {
 		if (microseconds == 0 || microseconds > MAX_PERIOD) return false;
 		uint32_t cycles = (24000000 / 1000000) * microseconds - 1;
-		if (cycles < 36) return false;
+		if (cycles < 17) return false;
 		return beginCycles(funct, cycles);
 	}
 	bool begin(void (*funct)(), int microseconds) {
@@ -66,7 +66,7 @@ public:
 	bool begin(void (*funct)(), float microseconds) {
 		if (microseconds <= 0 || microseconds > MAX_PERIOD) return false;
 		uint32_t cycles = (float)(24000000 / 1000000) * microseconds - 0.5;
-		if (cycles < 36) return false;
+		if (cycles < 17) return false;
 		return beginCycles(funct, cycles);
 	}
 	bool begin(void (*funct)(), double microseconds) {
@@ -75,7 +75,7 @@ public:
 	void update(unsigned int microseconds) {
 		if (microseconds == 0 || microseconds > MAX_PERIOD) return;
 		uint32_t cycles = (24000000 / 1000000) * microseconds - 1;
-		if (cycles < 36) return;
+		if (cycles < 17) return;
 		if (channel) channel->LDVAL = cycles;
 	}
 	void update(int microseconds) {
@@ -91,7 +91,7 @@ public:
 	void update(float microseconds) {
 		if (microseconds <= 0 || microseconds > MAX_PERIOD) return;
 		uint32_t cycles = (float)(24000000 / 1000000) * microseconds - 0.5;
-		if (cycles < 36) return;
+		if (cycles < 17) return;
 		if (channel) channel->LDVAL = cycles;
 	}
 	void update(double microseconds) {


### PR DESCRIPTION
Longer term we might consider changing timer over to using system clock, with default(max) divisior of 4 to go to PID instead of fixed 24mhz...

But in the mean time, try to allow IntervalTimer Settings that work at least as well as default settings for T3.2 whoes BUS speed is 48mhz, so the magic number of 36 was used which allowed a minimum value passed into begin/update of 36
48*.75-.5

With T4 code we just blindly left the magic number of 36...  So this one simply sort of halves it.  24*.75-.5 ... I rounded down to 17