### PR TITLE
T4 - IntervalTimer - Checks/uses which clock input

### DIFF
--- a/teensy4/IntervalTimer.h
+++ b/teensy4/IntervalTimer.h
@@ -33,14 +33,13 @@
 
 #include <stddef.h>
 #include "imxrt.h"
+#include "core_pins.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
 class IntervalTimer {
-private:
-	static const uint32_t MAX_PERIOD = UINT32_MAX / (24000000 / 1000000);
 public:
 	constexpr IntervalTimer() {
 	}
@@ -48,8 +47,10 @@ public:
 		end();
 	}
 	bool begin(void (*funct)(), unsigned int microseconds) {
-		if (microseconds == 0 || microseconds > MAX_PERIOD) return false;
-		uint32_t cycles = (24000000 / 1000000) * microseconds - 1;
+		uint32_t pid_clock_mhz = (CCM_CSCMR1 & CCM_CSCMR1_PERCLK_CLK_SEL)? 24 : (F_BUS_ACTUAL / 1000000);
+		uint32_t max_period = UINT32_MAX / pid_clock_mhz;
+		if (microseconds == 0 || microseconds > max_period) return false;
+		uint32_t cycles = pid_clock_mhz * microseconds - 1;
 		if (cycles < 17) return false;
 		return beginCycles(funct, cycles);
 	}
@@ -64,8 +65,10 @@ public:
 		return begin(funct, (int)microseconds);
 	}
 	bool begin(void (*funct)(), float microseconds) {
-		if (microseconds <= 0 || microseconds > MAX_PERIOD) return false;
-		uint32_t cycles = (float)(24000000 / 1000000) * microseconds - 0.5;
+		uint32_t pid_clock_mhz = (CCM_CSCMR1 & CCM_CSCMR1_PERCLK_CLK_SEL)? 24 : (F_BUS_ACTUAL / 1000000);
+		uint32_t max_period = UINT32_MAX / pid_clock_mhz;
+		if (microseconds <= 0 || microseconds > max_period) return false;
+		uint32_t cycles = (float)pid_clock_mhz * microseconds - 0.5;
 		if (cycles < 17) return false;
 		return beginCycles(funct, cycles);
 	}
@@ -73,8 +76,10 @@ public:
 		return begin(funct, (float)microseconds);
 	}
 	void update(unsigned int microseconds) {
-		if (microseconds == 0 || microseconds > MAX_PERIOD) return;
-		uint32_t cycles = (24000000 / 1000000) * microseconds - 1;
+		uint32_t pid_clock_mhz = (CCM_CSCMR1 & CCM_CSCMR1_PERCLK_CLK_SEL)? 24 : (F_BUS_ACTUAL / 1000000);
+		uint32_t max_period = UINT32_MAX / pid_clock_mhz;
+		if (microseconds == 0 || microseconds > max_period) return;
+		uint32_t cycles = pid_clock_mhz * microseconds - 1;
 		if (cycles < 17) return;
 		if (channel) channel->LDVAL = cycles;
 	}
@@ -89,8 +94,10 @@ public:
 		return update((int)microseconds);
 	}
 	void update(float microseconds) {
-		if (microseconds <= 0 || microseconds > MAX_PERIOD) return;
-		uint32_t cycles = (float)(24000000 / 1000000) * microseconds - 0.5;
+		uint32_t pid_clock_mhz = (CCM_CSCMR1 & CCM_CSCMR1_PERCLK_CLK_SEL)? 24 : (F_BUS_ACTUAL / 1000000);
+		uint32_t max_period = UINT32_MAX / pid_clock_mhz;
+		if (microseconds <= 0 || microseconds > max_period) return;
+		uint32_t cycles = (float)pid_clock_mhz * microseconds - 0.5;
 		if (cycles < 17) return;
 		if (channel) channel->LDVAL = cycles;
 	}


### PR DESCRIPTION
The T4 Interval Timer code was hard coded assuming 24mhz clock.  This did not work if the user changed to use Peripheral clock instead like if their sketch did:

```
  // Set PID and GPT to BUS speed
  CCM_CSCMR1 &= ~CCM_CSCMR1_PERCLK_CLK_SEL;
```

So this change instead checks the value of that register to see which clock source is selected for PIT and GPT and then computes based off of that...

Appears to work fine for simple test case:
```
#include <IntervalTimer.h>
// default: IntervalTImer::begin 0.750000 24 17
IntervalTimer my_timer;
uint32_t count = 0;
uint8_t led_state = 0;
void isr () {
  digitalWriteFast(2, HIGH);
  count++;
  if (count == 1000000) {
    led_state = led_state ? 0 : 1;
    digitalWriteFast(13, led_state);
    count = 0;
  }
  digitalWriteFast(2, LOW);
  asm("dsb");
}

void setup() {
  // Set PID and GPT to BUS speed
  CCM_CSCMR1 &= ~CCM_CSCMR1_PERCLK_CLK_SEL;
  pinMode(13, OUTPUT);
  pinMode(2, OUTPUT);
  while (!Serial && millis() < 4000) ;
  Serial.begin(115200);
  if (!my_timer.begin(&isr, 0.5)) {
    Serial.println("\n*** timer begin failed ***");
    while (1) {
      digitalWrite(13, !digitalRead(13));
      delay(125);
    }
  }
}
void loop() {

}
```
Also appears similar (same) code appears to work in @luni TimerTestTool library.

He also found that going to the other clock appeared to reduce the overhead on system???  Not sure but more details up on the thread:
https://forum.pjrc.com/threads/59222-IntervalTimer-on-Teensy-4-0-versus-3-6?p=227971&viewfull=1#post227971