### PR TITLE
T4 - USB Keyboard support LEDS

### DIFF
--- a/teensy4/usb.c
+++ b/teensy4/usb.c
@@ -621,9 +621,9 @@ static void endpoint0_complete(void)
 	}
 #endif
 #ifdef KEYBOARD_INTERFACE
-	if (setup.word1 == 0x02000921 && setup.word2 == ((1<<16)|KEYBOARD_INTERFACE)) {
+	if (setup.word1 == 0x02000921 && setup.word2 == ((1 << 16) | KEYBOARD_INTERFACE)) {
 		keyboard_leds = endpoint0_buffer[0];
-		usb_start_sof_interrupts(NUM_INTERFACE);
+		endpoint0_transmit(NULL, 0, 0);
 	}
 #endif
 #ifdef SEREMU_INTERFACE

--- a/teensy4/usb.c
+++ b/teensy4/usb.c
@@ -620,6 +620,12 @@ static void endpoint0_complete(void)
 		}
 	}
 #endif
+#ifdef KEYBOARD_INTERFACE
+	if (setup.word1 == 0x02000921 && setup.word2 == ((1<<16)|KEYBOARD_INTERFACE)) {
+		keyboard_leds = endpoint0_buffer[0];
+		usb_start_sof_interrupts(NUM_INTERFACE);
+	}
+#endif
 #ifdef SEREMU_INTERFACE
 	if (setup.word1 == 0x03000921 && setup.word2 == ((4<<16)|SEREMU_INTERFACE)
 	  && endpoint0_buffer[0] == 0xA9 && endpoint0_buffer[1] == 0x45


### PR DESCRIPTION
Migrated the T3 code over to handle the message to set the logical keyboard LEDS

As per forum thread: https://forum.pjrc.com/threads/59372-Teensy-4-0-no-support-for-keyboard_leds