### PR TITLE
teensy3: new: Remove sized delete operators to kill C++14 warnings

### DIFF
--- a/teensy3/new.cpp
+++ b/teensy3/new.cpp
@@ -45,16 +45,6 @@ void operator delete[](void * ptr)
   free(ptr);
 }
 
-void operator delete(void * ptr, size_t size)
-{
-  free(ptr);
-}
-
-void operator delete[](void * ptr, size_t size)
-{
-  free(ptr);
-}
-
 //int __cxa_guard_acquire(__guard *g) {return !*(char *)(g);};
 //void __cxa_guard_release (__guard *g) {*(char *)g = 1;};
 //void __cxa_guard_abort (__guard *) {}; 

--- a/teensy3/new.h
+++ b/teensy3/new.h
@@ -38,8 +38,6 @@ void * operator new(size_t size);
 void * operator new[](size_t size);
 void operator delete(void * ptr);
 void operator delete[](void * ptr);
-void operator delete(void * ptr, size_t size);
-void operator delete[](void * ptr, size_t size);
 
 __extension__ typedef int __guard __attribute__((mode (__DI__)));
 


### PR DESCRIPTION
Gets rid of the following warnings with arm/bin/arm-none-eabi-g++ 5.4.1:

    teensy3.copy/new.h:41:6: warning: 'void operator delete(void*, size_t)' is a usual (non-placement) deallocation function in C++14 (or with -fsized-deallocation) [-Wc++14-compat]
     void operator delete(void * ptr, size_t size);
	  ^
    teensy3.copy/new.h:42:6: warning: 'void operator delete [](void*, size_t)' is a usual (non-placement) deallocation function in C++14 (or with -fsized-deallocation) [-Wc++14-compat]
     void operator delete[](void * ptr, size_t size);
	  ^
    teensy3.copy/new.cpp:48:6: warning: 'void operator delete(void*, size_t)' is a usual (non-placement) deallocation function in C++14 (or with -fsized-deallocation) [-Wc++14-compat]
     void operator delete(void * ptr, size_t size)
	  ^
    teensy3.copy/new.cpp:53:6: warning: 'void operator delete [](void*, size_t)' is a usual (non-placement) deallocation function in C++14 (or with -fsized-deallocation) [-Wc++14-compat]
     void operator delete[](void * ptr, size_t size)
	  ^

Signed-off-by: Geert Uytterhoeven <geert@linux-m68k.org>