### PR TITLE
teensy3: usb_desc: Make usb_descriptor_list_t.addr const void *

### DIFF
--- a/teensy3/usb_desc.c
+++ b/teensy3/usb_desc.c
@@ -1534,12 +1534,12 @@ const usb_descriptor_list_t usb_descriptor_list[] = {
         {0x2100, MULTITOUCH_INTERFACE, config_descriptor+MULTITOUCH_HID_DESC_OFFSET, 9},
 #endif
 #ifdef MTP_INTERFACE
-	{0x0304, 0x0409, (const uint8_t *)&usb_string_mtp, 0},
+	{0x0304, 0x0409, &usb_string_mtp, 0},
 #endif
-        {0x0300, 0x0000, (const uint8_t *)&string0, 0},
-        {0x0301, 0x0409, (const uint8_t *)&usb_string_manufacturer_name, 0},
-        {0x0302, 0x0409, (const uint8_t *)&usb_string_product_name, 0},
-        {0x0303, 0x0409, (const uint8_t *)&usb_string_serial_number, 0},
+        {0x0300, 0x0000, &string0, 0},
+        {0x0301, 0x0409, &usb_string_manufacturer_name, 0},
+        {0x0302, 0x0409, &usb_string_product_name, 0},
+        {0x0303, 0x0409, &usb_string_serial_number, 0},
 	{0, 0, NULL, 0}
 };
 

--- a/teensy3/usb_desc.h
+++ b/teensy3/usb_desc.h
@@ -875,7 +875,7 @@ extern const uint8_t usb_endpoint_config_table[NUM_ENDPOINTS];
 typedef struct {
 	uint16_t	wValue;
 	uint16_t	wIndex;
-	const uint8_t	*addr;
+	const void	*addr;
 	uint16_t	length;
 } usb_descriptor_list_t;
 

--- a/teensy3/usb_dev.c
+++ b/teensy3/usb_dev.c
@@ -329,7 +329,7 @@ static void usb_setup(void)
 					// for string descriptors, use the descriptor's
 					// length field, allowing runtime configured
 					// length.
-					datalen = *(list->addr);
+					datalen = *data;
 				} else {
 					datalen = list->length;
 				}


### PR DESCRIPTION
The addr member in usb_descriptor_list_t just points to a memory buffer,
hence change it to "void *".  This allows to remove several casts.

Update the single user that assumes "uint8_t *".

Signed-off-by: Geert Uytterhoeven <geert@linux-m68k.org>