### PR TITLE
T4.1 - Serial8 is on pins 34 and 35

### DIFF
--- a/teensy4/HardwareSerial.cpp
+++ b/teensy4/HardwareSerial.cpp
@@ -62,7 +62,7 @@
 
 #define UART_CLOCK 24000000
 
-#if defined(__IMXRT1052__)   
+#if defined(ARDUINO_TEENSY41)   
 SerialEventCheckingFunctionPointer HardwareSerial::serial_event_handler_checks[8] = {nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr};
 #else
 SerialEventCheckingFunctionPointer HardwareSerial::serial_event_handler_checks[7] = {nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr};

--- a/teensy4/HardwareSerial.h
+++ b/teensy4/HardwareSerial.h
@@ -120,7 +120,7 @@ extern "C" {
 	extern void IRQHandler_Serial5();
 	extern void IRQHandler_Serial6();
 	extern void IRQHandler_Serial7();
-	#if defined(__IMXRT1052__)   
+	#if defined(ARDUINO_TEENSY41)   
 	extern void IRQHandler_Serial8();
 	#endif
 }
@@ -243,7 +243,7 @@ private:
 	friend void IRQHandler_Serial5();
 	friend void IRQHandler_Serial6();
 	friend void IRQHandler_Serial7();
-	#if defined(__IMXRT1052__)   
+	#if defined(ARDUINO_TEENSY41)   
 	friend void IRQHandler_Serial8();
 	static SerialEventCheckingFunctionPointer serial_event_handler_checks[8];
 	#else	
@@ -268,7 +268,7 @@ extern void serialEvent5(void);
 extern void serialEvent6(void);
 extern void serialEvent7(void);
 
-	#if defined(__IMXRT1052__)   
+	#if defined(ARDUINO_TEENSY41)   
 extern HardwareSerial Serial8;
 extern void serialEvent8(void);
 #endif

--- a/teensy4/HardwareSerial5.cpp
+++ b/teensy4/HardwareSerial5.cpp
@@ -57,8 +57,13 @@ static BUFTYPE rx_buffer5[SERIAL5_RX_BUFFER_SIZE];
 static HardwareSerial::hardware_t UART8_Hardware = {
 	4, IRQ_LPUART8, &IRQHandler_Serial5, &serial_event_check_serial5,
 	CCM_CCGR6, CCM_CCGR6_LPUART8(CCM_CCGR_ON),
+	#if defined(ARDUINO_TEENSY41)
+	{{21,2, &IOMUXC_LPUART8_RX_SELECT_INPUT, 1}, {46, 2, &IOMUXC_LPUART8_RX_SELECT_INPUT, 0}},
+	{{20,2, &IOMUXC_LPUART8_TX_SELECT_INPUT, 1}, {47, 2, &IOMUXC_LPUART8_TX_SELECT_INPUT, 0}},
+	#else
 	{{21,2, &IOMUXC_LPUART8_RX_SELECT_INPUT, 1}, {38, 2, &IOMUXC_LPUART8_RX_SELECT_INPUT, 0}},
 	{{20,2, &IOMUXC_LPUART8_TX_SELECT_INPUT, 1}, {39, 2, &IOMUXC_LPUART8_TX_SELECT_INPUT, 0}},
+	#endif
 	0xff, // No CTS pin
 	0, // No CTS
 	IRQ_PRIORITY, 38, 24, // IRQ, rts_low_watermark, rts_high_watermark

--- a/teensy4/HardwareSerial8.cpp
+++ b/teensy4/HardwareSerial8.cpp
@@ -30,7 +30,7 @@
 
 #include <Arduino.h>
 #include "HardwareSerial.h"
-#if defined(__IMXRT1052__)   
+#if defined(__IMXRT1062__) && defined(ARDUINO_TEENSY41)
 
 #ifndef SERIAL8_TX_BUFFER_SIZE
 #define SERIAL8_TX_BUFFER_SIZE     40 // number of outgoing bytes to buffer
@@ -59,8 +59,9 @@ static BUFTYPE rx_buffer8[SERIAL8_RX_BUFFER_SIZE];
 static HardwareSerial::hardware_t UART5_Hardware = {
 	7, IRQ_LPUART5, &IRQHandler_Serial8, &serial_event_check_serial8,
 	CCM_CCGR3, CCM_CCGR3_LPUART5(CCM_CCGR_ON),
-	{{30,2, &IOMUXC_LPUART5_RX_SELECT_INPUT, 0}, {0xff, 0xff, nullptr, 0}},
-	{{31,2, nullptr, 0}, {0xff, 0xff, nullptr, 0}},
+    {{34,1, &IOMUXC_LPUART5_RX_SELECT_INPUT, 1}, {0xff, 0xff, nullptr, 0}},
+    {{35,1, &IOMUXC_LPUART5_TX_SELECT_INPUT, 1}, {0xff, 0xff, nullptr, 0}},
+
 	0xff, // No CTS pin
 	0, // No CTS
 	IRQ_PRIORITY, 38, 24, // IRQ, rts_low_watermark, rts_high_watermark

--- a/teensy4/pins_arduino.h
+++ b/teensy4/pins_arduino.h
@@ -93,9 +93,13 @@ const static uint8_t SCL = 19;
 #define PIN_SERIAL_TX (1)
 
 
+#ifdef ARDUINO_TEENSY41
+#define NUM_DIGITAL_PINS  55
+#define NUM_ANALOG_INPUTS 18
+#else
 #define NUM_DIGITAL_PINS  40
 #define NUM_ANALOG_INPUTS 14
-
+#endif
 
 #define NOT_AN_INTERRUPT -1
 


### PR DESCRIPTION
Serial8 is now defined for T4.1.

Previously it was defined for T4B1, but went away on T4B2 and released.  It is now defined on the T4.1