### PR TITLE
Disable keepers

### DIFF
--- a/teensy4/startup.c
+++ b/teensy4/startup.c
@@ -22,6 +22,7 @@ void (* _VectorsRam[NVIC_NUM_INTERRUPTS+16])(void);
 
 static void memory_copy(uint32_t *dest, const uint32_t *src, uint32_t *dest_end);
 static void memory_clear(uint32_t *dest, uint32_t *dest_end);
+static void disable_keepers(void);
 static void configure_systick(void);
 static void reset_PFD();
 extern void systick_isr(void);
@@ -120,7 +121,8 @@ void ResetHandler(void)
 		SNVS_LPCR |= SNVS_LPCR_SRTC_ENV;
 	}
 	SNVS_HPCR |= SNVS_HPCR_RTC_EN | SNVS_HPCR_HP_TS;
-
+	
+	disable_keepers();
 	startup_early_hook();
 	while (millis() < 20) ; // wait at least 20ms before starting USB
 	usb_init();
@@ -139,8 +141,10 @@ void ResetHandler(void)
 	while (1) ;
 }
 
-
-
+FLASHMEM static void disable_keepers(void) {
+	for (unsigned i = 0; i < CORE_NUM_TOTAL_PINS; i++)
+		pinMode(i, INPUT_DISABLE);
+}
 
 // ARM SysTick is used for most Ardiuno timing functions, delay(), millis(),
 // micros().  SysTick can run from either the ARM core clock, or from an


### PR DESCRIPTION
See https://github.com/PaulStoffregen/cores/issues/449
and 
https://forum.pjrc.com/threads/60005-Teensy-4-0-ADC-keeper-issue?p=232877&viewfull=1#post232877

In short: Pins behave different from Teensy 3, are not completely disabled after startup due to enabled keepers.
This may be inompatible to connected electronics and is incompatible to analogRead.