### PR TITLE
RX with 4 transfers using similar code to seremu

### DIFF
--- a/teensy4/usb.c
+++ b/teensy4/usb.c
@@ -3,6 +3,7 @@
 #include "usb_desc.h"
 #include "usb_serial.h"
 #include "usb_seremu.h"
+#include "usb_rawhid.h"
 #include "usb_keyboard.h"
 #include "usb_mouse.h"
 #include "usb_joystick.h"

--- a/teensy4/usb_inst.cpp
+++ b/teensy4/usb_inst.cpp
@@ -39,6 +39,18 @@ usb_serial_class Serial;
 #endif
 #endif
 
+#ifdef CDC2_DATA_INTERFACE
+#ifdef CDC2_STATUS_INTERFACE
+usb_serial2_class SerialUSB1;
+#endif
+#endif
+
+#ifdef CDC3_DATA_INTERFACE
+#ifdef CDC3_STATUS_INTERFACE
+usb_serial3_class SerialUSB2;
+#endif
+#endif
+
 #ifdef MIDI_INTERFACE
 usb_midi_class usbMIDI;
 #endif

--- a/teensy4/usb_rawhid.c
+++ b/teensy4/usb_rawhid.c
@@ -41,7 +41,7 @@
 
 #define TX_NUM   4
 static transfer_t tx_transfer[TX_NUM] __attribute__ ((used, aligned(32)));
-static uint8_t txbuffer[RAWHID_TX_SIZE * TX_NUM];
+DMAMEM static uint8_t txbuffer[RAWHID_TX_SIZE * TX_NUM];
 static uint8_t tx_head=0;
 
 #define RX_NUM  4
@@ -136,6 +136,7 @@ int usb_rawhid_send(const void *buffer, uint32_t timeout)
 	}
 	uint8_t *txdata = txbuffer + (tx_head * RAWHID_TX_SIZE);
 	memcpy(txdata, buffer, RAWHID_TX_SIZE);
+	arm_dcache_flush_delete(txdata, SEREMU_TX_SIZE);
 	usb_prepare_transfer(xfer, txdata, RAWHID_TX_SIZE, 0);
 	usb_transmit(RAWHID_TX_ENDPOINT, xfer);
 	if (++tx_head >= TX_NUM) tx_head = 0;

--- a/teensy4/usb_rawhid.c
+++ b/teensy4/usb_rawhid.c
@@ -30,6 +30,7 @@
 
 #include "usb_dev.h"
 #include "usb_rawhid.h"
+#include "avr/pgmspace.h" // for PROGMEM, DMAMEM, FASTRUN
 #include "core_pins.h" // for yield(), millis()
 #include <string.h>    // for memcpy()
 //#include "HardwareSerial.h"
@@ -43,16 +44,17 @@ static transfer_t tx_transfer[TX_NUM] __attribute__ ((used, aligned(32)));
 static uint8_t txbuffer[RAWHID_TX_SIZE * TX_NUM];
 static uint8_t tx_head=0;
 
-static transfer_t rx_transfer[1] __attribute__ ((used, aligned(32)));
-static uint8_t rx_buffer[RAWHID_RX_SIZE];
-
+#define RX_NUM  4
+static transfer_t rx_transfer[RX_NUM] __attribute__ ((used, aligned(32)));
+DMAMEM static uint8_t rx_buffer[RAWHID_RX_SIZE * RX_NUM] __attribute__ ((aligned(32)));
+static volatile uint8_t rx_head;
+static volatile uint8_t rx_tail;
+static uint8_t rx_list[RX_NUM + 1];
+static volatile uint32_t rx_available;
+static void rx_queue_transfer(int i);
+static void rx_event(transfer_t *t);
 extern volatile uint8_t usb_configuration;
 
-
-static void rx_event(transfer_t *t)
-{
-	//printf("rx\n");
-}
 
 void usb_rawhid_configure(void)
 {
@@ -60,27 +62,63 @@ void usb_rawhid_configure(void)
 	memset(tx_transfer, 0, sizeof(tx_transfer));
 	memset(rx_transfer, 0, sizeof(rx_transfer));
 	tx_head = 0;
+	rx_head = 0;
+	rx_tail = 0;
 	usb_config_tx(RAWHID_TX_ENDPOINT, RAWHID_TX_SIZE, 0, NULL);
 	usb_config_rx(RAWHID_RX_ENDPOINT, RAWHID_RX_SIZE, 0, rx_event);
-	//usb_config_rx(RAWHID_RX_ENDPOINT, RAWHID_RX_SIZE, 0, NULL); // why does this not work?
-	usb_prepare_transfer(rx_transfer + 0, rx_buffer, RAWHID_RX_SIZE, 0);
-	usb_receive(RAWHID_RX_ENDPOINT, rx_transfer + 0);
+	int i;
+	for (i=0; i < RX_NUM; i++) rx_queue_transfer(i);
 }
+
+/*************************************************************************/
+/**                               Receive                               **/
+/*************************************************************************/
+
+static void rx_queue_transfer(int i)
+{
+	void *buffer = rx_buffer + i * RAWHID_RX_SIZE;
+	arm_dcache_delete(buffer, RAWHID_RX_SIZE);
+	//memset(buffer, )
+	NVIC_DISABLE_IRQ(IRQ_USB1);
+	usb_prepare_transfer(rx_transfer + i, buffer, RAWHID_RX_SIZE, i);
+	usb_receive(RAWHID_RX_ENDPOINT, rx_transfer + i);
+	NVIC_ENABLE_IRQ(IRQ_USB1);
+}
+
+static void rx_event(transfer_t *t)
+{
+	int i = t->callback_param;
+	//printf("rx event i=%d\n", i);
+	// received a packet with data
+	uint32_t head = rx_head;
+	if (++head > RX_NUM) head = 0;
+	rx_list[head] = i;
+	rx_head = head;
+}
+
 
 int usb_rawhid_recv(void *buffer, uint32_t timeout)
 {
 	uint32_t wait_begin_at = systick_millis_count;
+	uint32_t tail = rx_tail;
 	while (1) {
 		if (!usb_configuration) return -1; // usb not enumerated by host
-		uint32_t status = usb_transfer_status(rx_transfer);
-		if (!(status & 0x80)) break; // transfer descriptor ready
-		if (systick_millis_count - wait_begin_at > timeout) return 0;
+		if (tail != rx_head) break;
+		if (systick_millis_count - wait_begin_at > timeout)  {
+			return 0;
+		}
 		yield();
 	}
-	memcpy(buffer, rx_buffer, RAWHID_RX_SIZE);
-	memset(rx_transfer, 0, sizeof(rx_transfer));
-	usb_prepare_transfer(rx_transfer + 0, rx_buffer, RAWHID_RX_SIZE, 0);
-	usb_receive(RAWHID_RX_ENDPOINT, rx_transfer + 0);
+//	digitalWriteFast(0, LOW);
+	if (++tail > RX_NUM) tail = 0;
+	uint32_t i = rx_list[tail];
+	rx_tail = tail;
+
+	memcpy(buffer,  rx_buffer + i * RAWHID_RX_SIZE, RAWHID_RX_SIZE);
+	rx_queue_transfer(i);
+	//memset(rx_transfer, 0, sizeof(rx_transfer));
+	//usb_prepare_transfer(rx_transfer + 0, rx_buffer, RAWHID_RX_SIZE, 0);
+	//usb_receive(RAWHID_RX_ENDPOINT, rx_transfer + 0);
 	return RAWHID_RX_SIZE;
 }
 
@@ -107,7 +145,8 @@ int usb_rawhid_send(const void *buffer, uint32_t timeout)
 int usb_rawhid_available(void)
 {
 	if (!usb_configuration) return 0;
-	if (!(usb_transfer_status(rx_transfer) & 0x80)) return RAWHID_RX_SIZE;
+	if (rx_head != rx_tail) return RAWHID_RX_SIZE;
+	//if (!(usb_transfer_status(rx_transfer) & 0x80)) return RAWHID_RX_SIZE;
 	return 0;
 }
 


### PR DESCRIPTION
Testing against issues of hang from thread:
https://forum.pjrc.com/threads/59881-RawHID-recv()-hangs-after-updating-to-Teensyduino-1-4-9-or-higher-for-Teensy-4-0

@PaulStoffregen - The RX now has 4 transfers and more or less same RX code as SEREMU except not worrying about partial frames and the other SEREMU Stuff.  

Like Seremu I did put the RX buffer into DMAMEM, but have not touched the TX Buffer yet which is still in main memory. 

Currently running on two T4.x boards talking to each other. 

Here is a modified one that would have hung but modified to check a 4 byte sequence number instead of a fixed number:
```
#include <Arduino.h>

extern "C" {
  extern char * _sbrk(int incr);
}
void blink(int num);
void setup()
{
  while (!Serial && millis() < 3000) ;
  Serial.begin(115200);
  delay(500); // Simulate initialization
  pinMode(13, OUTPUT);
  pinMode(0, OUTPUT);
  pinMode(1, OUTPUT);
  pinMode(2, OUTPUT);
  pinMode(3, OUTPUT);
  pinMode(4, OUTPUT);
  pinMode(5, OUTPUT);
  blink(1);
}

char rx_buffer[64];

elapsedMicros time;
uint32_t loop_count = 0;
uint32_t receive_count = 0;
uint32_t valid_count = 0;
uint32_t last_seq_num = (uint32_t) - 1;

void loop()
{
  uint32_t seq_num;
  if (time < 100)
  {
    return;
  }
  loop_count++;
  int n = RawHID.recv(rx_buffer, 1);
  if (n > 0)
  {
    receive_count++;
    seq_num = rx_buffer[0] + (uint32_t)(rx_buffer[1] << 8)
              + (uint32_t)(rx_buffer[2] << 16) + (uint32_t)(rx_buffer[3] << 24);
    if (seq_num != (last_seq_num + 1)) Serial.printf("Seq number change %d %d\n",
          last_seq_num, seq_num);
    last_seq_num = seq_num;
    blink(2);
  }
  time = 0;
  if ((loop_count & 0x7f) == 0) Serial.printf("L:%u R:%u: Seq:%d  Heap: %x\n", loop_count, receive_count,
        last_seq_num, (uint32_t)_sbrk(0));
}

void blink(int num)
{
  for (int i = 0; i < num; i++)
  {
    digitalWrite(13, HIGH);
    delay(10);
    digitalWrite(13, LOW);
    delay(10);
  }
}
```

And the one I ran on the other side to drive it.  Note it could be simplified... 
```
// Simple test of USB Host Mouse/Keyboard
//
// This example is in the public domain

#include "USBHost_t36.h"

USBHost myusb;
USBHub hub1(myusb);
USBHIDParser hid1(myusb);
USBHIDParser hid2(myusb);
USBHIDParser hid3(myusb);
RawHIDController rawhid1(myusb);
RawHIDController rawhid2(myusb, 0xffc90004);
uint8_t serial1buffer[256];


USBDriver *drivers[] = {&hub1, &hid1, &hid2, &hid3};
#define CNT_DEVICES (sizeof(drivers)/sizeof(drivers[0]))
const char * driver_names[CNT_DEVICES] = {"Hub1", "HID1" , "HID2", "HID3"};
bool driver_active[CNT_DEVICES] = {false, false, false, false};

// Lets also look at HID Input devices
USBHIDInput *hiddrivers[] = {&rawhid1, &rawhid2};
#define CNT_HIDDEVICES (sizeof(hiddrivers)/sizeof(hiddrivers[0]))
const char * hid_driver_names[CNT_DEVICES] = {"RawHid1", "RawHid2"};
bool hid_driver_active[CNT_DEVICES] = {false, false};
bool show_changed_only = false;


void setup()
{
  while (!Serial) ; // wait for Arduino Serial Monitor
  Serial4.begin(115200);  // leave default speed for now.
  Serial.println("\n\nUSB Host Testing");
  Serial.println(sizeof(USBHub), DEC);
  myusb.begin();
  rawhid1.attachReceive(OnReceiveHidData);
  rawhid2.attachReceive(OnReceiveHidData);
  pinMode(13, OUTPUT);
  Serial1.begin(115200);  // Debug output...
}

uint32_t loop_count = 0;
void loop()
{
  myusb.Task();

  if (Serial.available()) {
    int ch = Serial.read(); // get the first char.
    while (Serial.read() != -1) ;
    if (show_changed_only) {
      show_changed_only = false;
      Serial.println("\n*** Show All fields mode ***");
    } else {
      show_changed_only = true;
      Serial.println("\n*** Show only changed fields mode ***");
    }
  }
  int cbSerial1;
  if ((cbSerial1 = min(Serial1.available(), sizeof(serial1buffer)))) {
    int cba = Serial.availableForWrite();
    if (cba < cbSerial1) cbSerial1 = cba;
    Serial1.readBytes(serial1buffer, cbSerial1);
    Serial.write(serial1buffer, cbSerial1);
  }

  for (uint8_t i = 0; i < CNT_DEVICES; i++) {
    if (*drivers[i] != driver_active[i]) {
      if (driver_active[i]) {
        Serial.printf("*** Device %s - disconnected ***\n", driver_names[i]);
        driver_active[i] = false;
      } else {
        Serial.printf("*** Device %s %x:%x - connected ***\n", driver_names[i], drivers[i]->idVendor(), drivers[i]->idProduct());
        driver_active[i] = true;

        const uint8_t *psz = drivers[i]->manufacturer();
        if (psz && *psz) Serial.printf("  manufacturer: %s\n", psz);
        psz = drivers[i]->product();
        if (psz && *psz) Serial.printf("  product: %s\n", psz);
        psz = drivers[i]->serialNumber();
        if (psz && *psz) Serial.printf("  Serial: %s\n", psz);
      }
    }
  }

  for (uint8_t i = 0; i < CNT_HIDDEVICES; i++) {
    if (*hiddrivers[i] != hid_driver_active[i]) {
      if (hid_driver_active[i]) {
        Serial.printf("*** HID Device %s - disconnected ***\n", hid_driver_names[i]);
        hid_driver_active[i] = false;
      } else {
        Serial.printf("*** HID Device %s %x:%x - connected ***\n", hid_driver_names[i], hiddrivers[i]->idVendor(), hiddrivers[i]->idProduct());
        hid_driver_active[i] = true;

        const uint8_t *psz = hiddrivers[i]->manufacturer();
        if (psz && *psz) Serial.printf("  manufacturer: %s\n", psz);
        psz = hiddrivers[i]->product();
        if (psz && *psz) Serial.printf("  product: %s\n", psz);
        psz = hiddrivers[i]->serialNumber();
        if (psz && *psz) Serial.printf("  Serial: %s\n", psz);
      }
    }
  }
  // See if we have some RAW data
  if (rawhid1) {
    uint8_t buffer[64];
    digitalWriteFast(13, !digitalReadFast(13));
    memset(buffer, 0, sizeof(buffer));
    loop_count++;
    buffer[0] = (loop_count & 0xff);
    buffer[1] = (loop_count >> 8) & 0xff;
    buffer[2] = (loop_count >> 16) & 0xff;
    buffer[3] = (loop_count >> 24) & 0xff;
    rawhid1.sendPacket(buffer);
    delay(100);
  }

}
bool OnReceiveHidData(uint32_t usage, const uint8_t *data, uint32_t len) {
  // Called for maybe both HIDS for rawhid basic test.  One is for the Teensy
  // to output to Serial. while still having Raw Hid...
  if (usage == 0xffc90004) {
    // Lets trim off trailing null characters.
    while ((len > 0) && (data[len - 1] == 0)) {
      len--;
    }
    if (len) {
      Serial.print("RawHid Serial: ");
      Serial.write(data, len);
    }
  } else {
    Serial.print("RawHID data: ");
    Serial.println(usage, HEX);
    while (len) {
      uint8_t cb = (len > 16) ? 16 : len;
      const uint8_t *p = data;
      uint8_t i;
      for (i = 0; i < cb; i++) {
        Serial.printf("%02x ", *p++);
      }
      Serial.print(": ");
      for (i = 0; i < cb; i++) {
        Serial.write(((*data >= ' ') && (*data <= '~')) ? *data : '.');
        data++;
      }
      len -= cb;
      Serial.println();
    }
  }

  return true;
}
```
I have run older test one up to about cnt of 25000 records sent and now with this updated test sketches about 7000 so far. 
