### PR TITLE
Use standard (~44kHz) sample rate for Teensy LC too

### DIFF
--- a/teensy3/AudioStream.h
+++ b/teensy3/AudioStream.h
@@ -56,10 +56,8 @@
 #endif
 
 #ifndef AUDIO_SAMPLE_RATE_EXACT
-#if defined(__MK20DX128__) || defined(__MK20DX256__) || defined(__MK64FX512__) || defined(__MK66FX1M0__)
+#if defined(__MK20DX128__) || defined(__MK20DX256__) || defined(__MK64FX512__) || defined(__MK66FX1M0__) || defined(__MKL26Z64__)
 #define AUDIO_SAMPLE_RATE_EXACT 44117.64706 // 48 MHz / 1088, or 96 MHz * 2 / 17 / 256
-#elif defined(__MKL26Z64__)
-#define AUDIO_SAMPLE_RATE_EXACT 22058.82353 // 48 MHz / 2176, or 96 MHz * 1 / 17 / 256
 #endif
 #endif
 


### PR DESCRIPTION
The original code here (from 345b03b31f54e21d848e65a84c86e32cd0aaa630) was introduced in 2015 with the aspirational comment that Teensy-LC will eventually have Audio support but at 22 kHz instead of 44 kHz.  Now, 5 years later, there's evidence of a lot of progress in that direction, but much of the functionality still isn't supported.

I'd like to make the case that, rather than try to support the full Audio library at reduced sample rate on the old hardware, it would be better to support a minimally useful subset (e.g. audio from flash memory to analog or I2S output (e.g. for use with the prop shield or audio shield) at full sample rate.  I recently submitted a small PR to the Audio library that supports DAC output for Teensy-LC, and can verify that pushing audio data from the flash memory on the prop shield to the analog output works just fine on Teensy-LC.