### PR TITLE
Modify __NEWLIB_MINOR__ check for the newlib 2.2.0 release

### DIFF
--- a/teensy4/avr_functions.h
+++ b/teensy4/avr_functions.h
@@ -97,7 +97,7 @@ static inline void eeprom_update_block(const void *buf, void *addr, uint32_t len
 char * ultoa(unsigned long val, char *buf, int radix);
 char * ltoa(long val, char *buf, int radix);
 
-#if defined(_NEWLIB_VERSION) && (__NEWLIB__ < 2 || __NEWLIB__ == 2 && __NEWLIB_MINOR__ < 2)
+#if defined(_NEWLIB_VERSION) && (__NEWLIB__ < 2 || __NEWLIB__ == 2 && __NEWLIB_MINOR__ < 1)
 static inline char * utoa(unsigned int val, char *buf, int radix) __attribute__((always_inline, unused));
 static inline char * utoa(unsigned int val, char *buf, int radix) { return ultoa(val, buf, radix); }
 static inline char * itoa(int val, char *buf, int radix) __attribute__((always_inline, unused));


### PR DESCRIPTION
__NEWLIB_MINOR__ was set to 1 as of the release of newlib 2.2.0. It was updated to 2 once 2.2.0 was released and therefore was not included in a release until 2.2.1 was released.