### PR TITLE
#460 Add Teensy4.0 Continuous DMA Support

### DIFF
--- a/teensy4/DMAChannel.h
+++ b/teensy4/DMAChannel.h
@@ -490,31 +490,11 @@ public:
 	// it will move data as rapidly as possible, without waiting.
 	// Normally this would be used with disableOnCompletion().
 	void triggerContinuously(void) {
-		// TODO: update this for IMXRT.  On Kinetis, a small handful
-		// of DMAMUX slots were dedicated to "always on".  On IMXRT,
-		// all of them can work as "always on" by setting their
-		// DMAMUX_CHCFG_A_ON bit.
-#if 0
-		volatile uint8_t *mux = (volatile uint8_t *)&DMAMUX0_CHCFG0;
-		mux[channel] = 0;
-#if DMAMUX_NUM_SOURCE_ALWAYS >= DMA_NUM_CHANNELS
-		mux[channel] = DMAMUX_SOURCE_ALWAYS0 + channel;	
-#else
-		// search for an unused "always on" source
-		unsigned int i = DMAMUX_SOURCE_ALWAYS0;
-		for (i = DMAMUX_SOURCE_ALWAYS0;
-		  i < DMAMUX_SOURCE_ALWAYS0 + DMAMUX_NUM_SOURCE_ALWAYS; i++) {
-			unsigned int ch;
-			for (ch=0; ch < DMA_NUM_CHANNELS; ch++) {
-				if (mux[ch] == i) break;
-			}
-			if (ch >= DMA_NUM_CHANNELS) {
-				mux[channel] = (i | DMAMUX_ENABLE);
-				return;
-			}
-		}
-#endif
-#endif
+		// On IMXRT, all DMAMUX channels can work as "always on" by
+		// setting their DMAMUX_CHCFG_A_ON bit (and enabling).
+		volatile uint32_t *mux = &DMAMUX_CHCFG0 + channel;
+		*mux = 0;
+		*mux = DMAMUX_CHCFG_A_ON | DMAMUX_CHCFG_ENBL;
 	}
 
 	// Manually trigger the DMA channel.


### PR DESCRIPTION
There was a TODO to add continuous DMA triggering in the Teensy4.0 DMA Channel, needed this in a project so thought it would be worth while making a little PR to get it added to the main repo. 

Cheers for a great platform and toolset btw :) 