### PR TITLE
T4.x CTS pins - T4.1 add memory chip area to Serial ports.

### DIFF
--- a/teensy4/HardwareSerial1.cpp
+++ b/teensy4/HardwareSerial1.cpp
@@ -56,8 +56,13 @@ static BUFTYPE rx_buffer1[SERIAL1_RX_BUFFER_SIZE];
 const HardwareSerial::hardware_t UART6_Hardware = {
 	0, IRQ_LPUART6, &IRQHandler_Serial1, &serial_event_check_serial1,
 	CCM_CCGR3, CCM_CCGR3_LPUART6(CCM_CCGR_ON),
+	#if defined(ARDUINO_TEENSY41)
+	{{0,2, &IOMUXC_LPUART6_RX_SELECT_INPUT, 1}, {52, 2, &IOMUXC_LPUART6_RX_SELECT_INPUT, 0}},
+	{{1,2, &IOMUXC_LPUART6_TX_SELECT_INPUT, 0}, {53, 2, nullptr, 0}},
+	#else
 	{{0,2, &IOMUXC_LPUART6_RX_SELECT_INPUT, 1}, {0xff, 0xff, nullptr, 0}},
-	{{1,2, nullptr, 0}, {0xff, 0xff, nullptr, 0}},
+	{{1,2, &IOMUXC_LPUART6_TX_SELECT_INPUT, 1}, {0xff, 0xff, nullptr, 0}},
+	#endif
 	0xff, // No CTS pin
 	0, // No CTS
 	IRQ_PRIORITY, 38, 24, // IRQ, rts_low_watermark, rts_high_watermark

--- a/teensy4/HardwareSerial2.cpp
+++ b/teensy4/HardwareSerial2.cpp
@@ -63,7 +63,7 @@ static HardwareSerial::hardware_t UART4_Hardware = {
 	{{7,2, nullptr, 0}, {0xff, 0xff, nullptr, 0}},
 	#elif defined(__IMXRT1062__)
 	{{7,2, &IOMUXC_LPUART4_RX_SELECT_INPUT, 2}, {0xff, 0xff, nullptr, 0}},
-	{{8,2, nullptr, 0}, {0xff, 0xff, nullptr, 0}},
+	{{8,2, &IOMUXC_LPUART4_TX_SELECT_INPUT, 2}, {0xff, 0xff, nullptr, 0}},
 	#endif
 	0xff, // No CTS pin
 	0, // No CTS

--- a/teensy4/HardwareSerial3.cpp
+++ b/teensy4/HardwareSerial3.cpp
@@ -57,7 +57,7 @@ static HardwareSerial::hardware_t UART2_Hardware = {
 	2, IRQ_LPUART2, &IRQHandler_Serial3, &serial_event_check_serial3, 
 	CCM_CCGR0, CCM_CCGR0_LPUART2(CCM_CCGR_ON),
 	{{15,2, &IOMUXC_LPUART2_RX_SELECT_INPUT, 1}, {0xff, 0xff, nullptr, 0}},
-	{{14,2, nullptr, 0}, {0xff, 0xff, nullptr, 0}},
+	{{14,2, &IOMUXC_LPUART2_TX_SELECT_INPUT, 1}, {0xff, 0xff, nullptr, 0}},
 	19, //IOMUXC_SW_MUX_CTL_PAD_GPIO_AD_B1_00, // 19
 	2, // page 473 
 	IRQ_PRIORITY, 38, 24, // IRQ, rts_low_watermark, rts_high_watermark

--- a/teensy4/HardwareSerial4.cpp
+++ b/teensy4/HardwareSerial4.cpp
@@ -58,7 +58,7 @@ static HardwareSerial::hardware_t UART3_Hardware = {
 	3, IRQ_LPUART3, &IRQHandler_Serial4, &serial_event_check_serial4,
 	CCM_CCGR0, CCM_CCGR0_LPUART3(CCM_CCGR_ON),
 	{{16,2, &IOMUXC_LPUART3_RX_SELECT_INPUT, 0}, {0xff, 0xff, nullptr, 0}},
-	{{17,2, nullptr, 0}, {0xff, 0xff, nullptr, 0}},
+	{{17,2, &IOMUXC_LPUART3_TX_SELECT_INPUT, 0}, {0xff, 0xff, nullptr, 0}},
 	0xff, // No CTS pin
 	0, // No CTS
 	IRQ_PRIORITY, 38, 24, // IRQ, rts_low_watermark, rts_high_watermark

--- a/teensy4/HardwareSerial5.cpp
+++ b/teensy4/HardwareSerial5.cpp
@@ -60,12 +60,14 @@ static HardwareSerial::hardware_t UART8_Hardware = {
 	#if defined(ARDUINO_TEENSY41)
 	{{21,2, &IOMUXC_LPUART8_RX_SELECT_INPUT, 1}, {46, 2, &IOMUXC_LPUART8_RX_SELECT_INPUT, 0}},
 	{{20,2, &IOMUXC_LPUART8_TX_SELECT_INPUT, 1}, {47, 2, &IOMUXC_LPUART8_TX_SELECT_INPUT, 0}},
+	43, //  CTS pin
+	2, //  CTS
 	#else
 	{{21,2, &IOMUXC_LPUART8_RX_SELECT_INPUT, 1}, {38, 2, &IOMUXC_LPUART8_RX_SELECT_INPUT, 0}},
 	{{20,2, &IOMUXC_LPUART8_TX_SELECT_INPUT, 1}, {39, 2, &IOMUXC_LPUART8_TX_SELECT_INPUT, 0}},
+	35, //  CTS pin
+	2, //  CTS
 	#endif
-	0xff, // No CTS pin
-	0, // No CTS
 	IRQ_PRIORITY, 38, 24, // IRQ, rts_low_watermark, rts_high_watermark
 };
 HardwareSerial Serial5(&IMXRT_LPUART8, &UART8_Hardware, tx_buffer5, SERIAL5_TX_BUFFER_SIZE,

--- a/teensy4/HardwareSerial7.cpp
+++ b/teensy4/HardwareSerial7.cpp
@@ -58,7 +58,7 @@ static HardwareSerial::hardware_t UART7_Hardware = {
 	6, IRQ_LPUART7, &IRQHandler_Serial7, &serial_event_check_serial7,
 	CCM_CCGR5, CCM_CCGR5_LPUART7(CCM_CCGR_ON),
 	{{28,2, &IOMUXC_LPUART7_RX_SELECT_INPUT, 1}, {0xff, 0xff, nullptr, 0}},
-	{{29,2, nullptr, 0}, {0xff, 0xff, nullptr, 0}},
+	{{29,2, &IOMUXC_LPUART7_TX_SELECT_INPUT, 1}, {0xff, 0xff, nullptr, 0}},
 	0xff, // No CTS pin
 	0, // No CTS
 	IRQ_PRIORITY, 38, 24, // IRQ, rts_low_watermark, rts_high_watermark

--- a/teensy4/HardwareSerial8.cpp
+++ b/teensy4/HardwareSerial8.cpp
@@ -59,11 +59,11 @@ static BUFTYPE rx_buffer8[SERIAL8_RX_BUFFER_SIZE];
 static HardwareSerial::hardware_t UART5_Hardware = {
 	7, IRQ_LPUART5, &IRQHandler_Serial8, &serial_event_check_serial8,
 	CCM_CCGR3, CCM_CCGR3_LPUART5(CCM_CCGR_ON),
-    {{34,1, &IOMUXC_LPUART5_RX_SELECT_INPUT, 1}, {0xff, 0xff, nullptr, 0}},
+    {{34,1, &IOMUXC_LPUART5_RX_SELECT_INPUT, 1}, {48, 2, &IOMUXC_LPUART5_RX_SELECT_INPUT, 0}},
     {{35,1, &IOMUXC_LPUART5_TX_SELECT_INPUT, 1}, {0xff, 0xff, nullptr, 0}},
 
-	0xff, // No CTS pin
-	0, // No CTS
+	50, // CTS pin
+	2, //  CTS
 	IRQ_PRIORITY, 38, 24, // IRQ, rts_low_watermark, rts_high_watermark
 };
 HardwareSerial Serial8(&IMXRT_LPUART5, &UART5_Hardware, tx_buffer8, SERIAL8_TX_BUFFER_SIZE,


### PR DESCRIPTION
A few of the T4 and now T4.1 Serial ports support a CTS pin.  One was previous fixed, added the others to tables.

Also T4.1 has Some Serial port pins in the area that the optional memory chips could be installed.

Part of the table updates came from an earlier PR, for the input select pins for the TX pins.  

Note: I have not tested these new pins as don't have T4.1 with these pins available. 