### PR TITLE
T4.x AttachCTS and setRX can use XBar pins

### DIFF
--- a/teensy4/HardwareSerial.cpp
+++ b/teensy4/HardwareSerial.cpp
@@ -62,6 +62,10 @@
 
 #define UART_CLOCK 24000000
 
+extern "C" {
+    extern void xbar_connect(unsigned int input, unsigned int output);
+}
+
 #if defined(ARDUINO_TEENSY41)   
 SerialEventCheckingFunctionPointer HardwareSerial::serial_event_handler_checks[8] = {nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr};
 #else
@@ -243,9 +247,9 @@ void HardwareSerial::setRX(uint8_t pin)
 				// new pin - so lets maybe reset the old pin to INPUT? and then set new pin parameters
 				// only change IO pins if done after begin has been called. 
 				if ((hardware->ccm_register & hardware->ccm_value)) {
-				*(portConfigRegister(hardware->rx_pins[rx_pin_index_].pin)) = 5;
+					*(portConfigRegister(hardware->rx_pins[rx_pin_index_].pin)) = 5;
 
-				// now set new pin info.
+					// now set new pin info.
 					*(portControlRegister(hardware->rx_pins[rx_pin_new_index].pin)) =  IOMUXC_PAD_DSE(7) | IOMUXC_PAD_PKE | IOMUXC_PAD_PUE | IOMUXC_PAD_PUS(3) | IOMUXC_PAD_HYS;;
 					*(portConfigRegister(hardware->rx_pins[rx_pin_new_index].pin)) = hardware->rx_pins[rx_pin_new_index].mux_val;
 					if (hardware->rx_pins[rx_pin_new_index].select_input_register) {
@@ -253,7 +257,29 @@ void HardwareSerial::setRX(uint8_t pin)
 					}
 				}		
 				rx_pin_index_ = rx_pin_new_index;
-				break;
+				return;  // done. 
+			}
+		}
+		// If we got to here and did not find a valid pin there.  Maybe see if it is an XBar pin... 
+		for (uint8_t i = 0; i < count_pin_to_xbar_info; i++) {
+			if (pin_to_xbar_info[i].pin == pin) {
+				// So it is an XBAR pin set the XBAR..
+				//Serial.printf("ACTS XB(%d), X(%u %u), MUX:%x\n", i, pin_to_xbar_info[i].xbar_in_index, 
+				//			hardware->xbar_out_lpuartX_trig_input,  pin_to_xbar_info[i].mux_val);
+				CCM_CCGR2 |= CCM_CCGR2_XBAR1(CCM_CCGR_ON);
+				xbar_connect(pin_to_xbar_info[i].xbar_in_index, hardware->xbar_out_lpuartX_trig_input);
+
+				// We need to update port register to use this as the trigger
+				port->PINCFG = LPUART_PINCFG_TRGSEL(1);  // Trigger select as alternate RX
+
+				//  configure the pin. 
+				*(portControlRegister(pin)) = IOMUXC_PAD_DSE(7) | IOMUXC_PAD_PKE | IOMUXC_PAD_PUE | IOMUXC_PAD_PUS(3) | IOMUXC_PAD_HYS;;
+				*(portConfigRegister(pin)) = pin_to_xbar_info[i].mux_val;
+				port->MODIR |= LPUART_MODIR_TXCTSE;
+				if (pin_to_xbar_info[i].select_input_register) *(pin_to_xbar_info[i].select_input_register) = pin_to_xbar_info[i].select_val;
+				//Serial.printf("SerialX::begin stat:%x ctrl:%x fifo:%x water:%x\n", port->STAT, port->CTRL, port->FIFO, port->WATER );
+				//Serial.printf("  PINCFG: %x MODIR: %x\n", port->PINCFG, port->MODIR);	
+				return;
 			}
 		}
 	}
@@ -315,6 +341,30 @@ bool HardwareSerial::attachCts(uint8_t pin)
 		port->MODIR |= LPUART_MODIR_TXCTSE;
 		return true;
 	} else {
+		// See maybe this a pin we can use XBAR for.
+		for (uint8_t i = 0; i < count_pin_to_xbar_info; i++) {
+			if (pin_to_xbar_info[i].pin == pin) {
+				// So it is an XBAR pin set the XBAR..
+				//Serial.printf("ACTS XB(%d), X(%u %u), MUX:%x\n", i, pin_to_xbar_info[i].xbar_in_index, 
+				//			hardware->xbar_out_lpuartX_trig_input,  pin_to_xbar_info[i].mux_val);
+				CCM_CCGR2 |= CCM_CCGR2_XBAR1(CCM_CCGR_ON);
+				xbar_connect(pin_to_xbar_info[i].xbar_in_index, hardware->xbar_out_lpuartX_trig_input);
+
+				// We need to update port register to use this as the trigger
+				port->PINCFG = LPUART_PINCFG_TRGSEL(2);  // Trigger select as alternate CTS pin
+
+				//  configure the pin. 
+				*(portControlRegister(pin)) = IOMUXC_PAD_DSE(7) | IOMUXC_PAD_PKE | IOMUXC_PAD_PUE | IOMUXC_PAD_PUS(0) | IOMUXC_PAD_HYS;
+				*(portConfigRegister(pin)) = pin_to_xbar_info[i].mux_val;
+				if (pin_to_xbar_info[i].select_input_register) *(pin_to_xbar_info[i].select_input_register) = pin_to_xbar_info[i].select_val;
+				port->MODIR |= LPUART_MODIR_TXCTSE;
+
+				//Serial.printf("SerialX::begin stat:%x ctrl:%x fifo:%x water:%x\n", port->STAT, port->CTRL, port->FIFO, port->WATER );
+				//Serial.printf("  PINCFG: %x MODIR: %x\n", port->PINCFG, port->MODIR);	
+				return true;
+			}
+		}
+		// Fell through so not valid pin for this. 
 		port->MODIR &= ~LPUART_MODIR_TXCTSE;
 		return false;
 	}
@@ -578,3 +628,40 @@ void HardwareSerial::disableSerialEvents()
 		serial_event_handlers_active--;
 	}
 }
+
+
+const pin_to_xbar_info_t PROGMEM pin_to_xbar_info[] = {
+	{0,  17, 1, &IOMUXC_XBAR1_IN17_SELECT_INPUT, 0x1},
+	{1,  16, 1, nullptr, 0},
+	{2,   6, 3, &IOMUXC_XBAR1_IN06_SELECT_INPUT, 0x0},
+	{3,   7, 3, &IOMUXC_XBAR1_IN07_SELECT_INPUT, 0x0},
+	{4,   8, 3, &IOMUXC_XBAR1_IN08_SELECT_INPUT, 0x0},
+	{5,  17, 3, &IOMUXC_XBAR1_IN17_SELECT_INPUT, 0x0},
+	{7,  15, 1, nullptr, 0 },
+	{8,  14, 1, nullptr, 0},
+	{30, 23, 1, &IOMUXC_XBAR1_IN23_SELECT_INPUT, 0x0},
+	{31, 22, 1, &IOMUXC_XBAR1_IN22_SELECT_INPUT, 0x0},
+	{32, 10, 1, nullptr, 0},
+	{33,  9, 3, &IOMUXC_XBAR1_IN09_SELECT_INPUT, 0x0},
+
+#ifdef ARDUINO_TEENSY41
+	{36, 16, 1, nullptr, 0},
+	{37, 17, 1, &IOMUXC_XBAR1_IN17_SELECT_INPUT, 0x3},
+	{42,  7, 3, &IOMUXC_XBAR1_IN07_SELECT_INPUT, 0x1},
+	{43,  6, 3, &IOMUXC_XBAR1_IN06_SELECT_INPUT, 0x1},
+	{44,  5, 3, &IOMUXC_XBAR1_IN05_SELECT_INPUT, 0x1},
+	{45,  4, 3, &IOMUXC_XBAR1_IN04_SELECT_INPUT, 0x1},
+	{46,  9, 3, &IOMUXC_XBAR1_IN09_SELECT_INPUT, 0x1},
+	{47,  8, 3, &IOMUXC_XBAR1_IN08_SELECT_INPUT, 0x1}
+#else	
+	{34,  7, 3, &IOMUXC_XBAR1_IN07_SELECT_INPUT, 0x1},
+	{35,  6, 3, &IOMUXC_XBAR1_IN06_SELECT_INPUT, 0x1},
+	{36,  5, 3, &IOMUXC_XBAR1_IN05_SELECT_INPUT, 0x1},
+	{37,  4, 3, &IOMUXC_XBAR1_IN04_SELECT_INPUT, 0x1},
+	{38,  9, 3, &IOMUXC_XBAR1_IN09_SELECT_INPUT, 0x1},
+	{39,  8, 3, &IOMUXC_XBAR1_IN08_SELECT_INPUT, 0x1}
+#endif
+};
+
+const uint8_t PROGMEM count_pin_to_xbar_info = sizeof(pin_to_xbar_info)/sizeof(pin_to_xbar_info[0]);
+

--- a/teensy4/HardwareSerial.h
+++ b/teensy4/HardwareSerial.h
@@ -125,6 +125,23 @@ extern "C" {
 	#endif
 }
 
+//===================================================================
+// Should find a good home for this
+// Map IO pin to XBar pin... 
+//===================================================================
+// BUGBUG - find a good home
+typedef struct _pin_to_xbar_info{
+	const uint8_t 		pin;		// The pin number
+	const uint8_t		xbar_in_index; // What XBar input index. 
+	const uint32_t 		mux_val;	// Value to set for mux;
+	volatile uint32_t	*select_input_register; // Which register controls the selection
+	const uint32_t		select_val;	// Value for that selection
+} pin_to_xbar_info_t;
+
+extern const pin_to_xbar_info_t pin_to_xbar_info[];
+extern const uint8_t count_pin_to_xbar_info;
+
+
 typedef void(*SerialEventCheckingFunctionPointer)();
 
 class HardwareSerial : public Stream
@@ -153,6 +170,7 @@ public:
 		const uint16_t irq_priority;
 		const uint16_t rts_low_watermark;
 		const uint16_t rts_high_watermark;
+		const uint8_t xbar_out_lpuartX_trig_input;
 	} hardware_t;
 public:
 	constexpr HardwareSerial(IMXRT_LPUART_t *myport, const hardware_t *myhardware, 

--- a/teensy4/HardwareSerial1.cpp
+++ b/teensy4/HardwareSerial1.cpp
@@ -1,3 +1,4 @@
+
 /* Teensyduino Core Library
  * http://www.pjrc.com/teensy/
  * Copyright (c) 2019 PJRC.COM, LLC.
@@ -66,6 +67,7 @@ const HardwareSerial::hardware_t UART6_Hardware = {
 	0xff, // No CTS pin
 	0, // No CTS
 	IRQ_PRIORITY, 38, 24, // IRQ, rts_low_watermark, rts_high_watermark
+	XBARA1_OUT_LPUART6_TRG_INPUT	// XBar Tigger 
 };
 HardwareSerial Serial1(&IMXRT_LPUART6, &UART6_Hardware, tx_buffer1, SERIAL1_TX_BUFFER_SIZE,
 	rx_buffer1,  SERIAL1_RX_BUFFER_SIZE);

--- a/teensy4/HardwareSerial2.cpp
+++ b/teensy4/HardwareSerial2.cpp
@@ -68,6 +68,7 @@ static HardwareSerial::hardware_t UART4_Hardware = {
 	0xff, // No CTS pin
 	0, // No CTS
 	IRQ_PRIORITY, 38, 24, // IRQ, rts_low_watermark, rts_high_watermark
+	XBARA1_OUT_LPUART4_TRG_INPUT
 };
 HardwareSerial Serial2(&IMXRT_LPUART4, &UART4_Hardware, tx_buffer2, SERIAL2_TX_BUFFER_SIZE, 
 	rx_buffer2,  SERIAL2_RX_BUFFER_SIZE);

--- a/teensy4/HardwareSerial3.cpp
+++ b/teensy4/HardwareSerial3.cpp
@@ -61,6 +61,7 @@ static HardwareSerial::hardware_t UART2_Hardware = {
 	19, //IOMUXC_SW_MUX_CTL_PAD_GPIO_AD_B1_00, // 19
 	2, // page 473 
 	IRQ_PRIORITY, 38, 24, // IRQ, rts_low_watermark, rts_high_watermark
+	XBARA1_OUT_LPUART2_TRG_INPUT
 };
 HardwareSerial Serial3(&IMXRT_LPUART2, &UART2_Hardware,tx_buffer3, SERIAL3_TX_BUFFER_SIZE,
 	rx_buffer3,  SERIAL3_RX_BUFFER_SIZE);

--- a/teensy4/HardwareSerial4.cpp
+++ b/teensy4/HardwareSerial4.cpp
@@ -62,6 +62,7 @@ static HardwareSerial::hardware_t UART3_Hardware = {
 	0xff, // No CTS pin
 	0, // No CTS
 	IRQ_PRIORITY, 38, 24, // IRQ, rts_low_watermark, rts_high_watermark
+	XBARA1_OUT_LPUART3_TRG_INPUT
 };
 HardwareSerial Serial4(&IMXRT_LPUART3, &UART3_Hardware, tx_buffer4, SERIAL4_TX_BUFFER_SIZE,
 	rx_buffer4,  SERIAL4_RX_BUFFER_SIZE);

--- a/teensy4/HardwareSerial5.cpp
+++ b/teensy4/HardwareSerial5.cpp
@@ -69,6 +69,7 @@ static HardwareSerial::hardware_t UART8_Hardware = {
 	2, //  CTS
 	#endif
 	IRQ_PRIORITY, 38, 24, // IRQ, rts_low_watermark, rts_high_watermark
+	XBARA1_OUT_LPUART8_TRG_INPUT
 };
 HardwareSerial Serial5(&IMXRT_LPUART8, &UART8_Hardware, tx_buffer5, SERIAL5_TX_BUFFER_SIZE,
 	rx_buffer5,  SERIAL5_RX_BUFFER_SIZE);

--- a/teensy4/HardwareSerial6.cpp
+++ b/teensy4/HardwareSerial6.cpp
@@ -62,7 +62,7 @@ static HardwareSerial::hardware_t UART1_Hardware = {
 	0xff, // No CTS pin
 	0, // No CTS
 	IRQ_PRIORITY, 38, 24, // IRQ, rts_low_watermark, rts_high_watermark
-
+	XBARA1_OUT_LPUART1_TRG_INPUT
 };
 
 HardwareSerial Serial6(&IMXRT_LPUART1, &UART1_Hardware, tx_buffer6, SERIAL6_TX_BUFFER_SIZE,

--- a/teensy4/HardwareSerial7.cpp
+++ b/teensy4/HardwareSerial7.cpp
@@ -62,6 +62,7 @@ static HardwareSerial::hardware_t UART7_Hardware = {
 	0xff, // No CTS pin
 	0, // No CTS
 	IRQ_PRIORITY, 38, 24, // IRQ, rts_low_watermark, rts_high_watermark
+	XBARA1_OUT_LPUART7_TRG_INPUT
 };
 HardwareSerial Serial7(&IMXRT_LPUART7, &UART7_Hardware, tx_buffer7, SERIAL7_TX_BUFFER_SIZE,
 	rx_buffer7,  SERIAL7_RX_BUFFER_SIZE);

--- a/teensy4/HardwareSerial8.cpp
+++ b/teensy4/HardwareSerial8.cpp
@@ -65,6 +65,7 @@ static HardwareSerial::hardware_t UART5_Hardware = {
 	50, // CTS pin
 	2, //  CTS
 	IRQ_PRIORITY, 38, 24, // IRQ, rts_low_watermark, rts_high_watermark
+	XBARA1_OUT_LPUART5_TRG_INPUT
 };
 HardwareSerial Serial8(&IMXRT_LPUART5, &UART5_Hardware, tx_buffer8, SERIAL8_TX_BUFFER_SIZE,
 	rx_buffer8,  SERIAL8_RX_BUFFER_SIZE);


### PR DESCRIPTION
As there are very very available pins to be used directly as CTS (and
alternate RX pins) and the IMXRT 1062s processor has the ability to
use XBAR pins for these functions.  As per a question from Paul,
I went and implemented it.

I added a pin to xbar mapping table to Hardware Serial.  In actuality
it could be moved to some place more generic as the table is not
specific to SerialX.  Currently the table looks like:

```
//===================================================================
// Should find a good home for this
// Map IO pin to XBar pin...
//===================================================================
// BUGBUG - find a good home
typedef struct _pin_to_xbar_info{
	const uint8_t 		pin;		// The pin number
	const uint8_t		xbar_in_index; // What XBar
	input index.
	const uint32_t 		mux_val;	// Value to set for mux;
	volatile uint32_t	*select_input_register; // Which
		register controls the selection
	const uint32_t	select_val;	// Value for that selection
} pin_to_xbar_info_t;
```
The table for T4 and 4.1 looks like:
```
const pin_to_xbar_info_t PROGMEM pin_to_xbar_info[] = {
{0,  17, 1, &IOMUXC_XBAR1_IN17_SELECT_INPUT, 0x1},
{1,  16, 1, nullptr, 0},
{2,   6, 3, &IOMUXC_XBAR1_IN06_SELECT_INPUT, 0x0},
{3,   7, 3, &IOMUXC_XBAR1_IN07_SELECT_INPUT, 0x0},
{4,   8, 3, &IOMUXC_XBAR1_IN08_SELECT_INPUT, 0x0},
{5,  17, 3, &IOMUXC_XBAR1_IN17_SELECT_INPUT, 0x0},
{7,  15, 1, nullptr, 0 },
{8,  14, 1, nullptr, 0},
{30, 23, 1, &IOMUXC_XBAR1_IN23_SELECT_INPUT, 0x0},
{31, 22, 1, &IOMUXC_XBAR1_IN22_SELECT_INPUT, 0x0},
{32, 10, 1, nullptr, 0},
{33,  9, 3, &IOMUXC_XBAR1_IN09_SELECT_INPUT, 0x0},
{36, 16, 1, nullptr, 0},
{37, 17, 1, &IOMUXC_XBAR1_IN17_SELECT_INPUT, 0x3},
{42,  7, 3, &IOMUXC_XBAR1_IN07_SELECT_INPUT, 0x1},
{43,  6, 3, &IOMUXC_XBAR1_IN06_SELECT_INPUT, 0x1},
{44,  5, 3, &IOMUXC_XBAR1_IN05_SELECT_INPUT, 0x1},
{45,  4, 3, &IOMUXC_XBAR1_IN04_SELECT_INPUT, 0x1},
{46,  9, 3, &IOMUXC_XBAR1_IN09_SELECT_INPUT, 0x1},
{47,  8, 3, &IOMUXC_XBAR1_IN08_SELECT_INPUT, 0x1}
{34,  7, 3, &IOMUXC_XBAR1_IN07_SELECT_INPUT, 0x1},
{35,  6, 3, &IOMUXC_XBAR1_IN06_SELECT_INPUT, 0x1},
{36,  5, 3, &IOMUXC_XBAR1_IN05_SELECT_INPUT, 0x1},
{37,  4, 3, &IOMUXC_XBAR1_IN04_SELECT_INPUT, 0x1},
{38,  9, 3, &IOMUXC_XBAR1_IN09_SELECT_INPUT, 0x1},
{39,  8, 3, &IOMUXC_XBAR1_IN08_SELECT_INPUT, 0x1}
};
```
The code for both attachCts as well as setRX were updated, to
first look to see if the pin matches one that is specifically
is a CTS pin (or RX), then it uses the LPUart system directly,
if not it runs through this list to see if there is a mapping
to pin to an XBar pin, and then configures the Serial system to
use the specified pin as the trigger pin, plus setup XBar to map,
the Xbar pin to the Trigger pin value defined for that LPuart, and
does the stuff to configure that pin for the functionality.

We should note that each XBar signal(?) may map to multiple IO pins,
and only one of them can be used per sketch as XBar pin, example the
signal 17 maps to pins: 0, 5 and T4.1 37.

Also each LPUart has only one trigger value, so you can only use it
for either Cts or RX (or neither).