### PR TITLE
Fix/Add seralEventUSB1 and serialEventUSB2

### DIFF
--- a/teensy3/core_pins.h
+++ b/teensy3/core_pins.h
@@ -2000,9 +2000,11 @@ void _restart_Teensyduino_(void) __attribute__((noreturn));
 // Probably should be in a better spot.  
 extern uint8_t yield_active_check_flags;
 
-#define YIELD_CHECK_USB_SERIAL 		0x1   // check the USB for Serial.available()
+#define YIELD_CHECK_USB_SERIAL 		0x1   	// check the USB for Serial.available()
 #define YIELD_CHECK_HARDWARE_SERIAL 0x2		// check Hardware Serial ports available
 #define YIELD_CHECK_EVENT_RESPONDER	0x4		// User has created eventResponders that use yield
+#define YIELD_CHECK_USB_SERIALUSB1  0x8		// Check for SerialUSB1
+#define YIELD_CHECK_USB_SERIALUSB2  0x10	// Check for SerialUSB2
 
 void yield(void);
 

--- a/teensy3/serialEventUSB1.cpp
+++ b/teensy3/serialEventUSB1.cpp
@@ -1,0 +1,5 @@
+
+#include <Arduino.h>
+void serialEventUSB1() __attribute__((weak));
+void serialEventUSB1() {}
+uint8_t _serialEventUSB1_default PROGMEM = 1;	

--- a/teensy3/serialEventUSB2.cpp
+++ b/teensy3/serialEventUSB2.cpp
@@ -1,0 +1,5 @@
+
+#include <Arduino.h>
+void serialEventUSB2() __attribute__((weak));
+void serialEventUSB2() {}
+uint8_t _serialEventUSB2_default PROGMEM = 1;	

--- a/teensy3/usb_inst.cpp
+++ b/teensy3/usb_inst.cpp
@@ -97,10 +97,3 @@ usb_seremu_class Serial;
 #endif
 
 #endif // F_CPU
-
-//void serialEvent() __attribute__((weak));
-//void serialEvent() {}
-void serialEventUSB1() __attribute__((weak));
-void serialEventUSB1() {}
-void serialEventUSB2() __attribute__((weak));
-void serialEventUSB2() {}

--- a/teensy3/yield.cpp
+++ b/teensy3/yield.cpp
@@ -33,11 +33,17 @@
 
 #ifdef USB_TRIPLE_SERIAL
 uint8_t yield_active_check_flags = YIELD_CHECK_USB_SERIAL | YIELD_CHECK_USB_SERIALUSB1 | YIELD_CHECK_USB_SERIALUSB2; // default to check USB.
+extern const uint8_t _serialEventUSB2_default;	
+extern const uint8_t _serialEventUSB1_default;	
+
 #elif defined(USB_DUAL_SERIAL)
 uint8_t yield_active_check_flags = YIELD_CHECK_USB_SERIAL | YIELD_CHECK_USB_SERIALUSB1; // default to check USB.
+extern const uint8_t _serialEventUSB1_default;	
+
 #else
 uint8_t yield_active_check_flags = YIELD_CHECK_USB_SERIAL; // default to check USB.
 #endif
+
 extern const uint8_t _serialEvent_default;	
 
 void yield(void) __attribute__ ((weak));
@@ -64,7 +70,7 @@ void yield(void)
 #endif
 #ifdef USB_TRIPLE_SERIAL
 	if (yield_active_check_flags & YIELD_CHECK_USB_SERIALUSB2) {
-		if (SerialUSB1.available()) serialEventUSB1();
+		if (SerialUSB2.available()) serialEventUSB2();
 		if (_serialEventUSB2_default) yield_active_check_flags &= ~YIELD_CHECK_USB_SERIALUSB2;
 	}
 #endif

--- a/teensy4/EventResponder.cpp
+++ b/teensy4/EventResponder.cpp
@@ -43,6 +43,8 @@ bool EventResponder::runningFromYield = false;
 // TODO: interrupt disable/enable needed in many places!!!
 // BUGBUG: See if file name order makes difference?
 uint8_t _serialEvent_default __attribute__((weak)) PROGMEM = 0 ;	
+uint8_t _serialEventUSB1_default __attribute__((weak)) PROGMEM = 0 ;	
+uint8_t _serialEventUSB2_default __attribute__((weak)) PROGMEM = 0 ;	
 
 void EventResponder::triggerEventNotImmediate()
 {

--- a/teensy4/core_pins.h
+++ b/teensy4/core_pins.h
@@ -1548,9 +1548,13 @@ void _restart_Teensyduino_(void) __attribute__((noreturn));
 
 // Define a set of flags to know which things yield should check when called. 
 extern uint8_t yield_active_check_flags;
-#define YIELD_CHECK_USB_SERIAL 		0x1   // check the USB for Serial.available()
+
+#define YIELD_CHECK_USB_SERIAL 		0x1   	// check the USB for Serial.available()
 #define YIELD_CHECK_HARDWARE_SERIAL 0x2		// check Hardware Serial ports available
 #define YIELD_CHECK_EVENT_RESPONDER	0x4		// User has created eventResponders that use yield
+#define YIELD_CHECK_USB_SERIALUSB1  0x8		// Check for SerialUSB1
+#define YIELD_CHECK_USB_SERIALUSB2  0x10	// Check for SerialUSB2
+
 void yield(void);
 
 void delay(uint32_t msec);

--- a/teensy4/serialEventUSB1.cpp
+++ b/teensy4/serialEventUSB1.cpp
@@ -1,0 +1,5 @@
+
+#include <Arduino.h>
+void serialEventUSB1() __attribute__((weak));
+void serialEventUSB1() {}
+uint8_t _serialEventUSB1_default PROGMEM = 1;	

--- a/teensy4/serialEventUSB2.cpp
+++ b/teensy4/serialEventUSB2.cpp
@@ -1,0 +1,5 @@
+
+#include <Arduino.h>
+void serialEventUSB2() __attribute__((weak));
+void serialEventUSB2() {}
+uint8_t _serialEventUSB2_default PROGMEM = 1;	


### PR DESCRIPTION
The code for T3.x was broken, especially for USB2...

And the code was not setup for T4.x.  So added it.

As @Defragster discovered  and noted in (#474) the USB1 and USB2 code was not in place in the yield code for T4.x so I added it.  

I also found parts of it were missing/wrong for T3.x  so fixed it. 

Had a quick and dirty test sketch that I tested both on with Single, DUAL and Triple serial.  Also where I would rename each of the serial event functions and verify that the event processing flags would properly change. 

```
#include <SPI.h>
void setup() {
  while (!Serial && millis() < 4000) ;  // wait for Serial port
  Serial.begin(115200);
  extern const uint8_t _serialEvent_default;
  extern const uint8_t _serialEventUSB1_default;
  extern const uint8_t _serialEventUSB2_default;
  Serial.printf("Default serialEvent? %d %d %d\n", _serialEvent_default,
                _serialEventUSB1_default, _serialEventUSB2_default);
  Serial.printf("start test yield_active_check_flags %x\n", yield_active_check_flags);

}

void TimeYieldCalls(const char *sz) {
  yield();
  Serial.print(sz); Serial.flush();
  elapsedMicros em = 0;
  for (uint32_t i = 0; i < 1000; i++) yield();
  uint32_t elapsed = em;
  Serial.print(": ");
  Serial.println(elapsed, DEC);
  Serial.flush();
}

void loop() {
}

void serialEvent() {
  Serial.print("Serial: ");
  while (SerialUSB.available())
    Serial.write(Serial.read());
  Serial.println();
}
#if defined(USB_TRIPLE_SERIAL) || defined(USB_DUAL_SERIAL)
void serialEventUSB1() {
  Serial.print("SerialUSB1: ");
  while (SerialUSB1.available())
    Serial.write(SerialUSB1.read());
  Serial.println();
}
#endif
#if defined(USB_TRIPLE_SERIAL)
void serialEventUSB2() {
  Serial.print("SerialUSB2: ");
  while (SerialUSB2.available())
    Serial.write(SerialUSB2.read());
  Serial.println();
}
#endif
```
