### PR TITLE
Add Keyboard report buffer.

### DIFF
--- a/teensy3/AudioStream.cpp
+++ b/teensy3/AudioStream.cpp
@@ -320,9 +320,13 @@ void software_isr(void) // AudioStream::update_all()
 {
 	AudioStream *p;
 
+#if defined(KINETISK)
 	ARM_DEMCR |= ARM_DEMCR_TRCENA;
 	ARM_DWT_CTRL |= ARM_DWT_CTRL_CYCCNTENA;
 	uint32_t totalcycles = ARM_DWT_CYCCNT;
+#elif defined(KINETISL)
+	uint32_t totalcycles = micros();
+#endif
 	//digitalWriteFast(2, HIGH);
 	for (p = AudioStream::first_update; p; p = p->next_update) {
 		if (p->active) {
@@ -336,7 +340,11 @@ void software_isr(void) // AudioStream::update_all()
 		}
 	}
 	//digitalWriteFast(2, LOW);
-	totalcycles = (ARM_DWT_CYCCNT - totalcycles) >> 4;;
+#if defined(KINETISK)
+	totalcycles = (ARM_DWT_CYCCNT - totalcycles) >> 4;
+#elif defined(KINETISL)
+	totalcycles = micros() - totalcycles;
+#endif
 	AudioStream::cpu_cycles_total = totalcycles;
 	if (totalcycles > AudioStream::cpu_cycles_total_max)
 		AudioStream::cpu_cycles_total_max = totalcycles;

--- a/teensy3/AudioStream.h
+++ b/teensy3/AudioStream.h
@@ -114,7 +114,11 @@ protected:
 	AudioStream::initialize_memory(data, num); \
 })
 
+#if defined(KINETISK)
 #define CYCLE_COUNTER_APPROX_PERCENT(n) (((n) + (F_CPU / 32 / AUDIO_SAMPLE_RATE * AUDIO_BLOCK_SAMPLES / 100)) / (F_CPU / 16 / AUDIO_SAMPLE_RATE * AUDIO_BLOCK_SAMPLES / 100))
+#elif defined(KINETISL)
+#define CYCLE_COUNTER_APPROX_PERCENT(n) ((n) * (int)(AUDIO_SAMPLE_RATE) + (int)(AUDIO_SAMPLE_RATE/2)) / (AUDIO_BLOCK_SAMPLES * 10000)
+#endif
 
 #define AudioProcessorUsage() (CYCLE_COUNTER_APPROX_PERCENT(AudioStream::cpu_cycles_total))
 #define AudioProcessorUsageMax() (CYCLE_COUNTER_APPROX_PERCENT(AudioStream::cpu_cycles_total_max))

--- a/usb_hid/usb_api.cpp
+++ b/usb_hid/usb_api.cpp
@@ -179,17 +179,17 @@ KEYCODE_TYPE usb_keyboard_class::deadkey_to_keycode(KEYCODE_TYPE keycode)
 //
 void usb_keyboard_class::write_key(KEYCODE_TYPE keycode)
 {
-	keyboard_report_data[0] = keycode_to_modifier(keycode);
-	keyboard_report_data[1] = 0;
-	keyboard_report_data[2] = keycode_to_key(keycode);
-	keyboard_report_data[3] = 0;
-	keyboard_report_data[4] = 0;
-	keyboard_report_data[5] = 0;
-	keyboard_report_data[6] = 0;
-	keyboard_report_data[7] = 0;
+	keyboard_report_buffer[0] = keycode_to_modifier(keycode);
+	keyboard_report_buffer[1] = 0;
+	keyboard_report_buffer[2] = keycode_to_key(keycode);
+	keyboard_report_buffer[3] = 0;
+	keyboard_report_buffer[4] = 0;
+	keyboard_report_buffer[5] = 0;
+	keyboard_report_buffer[6] = 0;
+	keyboard_report_buffer[7] = 0;
 	send_now();
-	keyboard_report_data[0] = 0;
-	keyboard_report_data[2] = 0;
+	keyboard_report_buffer[0] = 0;
+	keyboard_report_buffer[2] = 0;
 	send_now();
 }
 
@@ -222,31 +222,31 @@ uint8_t usb_keyboard_class::keycode_to_key(KEYCODE_TYPE keycode)
 
 void usb_keyboard_class::set_modifier(uint16_t c)
 {
-	keyboard_report_data[0] = (uint8_t)c;
+	keyboard_report_buffer[0] = (uint8_t)c;
 }
 void usb_keyboard_class::set_key1(uint8_t c)
 {
-	keyboard_report_data[2] = c;
+	keyboard_report_buffer[2] = c;
 }
 void usb_keyboard_class::set_key2(uint8_t c)
 {
-	keyboard_report_data[3] = c;
+	keyboard_report_buffer[3] = c;
 }
 void usb_keyboard_class::set_key3(uint8_t c)
 {
-	keyboard_report_data[4] = c;
+	keyboard_report_buffer[4] = c;
 }
 void usb_keyboard_class::set_key4(uint8_t c)
 {
-	keyboard_report_data[5] = c;
+	keyboard_report_buffer[5] = c;
 }
 void usb_keyboard_class::set_key5(uint8_t c)
 {
-	keyboard_report_data[6] = c;
+	keyboard_report_buffer[6] = c;
 }
 void usb_keyboard_class::set_key6(uint8_t c)
 {
-	keyboard_report_data[7] = c;
+	keyboard_report_buffer[7] = c;
 }
 
 
@@ -272,14 +272,14 @@ void usb_keyboard_class::send_now(void)
                 cli();
                 UENUM = KEYBOARD_ENDPOINT;
         }
-        UEDATX = keyboard_report_data[0];
-        UEDATX = keyboard_report_data[1];
-        UEDATX = keyboard_report_data[2];
-        UEDATX = keyboard_report_data[3];
-        UEDATX = keyboard_report_data[4];
-        UEDATX = keyboard_report_data[5];
-        UEDATX = keyboard_report_data[6];
-        UEDATX = keyboard_report_data[7];
+        UEDATX = keyboard_report_data[0] = keyboard_report_buffer[0];
+        UEDATX = keyboard_report_data[1] = keyboard_report_buffer[1];
+        UEDATX = keyboard_report_data[2] = keyboard_report_buffer[2];
+        UEDATX = keyboard_report_data[3] = keyboard_report_buffer[3];
+        UEDATX = keyboard_report_data[4] = keyboard_report_buffer[4];
+        UEDATX = keyboard_report_data[5] = keyboard_report_buffer[5];
+        UEDATX = keyboard_report_data[6] = keyboard_report_buffer[6];
+        UEDATX = keyboard_report_data[7] = keyboard_report_buffer[7];
         UEINTX = 0x3A;
         keyboard_idle_count = 0;
         SREG = intr_state;
@@ -315,9 +315,9 @@ void usb_keyboard_class::press(uint16_t n)
 #ifdef DEADKEYS_MASK
 	KEYCODE_TYPE deadkeycode = deadkey_to_keycode(keycode);
 	if (deadkeycode) {
-		modrestore = keyboard_report_data[0];
+		modrestore = keyboard_report_buffer[0];
 		if (modrestore) {
-			keyboard_report_data[0] = 0;
+			keyboard_report_buffer[0] = 0;
 			send_now();
 		}
 		// TODO: test if operating systems recognize
@@ -370,18 +370,18 @@ void usb_keyboard_class::presskey(uint8_t key, uint8_t modifier)
 	uint8_t i;
 
 	if (modifier) {
-		if ((keyboard_report_data[0] & modifier) != modifier) {
-			keyboard_report_data[0] |= modifier;
+		if ((keyboard_report_buffer[0] & modifier) != modifier) {
+			keyboard_report_buffer[0] |= modifier;
 			send_required = true;
 		}
 	}
 	if (key) {
 		for (i=2; i < 8; i++) {
-			if (keyboard_report_data[i] == key) goto end;
+			if (keyboard_report_buffer[i] == key) goto end;
 		}
 		for (i=2; i < 8; i++) {
-			if (keyboard_report_data[i] == 0) {
-				keyboard_report_data[i] = key;
+			if (keyboard_report_buffer[i] == 0) {
+				keyboard_report_buffer[i] = key;
 				send_required = true;
 				goto end;
 			}
@@ -397,15 +397,15 @@ void usb_keyboard_class::releasekey(uint8_t key, uint8_t modifier)
 	uint8_t i;
 
 	if (modifier) {
-		if ((keyboard_report_data[0] & modifier) != 0) {
-			keyboard_report_data[0] &= ~modifier;
+		if ((keyboard_report_buffer[0] & modifier) != 0) {
+			keyboard_report_buffer[0] &= ~modifier;
 			send_required = true;
 		}
 	}
 	if (key) {
 		for (i=2; i < 8; i++) {
-			if (keyboard_report_data[i] == key) {
-				keyboard_report_data[i] = 0;
+			if (keyboard_report_buffer[i] == key) {
+				keyboard_report_buffer[i] = 0;
 				send_required = true;
 			}
 		}
@@ -417,13 +417,13 @@ void usb_keyboard_class::releaseAll(void)
 {
 	uint8_t i, anybits;
 
-	anybits = keyboard_report_data[0];
+	anybits = keyboard_report_buffer[0];
 	for (i=2; i < 8; i++) {
-		anybits |= keyboard_report_data[i];
-		keyboard_report_data[i] = 0;
+		anybits |= keyboard_report_buffer[i];
+		keyboard_report_buffer[i] = 0;
 	}
 	if (!anybits) return;
-	keyboard_report_data[0] = 0;
+	keyboard_report_buffer[0] = 0;
 	send_now();
 }
 

--- a/usb_hid/usb_private.h
+++ b/usb_hid/usb_private.h
@@ -90,6 +90,7 @@ void usb_shutdown(void);		// shut off USB
 extern volatile uint8_t usb_configuration;
 extern volatile uint8_t usb_suspended;
 extern volatile uint8_t debug_flush_timer;
+uint8_t keyboard_report_buffer[8];
 extern uint8_t keyboard_report_data[];
 extern uint8_t keyboard_idle_count;
 extern volatile uint8_t keyboard_leds;

--- a/usb_serial_hid/usb_private.h
+++ b/usb_serial_hid/usb_private.h
@@ -134,6 +134,7 @@ extern uint8_t transmit_previous_timeout;
 extern volatile uint8_t cdc_line_coding[7];
 extern volatile uint8_t cdc_line_rtsdtr;
 
+uint8_t keyboard_report_buffer[8];
 extern uint8_t keyboard_report_data[];
 extern uint8_t keyboard_idle_count;
 extern volatile uint8_t keyboard_leds;


### PR DESCRIPTION
#### Unexpected behavior:
`Keyboard.set_keyN()` sends keystrokes to the host without calling `Keyboard.send_now()`. Tested on a Teensy 2.0.

#### Example:
`void setup() {}`
`void loop() { Keyboard.set_key1(4); }`

Result: the host sees the device as pressing and holding key 'a'

#### The cause, as I understand it:
`cores/usb_[serial_]hid/usb.c` sends the values of `keyboard_report_data[]` when idling. In `cores/usb_serial_hid/usb.c`, this happens on line 611. That line -- `UEDATX = keyboard_report_data[i]` -- copies the array into the USB transmit buffer. Removing that line prevents the unexpected behavior.

Line 611, however, is the idle handler (lines 603-616) for the start-of-frame handler (lines 587-618), which I vaguely believe is important to retain so that the device can be a good USB HID citizen. Removing this block appears to completely address the unexpected behavior but might cause other behaviors on hosts that expect intermittent updates.

#### My solution:
Add a buffer between `Keyboard.send_now()` and all other `Keyboard` methods. Now, `set_keyN()` and the others will modify `keyboard_report_buffer[N]` instead of `keyboard_report_data[N]`. Then, only when `send_now()` assigns the values of `...buffer[]` to `...data[]` is `usb.c` able to transmit those values to the host.

These changes are identical between `cores/usb_hid` and `cores/usb_serial_hid`.

[1]: https://www.pjrc.com/teensy/td_keyboard.html