### PR TITLE
Fix size of arm_dcache_flush_delte on T4.x USB RAWHID

### DIFF
--- a/teensy4/usb_rawhid.c
+++ b/teensy4/usb_rawhid.c
@@ -136,7 +136,7 @@ int usb_rawhid_send(const void *buffer, uint32_t timeout)
 	}
 	uint8_t *txdata = txbuffer + (tx_head * RAWHID_TX_SIZE);
 	memcpy(txdata, buffer, RAWHID_TX_SIZE);
-	arm_dcache_flush_delete(txdata, SEREMU_TX_SIZE);
+	arm_dcache_flush_delete(txdata, RAWHID_TX_SIZE );
 	usb_prepare_transfer(xfer, txdata, RAWHID_TX_SIZE, 0);
 	usb_transmit(RAWHID_TX_ENDPOINT, xfer);
 	if (++tx_head >= TX_NUM) tx_head = 0;


### PR DESCRIPTION
Was using SEREMU_TX_SIZE should use RAWHID_TX_SIZE