### PR TITLE
Update usb.c so MTP_repsonder can work at 600Mhz

### DIFF
--- a/teensy4/usb.c
+++ b/teensy4/usb.c
@@ -999,7 +999,7 @@ void usb_receive(int endpoint_number, transfer_t *transfer)
 
 uint32_t usb_transfer_status(const transfer_t *transfer)
 {
-#if 0
+#if #ifdef USB_MTPDISK
 	uint32_t status, cmd;
 	//int count=0;
 	cmd = USB1_USBCMD;


### PR DESCRIPTION
Paul
A long time ago @WMXZ came to the conclusion that the reason why we couldn't see files on the pc side (not sure on LINUX) when using the T4.x above about 450Mhz clock speed was because we had to use the alternate test in usb_transfer_status, see post #184, https://forum.pjrc.com/threads/58033-LittleFS-port-to-Teensy-SPIFlash?p=259193&viewfull=1#post259193.  

@defragster came up with a simpler fix so its only active is you are using mtp:
`file: usb.c
function: usb_transfer_status
changed #if 0 to #ifdef USB_MTPDISK` 

So going to propose the change for the next core update.  Hope i did the pr right :)