### PR TITLE
Update usb.c

### DIFF
--- a/teensy4/usb.c
+++ b/teensy4/usb.c
@@ -999,7 +999,7 @@ void usb_receive(int endpoint_number, transfer_t *transfer)
 
 uint32_t usb_transfer_status(const transfer_t *transfer)
 {
-#ifdef USB_MTPDISK
+#if defined(USB_MTPDISK) || defined(USB_MTPDISK_SERIAL)
 	uint32_t status, cmd;
 	//int count=0;
 	cmd = USB1_USBCMD;


### PR DESCRIPTION
To allow future MTP_SERIAL implementations and facilitate use of MTP_t4, that provides possibility of MTP_SERIAL