### PR TITLE
T4 No USB Support

### DIFF
--- a/teensy4/usb.c
+++ b/teensy4/usb.c
@@ -23,6 +23,8 @@
 
 // device mode, page 3155
 
+#if defined(NUM_ENDPOINTS)
+
 typedef struct endpoint_struct endpoint_t;
 
 struct endpoint_struct {
@@ -1019,4 +1021,10 @@ uint32_t usb_transfer_status(const transfer_t *transfer)
 #endif
 }
 
+#else // defined(NUM_ENDPOINTS)
 
+void usb_init(void)
+{
+}
+
+#endif // defined(NUM_ENDPOINTS)

--- a/teensy4/usb_dev.h
+++ b/teensy4/usb_dev.h
@@ -1,6 +1,8 @@
 #pragma once
 #include "imxrt.h"
 
+#if !defined(USB_DISABLED)
+
 typedef struct transfer_struct transfer_t;
 struct transfer_struct {
         uint32_t next;
@@ -39,3 +41,18 @@ extern void (*usb_timer1_callback)(void);
 #ifdef __cplusplus
 }
 #endif
+
+#else // !defined(USB_DISABLED)
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void usb_init(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+
+#endif // !defined(USB_DISABLED)

--- a/teensy4/usb_serial.h
+++ b/teensy4/usb_serial.h
@@ -35,6 +35,8 @@
 
 #if (defined(CDC_STATUS_INTERFACE) && defined(CDC_DATA_INTERFACE)) || defined(USB_DISABLED)
 
+#if !defined(USB_DISABLED)
+
 // C language implementation
 #ifdef __cplusplus
 extern "C" {
@@ -122,6 +124,46 @@ public:
 extern usb_serial_class Serial;
 extern void serialEvent(void);
 #endif // __cplusplus
+
+#else  // !defined(USB_DISABLED)
+
+// Allow Arduino programs using Serial to compile, but Serial will do nothing.
+#ifdef __cplusplus
+#include "Stream.h"
+class usb_serial_class : public Stream
+{
+public:
+    constexpr usb_serial_class() {}
+        void begin(long) { };
+        void end() { };
+        virtual int available() { return 0; }
+        virtual int read() { return -1; }
+        virtual int peek() { return -1; }
+        virtual void flush() { }
+        virtual void clear() { }
+        virtual size_t write(uint8_t c) { return 1; }
+        virtual size_t write(const uint8_t *buffer, size_t size) { return size; }
+    size_t write(unsigned long n) { return 1; }
+    size_t write(long n) { return 1; }
+    size_t write(unsigned int n) { return 1; }
+    size_t write(int n) { return 1; }
+    int availableForWrite() { return 0; }
+    using Print::write;
+        void send_now(void) { }
+        uint32_t baud(void) { return 0; }
+        uint8_t stopbits(void) { return 1; }
+        uint8_t paritytype(void) { return 0; }
+        uint8_t numbits(void) { return 8; }
+        uint8_t dtr(void) { return 1; }
+        uint8_t rts(void) { return 1; }
+        operator bool() { return true; }
+};
+
+extern usb_serial_class Serial;
+extern void serialEvent(void);
+#endif // __cplusplus
+
+#endif // !defined(USB_DISABLED)
 
 #endif // CDC_STATUS_INTERFACE && CDC_DATA_INTERFACE
 


### PR DESCRIPTION
Add support to T4 core to use USB Type: No USB, corresponding lines in boards.txt also need to be uncommented for the option to show up in the menu. This is really a copy and paste from the T3 core implementation of this so nothing major has been changed.