### PR TITLE
Teensy models as string defs

### DIFF
--- a/teensy3/teensy_model.h
+++ b/teensy3/teensy_model.h
@@ -1,0 +1,13 @@
+// This header file is in the public domain.
+
+#if defined( ARDUINO_TEENSY36 )
+#define TEENSY_MODEL "Teensy 3.6"
+#elif defined( ARDUINO_TEENSY35 )
+#define TEENSY_MODEL "Teensy 3.5"
+#elif defined ( ARDUINO_TEENSY32 )
+#define TEENSY_MODEL "Teensy 3.2"
+#elif defined ( ARDUINO_TEENSY30 )
+#define TEENSY_MODEL "Teensy 3.0"
+#elif defined ( ARDUINO_TEENSYLC )
+#define TEENSY_MODEL "Teensy LC"
+#endif

--- a/teensy4/teensy_model.h
+++ b/teensy4/teensy_model.h
@@ -1,0 +1,9 @@
+// This header file is in the public domain.
+
+#if defined( ARDUINO_TEENSY_MICROMOD )
+#define TEENSY_MODEL "Teensy MicroMod"
+#elif defined( ARDUINO_TEENSY41 )
+#define TEENSY_MODEL "Teensy 4.1"
+#elif defined ( ARDUINO_TEENSY40 )
+#define TEENSY_MODEL "Teensy 4.0"
+#endif


### PR DESCRIPTION
Not important, but long standing issue.
Allows to print the Teensy model without adding too much code.
Useful for the MTP-Responder, and perhaps (later) USB-Core to display the correct model.