### PR TITLE
fix -Wdeprecated-copy warning

### DIFF
--- a/teensy3/DMAChannel.h
+++ b/teensy3/DMAChannel.h
@@ -412,6 +412,10 @@ public:
 		copy_tcd(TCD, rhs.TCD);
 		return *this;
 	}
+	const DMASetting & operator = (const DMASetting &rhs) {
+		copy_tcd(TCD, rhs.TCD);
+		return *this;
+	}
 private:
 	TCD_t tcddata __attribute__((aligned(32)));
 };


### PR DESCRIPTION
DMAChannel.h: In copy constructor 'DMASetting::DMASetting(const DMASetting&)':
DMAChannel.h:405:11: warning: implicitly-declared 'constexpr DMASetting& DMASetting::operator=(const DMASetting&)' is deprecated [-Wdeprecated-copy]
  405 |   *this = c;
      |           ^
DMAChannel.h:403:2: note: because 'DMASetting' has user-provided 'DMASetting::DMASetting(const DMASetting&)'
  403 |  DMASetting(const DMASetting &c) {
      |  ^~~~~~~~~~