### PR TITLE
Update mk20dx128.c re FSEC use on 3.5/3.6

### DIFF
--- a/teensy3/mk20dx128.c
+++ b/teensy3/mk20dx128.c
@@ -35,6 +35,7 @@
 
 
 // Flash Security Setting. On Teensy 3.2, you can lock the MK20 chip to prevent
+// ( The same applies to the Teensy 3.5 and Teensy 3.6 for their processors )
 // anyone from reading your code.  You CAN still reprogram your Teensy while
 // security is set, but the bootloader will be unable to respond to auto-reboot
 // requests from Arduino. Pressing the program button will cause a full chip


### PR DESCRIPTION
RE forum post : https://forum.pjrc.com/threads/65070-Teensy-3-6-and-FSEC-security-register?p=262560&viewfull=1#post262560

Same FSEC change works on T_3.5 as well as the T_3.6