### PR TITLE
Allow cores\teensy4 printf debug optionally go to USB

### DIFF
--- a/teensy4/debug/printf.h
+++ b/teensy4/debug/printf.h
@@ -1,4 +1,11 @@
-// #define PRINT_DEBUG_STUFF
+// uncommenting the line below will enable the debug printf statements in cores\teensy4
+// by default it will print to the Serial4 TX pin at baud rate of 115200
+//#define PRINT_DEBUG_STUFF
+
+// uncommenting the line below will switch to doing outputs to USB Serial or SEREMU instead of Serial4
+// However some of the earlier print statements that happen before USB is initialized will be lost
+// if you need those outputs, better to use Serial 4.
+//#define PRINT_DEBUG_USING_USB // if both defined will try to direct stuff out USB Serial or SEREMU
 
 #ifdef PRINT_DEBUG_STUFF
 // defining printf this way breaks things like Serial.printf() in C++ :(

--- a/teensy4/debugprintf.c
+++ b/teensy4/debugprintf.c
@@ -5,6 +5,7 @@
 #include "avr/pgmspace.h"
 #include <stdarg.h>
 #include "imxrt.h"
+ #include "usb_desc.h"
 
 void putchar_debug(char c);
 static void puint_debug(unsigned int num);
@@ -70,6 +71,28 @@ static void puint_debug(unsigned int num)
 	printf_debug(buf + i);
 }
 
+// first is this normal Serial?
+#if defined(PRINT_DEBUG_USING_USB) && defined(CDC_STATUS_INTERFACE) && defined(CDC_DATA_INTERFACE)
+#include "usb_dev.h"
+#include "usb_serial.h"
+FLASHMEM void putchar_debug(char c)
+{
+	usb_serial_putchar(c);
+}	
+
+FLASHMEM void printf_debug_init(void) {}
+
+#elif defined(PRINT_DEBUG_USING_USB) && defined(SEREMU_INTERFACE) && !defined(CDC_STATUS_INTERFACE) && !defined(CDC_DATA_INTERFACE)
+#include "usb_dev.h"
+#include "usb_seremu.h"
+FLASHMEM void putchar_debug(char c)
+{
+	usb_seremu_putchar(c);
+}	
+
+FLASHMEM void printf_debug_init(void) {}
+
+#else
 FLASHMEM void putchar_debug(char c)
 {
 	while (!(LPUART3_STAT & LPUART_STAT_TDRE)) ; // wait
@@ -83,7 +106,7 @@ FLASHMEM void printf_debug_init(void)
         LPUART3_BAUD = LPUART_BAUD_OSR(25) | LPUART_BAUD_SBR(8); // ~115200 baud
         LPUART3_CTRL = LPUART_CTRL_TE;
 }
-
+#endif
 
 
 


### PR DESCRIPTION
There are times when I wish to debug the cores files, that I wish I could do debug output to USB.  Note: can do with cpp files by doing Serial.printf or the like, but more of a pain with .c files.

The printf stuff put into cores has been very useful for debuging esperailly earlier on.  I understand some of the time it is needed to debug usb stuff or early on stuff so TX pin of Serial4 makes sense.

But for other debugging sessions, wish you had option to go output to the logical Serial object.

So I added a new commented out define in the printf.h file that syas
#define PRINT_DEBUG_USING_USB

That is uncommented, the debug function putchar_debug is defined to either use usb_serial_putchar if we are using normal USB Serial or use usb_seremu_putchar if using Serial emulation.

So far my main testing has been with seremu..

Not sure if this is something you are interested in.  but just in case.
Did this Pull Request