### PR TITLE
AudioStream: Don't disable interrupts globally

### DIFF
--- a/teensy4/AudioStream.h
+++ b/teensy4/AudioStream.h
@@ -60,6 +60,8 @@
 
 #define AUDIO_SAMPLE_RATE AUDIO_SAMPLE_RATE_EXACT
 
+#define IRQ_AUDIO IRQ_SOFTWARE
+
 #ifndef __ASSEMBLER__
 class AudioStream;
 class AudioConnection;


### PR DESCRIPTION
Uses NVIC_ENABLE_IRQ / NVIC_DISABLE_IRQ instead, for better interrupt-latency and experience