### PR TITLE
I2S FRDE bits are not defined on Teensy LC

### DIFF
--- a/teensy3/kinetis.h
+++ b/teensy3/kinetis.h
@@ -5506,6 +5506,10 @@ typedef struct __attribute__((packed)) {
 #define I2S_MDR_DIVIDE(n)		((uint32_t)(n & 0xfff))		// MCLK Divide
 
 #if defined(KINETISL)
+#undef I2S0_TCR1
+#undef I2S0_RCR1
+#undef I2S_TCR1_TFW
+#undef I2S_RCR1_RFW
 #undef I2S_TCSR_FRDE
 #undef I2S_RCSR_FRDE
 #endif

--- a/teensy3/kinetis.h
+++ b/teensy3/kinetis.h
@@ -5505,6 +5505,11 @@ typedef struct __attribute__((packed)) {
 #define I2S_MDR_FRACT(n)		((uint32_t)(n & 0xff)<<12)	// MCLK Fraction
 #define I2S_MDR_DIVIDE(n)		((uint32_t)(n & 0xfff))		// MCLK Divide
 
+#if defined(KINETISL)
+#undef I2S_TCSR_FRDE
+#undef I2S_RCSR_FRDE
+#endif
+
 // General-Purpose Input/Output (GPIO)
 
 #define GPIOA_PDOR		(*(volatile uint32_t *)0x400FF000) // Port Data Output Register


### PR DESCRIPTION
Attention, this patch also requires a patch of INPUT_PDM.