### PR TITLE
Add defines for SNVS_LPGPR0-3 and GPR_Z_DIS

### DIFF
--- a/teensy4/imxrt.h
+++ b/teensy4/imxrt.h
@@ -8105,6 +8105,10 @@ typedef struct
 #define SNVS_LPSMCLR			(IMXRT_SNVS.offset060)
 #define SNVS_LPPGDR			(IMXRT_SNVS.offset064)
 #define SNVS_LPGPR			(IMXRT_SNVS.offset068)
+#define SNVS_LPGPR0                     (IMXRT_SNVS.offset100)
+#define SNVS_LPGPR1                     (IMXRT_SNVS.offset104)
+#define SNVS_LPGPR2                     (IMXRT_SNVS.offset108)
+#define SNVS_LPGPR3                     (IMXRT_SNVS.offset10C)
 #define IMXRT_SNVS_b		(*(IMXRT_REGISTER32_t *)0x400D4800)
 #define SNVS_HPVIDR1			(IMXRT_SNVS_b.offset3F8)
 #define SNVS_HPVIDR2			(IMXRT_SNVS_b.offset3FC)
@@ -8130,7 +8134,7 @@ typedef struct
 #define SNVS_LPCR_ON_TIME(n)		((uint32_t)(((n) & 0x03) << 20))
 #define SNVS_LPCR_PK_EN			((uint32_t)(1 << 22))
 #define SNVS_LPCR_PK_OVERRIDE		((uint32_t)(1 << 23))
-
+#define SNVS_LPCR_GPR_Z_DIS             ((uint32_t)(1 << 24))
 // 40.6: page 2035
 #define IMXRT_SPDIF		(*(IMXRT_REGISTER32_t *)0x40380000)
 #define SPDIF_SCR			(IMXRT_SPDIF.offset000)


### PR DESCRIPTION
There was questions up on forum threads:

https://forum.pjrc.com/threads/66076-Teensy-4-x-s-1062-MCU-has-16-bytes-of-NVRAM-on-RTC-unit?p=268385#post268385

Originally in the thread: https://forum.pjrc.com/threads/64592-Teensyduino-1-54-Beta-5?p=268336&viewfull=1#post268336

That said that the 16 byte memory that was battery backup was not defined nor worked.

So added the defines for the 4 registers.  Only one early on alias was defined before this for the first one...

Also added in the SNVS_LPCR_GPR_Z define which the register bit was talked about in a few other register definitions, this bit was not actually defined in the reference manual, it said it was reserved.  But reads or writes without this bit set in the register will zero out the 4 registers.

Tried example sketch to make sure it worked