### PR TITLE
Audiostream: Waveplayer needs 128Bytes blocks

### DIFF
--- a/teensy3/AudioStream.h
+++ b/teensy3/AudioStream.h
@@ -51,7 +51,7 @@
 #if defined(__MK20DX128__) || defined(__MK20DX256__) || defined(__MK64FX512__) || defined(__MK66FX1M0__)
 #define AUDIO_BLOCK_SAMPLES  128
 #elif defined(__MKL26Z64__)
-#define AUDIO_BLOCK_SAMPLES  64
+#define AUDIO_BLOCK_SAMPLES  128
 #endif
 #endif
 


### PR DESCRIPTION
Prelminary fix until someone fixes the Waveplayer