### PR TITLE
Fix a lot of -Wextra old style" const static warnings

### DIFF
--- a/teensy3/pins_arduino.h
+++ b/teensy3/pins_arduino.h
@@ -44,26 +44,26 @@
 #define PIN_A7  (21)
 #define PIN_A8  (22)
 #define PIN_A9  (23)
-const static uint8_t A0 = PIN_A0;
-const static uint8_t A1 = PIN_A1;
-const static uint8_t A2 = PIN_A2;
-const static uint8_t A3 = PIN_A3;
-const static uint8_t A4 = PIN_A4;
-const static uint8_t A5 = PIN_A5;
-const static uint8_t A6 = PIN_A6;
-const static uint8_t A7 = PIN_A7;
-const static uint8_t A8 = PIN_A8;
-const static uint8_t A9 = PIN_A9;
+static const uint8_t A0 = PIN_A0;
+static const uint8_t A1 = PIN_A1;
+static const uint8_t A2 = PIN_A2;
+static const uint8_t A3 = PIN_A3;
+static const uint8_t A4 = PIN_A4;
+static const uint8_t A5 = PIN_A5;
+static const uint8_t A6 = PIN_A6;
+static const uint8_t A7 = PIN_A7;
+static const uint8_t A8 = PIN_A8;
+static const uint8_t A9 = PIN_A9;
 
 #if defined(__MK20DX128__)
 #define PIN_A10 (34)
 #define PIN_A11 (35)
 #define PIN_A12 (36)
 #define PIN_A13 (37)
-const static uint8_t A10 = PIN_A10;
-const static uint8_t A11 = PIN_A11;
-const static uint8_t A12 = PIN_A12;
-const static uint8_t A13 = PIN_A13;
+static const uint8_t A10 = PIN_A10;
+static const uint8_t A11 = PIN_A11;
+static const uint8_t A12 = PIN_A12;
+static const uint8_t A13 = PIN_A13;
 
 #elif defined(__MK20DX256__)
 #define PIN_A10 (34)
@@ -77,25 +77,25 @@ const static uint8_t A13 = PIN_A13;
 #define PIN_A18 (29)
 #define PIN_A19 (30)
 #define PIN_A20 (31)
-const static uint8_t A10 = PIN_A10;
-const static uint8_t A11 = PIN_A11;
-const static uint8_t A12 = PIN_A12;
-const static uint8_t A13 = PIN_A13;
-const static uint8_t A14 = PIN_A14;
-const static uint8_t A15 = PIN_A15;
-const static uint8_t A16 = PIN_A16;
-const static uint8_t A17 = PIN_A17;
-const static uint8_t A18 = PIN_A18;
-const static uint8_t A19 = PIN_A19;
-const static uint8_t A20 = PIN_A20;
+static const uint8_t A10 = PIN_A10;
+static const uint8_t A11 = PIN_A11;
+static const uint8_t A12 = PIN_A12;
+static const uint8_t A13 = PIN_A13;
+static const uint8_t A14 = PIN_A14;
+static const uint8_t A15 = PIN_A15;
+static const uint8_t A16 = PIN_A16;
+static const uint8_t A17 = PIN_A17;
+static const uint8_t A18 = PIN_A18;
+static const uint8_t A19 = PIN_A19;
+static const uint8_t A20 = PIN_A20;
 
 #elif defined(__MKL26Z64__)
 #define PIN_A10 (24)
 #define PIN_A11 (25)
 #define PIN_A12 (26)
-const static uint8_t A10 = PIN_A10;
-const static uint8_t A11 = PIN_A11;
-const static uint8_t A12 = PIN_A12;
+static const uint8_t A10 = PIN_A10;
+static const uint8_t A11 = PIN_A11;
+static const uint8_t A12 = PIN_A12;
 
 #elif defined(__MK64FX512__) || defined(__MK66FX1M0__)
 #define PIN_A10 (64)
@@ -115,23 +115,23 @@ const static uint8_t A12 = PIN_A12;
 #define PIN_A24 (50)
 #define PIN_A25 (68)
 #define PIN_A26 (69)
-const static uint8_t A10 = PIN_A10;
-const static uint8_t A11 = PIN_A11;
-const static uint8_t A12 = PIN_A12;
-const static uint8_t A13 = PIN_A13;
-const static uint8_t A14 = PIN_A14;
-const static uint8_t A15 = PIN_A15;
-const static uint8_t A16 = PIN_A16;
-const static uint8_t A17 = PIN_A17;
-const static uint8_t A18 = PIN_A18;
-const static uint8_t A19 = PIN_A19;
-const static uint8_t A20 = PIN_A20;
-const static uint8_t A21 = PIN_A21;
-const static uint8_t A22 = PIN_A22;
-const static uint8_t A23 = PIN_A23;
-const static uint8_t A24 = PIN_A24;
-const static uint8_t A25 = PIN_A25;
-const static uint8_t A26 = PIN_A26;
+static const uint8_t A10 = PIN_A10;
+static const uint8_t A11 = PIN_A11;
+static const uint8_t A12 = PIN_A12;
+static const uint8_t A13 = PIN_A13;
+static const uint8_t A14 = PIN_A14;
+static const uint8_t A15 = PIN_A15;
+static const uint8_t A16 = PIN_A16;
+static const uint8_t A17 = PIN_A17;
+static const uint8_t A18 = PIN_A18;
+static const uint8_t A19 = PIN_A19;
+static const uint8_t A20 = PIN_A20;
+static const uint8_t A21 = PIN_A21;
+static const uint8_t A22 = PIN_A22;
+static const uint8_t A23 = PIN_A23;
+static const uint8_t A24 = PIN_A24;
+static const uint8_t A25 = PIN_A25;
+static const uint8_t A26 = PIN_A26;
 #endif
 
 #define LED_BUILTIN   (13)
@@ -140,15 +140,15 @@ const static uint8_t A26 = PIN_A26;
 #define PIN_SPI_MOSI  (11)
 #define PIN_SPI_MISO  (12)
 #define PIN_SPI_SCK   (13)
-const static uint8_t SS = 10;
-const static uint8_t MOSI = 11;
-const static uint8_t MISO = 12;
-const static uint8_t SCK = 13;
+static const uint8_t SS = 10;
+static const uint8_t MOSI = 11;
+static const uint8_t MISO = 12;
+static const uint8_t SCK = 13;
 
 #define PIN_WIRE_SDA  (18)
 #define PIN_WIRE_SCL  (19)
-const static uint8_t SDA = 18;
-const static uint8_t SCL = 19;
+static const uint8_t SDA = 18;
+static const uint8_t SCL = 19;
 
 #define PIN_SERIAL_RX (0)
 #define PIN_SERIAL_TX (1)

--- a/teensy4/pins_arduino.h
+++ b/teensy4/pins_arduino.h
@@ -48,29 +48,29 @@
 #define PIN_A11 (25)
 #define PIN_A12 (26)
 #define PIN_A13 (27)
-const static uint8_t A0 = PIN_A0;
-const static uint8_t A1 = PIN_A1;
-const static uint8_t A2 = PIN_A2;
-const static uint8_t A3 = PIN_A3;
-const static uint8_t A4 = PIN_A4;
-const static uint8_t A5 = PIN_A5;
-const static uint8_t A6 = PIN_A6;
-const static uint8_t A7 = PIN_A7;
-const static uint8_t A8 = PIN_A8;
-const static uint8_t A9 = PIN_A9;
-const static uint8_t A10 = PIN_A10;
-const static uint8_t A11 = PIN_A11;
-const static uint8_t A12 = PIN_A12;
-const static uint8_t A13 = PIN_A13;
+static const uint8_t A0 = PIN_A0;
+static const uint8_t A1 = PIN_A1;
+static const uint8_t A2 = PIN_A2;
+static const uint8_t A3 = PIN_A3;
+static const uint8_t A4 = PIN_A4;
+static const uint8_t A5 = PIN_A5;
+static const uint8_t A6 = PIN_A6;
+static const uint8_t A7 = PIN_A7;
+static const uint8_t A8 = PIN_A8;
+static const uint8_t A9 = PIN_A9;
+static const uint8_t A10 = PIN_A10;
+static const uint8_t A11 = PIN_A11;
+static const uint8_t A12 = PIN_A12;
+static const uint8_t A13 = PIN_A13;
 #ifdef ARDUINO_TEENSY41
 #define PIN_A14 (38)
 #define PIN_A15 (39)
 #define PIN_A16 (40)
 #define PIN_A17 (41)
-const static uint8_t A14 = PIN_A14;
-const static uint8_t A15 = PIN_A15;
-const static uint8_t A16 = PIN_A16;
-const static uint8_t A17 = PIN_A17;
+static const uint8_t A14 = PIN_A14;
+static const uint8_t A15 = PIN_A15;
+static const uint8_t A16 = PIN_A16;
+static const uint8_t A17 = PIN_A17;
 #endif
 
 #define LED_BUILTIN   (13)
@@ -79,15 +79,15 @@ const static uint8_t A17 = PIN_A17;
 #define PIN_SPI_MOSI  (11)
 #define PIN_SPI_MISO  (12)
 #define PIN_SPI_SCK   (13)
-const static uint8_t SS = 10;
-const static uint8_t MOSI = 11;
-const static uint8_t MISO = 12;
-const static uint8_t SCK = 13;
+static const uint8_t SS = 10;
+static const uint8_t MOSI = 11;
+static const uint8_t MISO = 12;
+static const uint8_t SCK = 13;
 
 #define PIN_WIRE_SDA  (18)
 #define PIN_WIRE_SCL  (19)
-const static uint8_t SDA = 18;
-const static uint8_t SCL = 19;
+static const uint8_t SDA = 18;
+static const uint8_t SCL = 19;
 
 #define PIN_SERIAL_RX (0)
 #define PIN_SERIAL_TX (1)


### PR DESCRIPTION
GCC -Wextra complains about "old style" const static.

This fixes a _lot_ of these warnings