### PR TITLE
make AUDIO_SAMPLE_RATE_EXACT float as on Teensy 4

### DIFF
--- a/teensy3/AudioStream.h
+++ b/teensy3/AudioStream.h
@@ -57,10 +57,10 @@
 
 #ifndef AUDIO_SAMPLE_RATE_EXACT
 #if defined(__MK20DX128__) || defined(__MK20DX256__) || defined(__MK64FX512__) || defined(__MK66FX1M0__)
-#define AUDIO_SAMPLE_RATE_EXACT 44117.64706 // 48 MHz / 1088, or 96 MHz * 2 / 17 / 256
+#define AUDIO_SAMPLE_RATE_EXACT 44117.64706f // 48 MHz / 1088, or 96 MHz * 2 / 17 / 256
 #elif defined(__MKL26Z64__)
 //#define AUDIO_SAMPLE_RATE_EXACT 22058.82353 // 48 MHz / 2176, or 96 MHz * 1 / 17 / 256
-#define AUDIO_SAMPLE_RATE_EXACT 44117.64706
+#define AUDIO_SAMPLE_RATE_EXACT 44117.64706f
 #endif
 #endif
 


### PR DESCRIPTION
This helps a lot to fix "double promotions" in the Audio Library