### PR TITLE
Make usb_keymedia_send() public (#558)

### DIFF
--- a/teensy3/usb_keyboard.c
+++ b/teensy3/usb_keyboard.c
@@ -82,7 +82,6 @@ static void usb_keymedia_press_consumer_key(uint16_t key);
 static void usb_keymedia_release_consumer_key(uint16_t key);
 static void usb_keymedia_press_system_key(uint8_t key);
 static void usb_keymedia_release_system_key(uint8_t key);
-static int usb_keymedia_send(void);
 #endif
 
 
@@ -647,7 +646,7 @@ void usb_keymedia_release_all(void)
 }
 
 // send the contents of keyboard_keys and keyboard_modifier_keys
-static int usb_keymedia_send(void)
+int usb_keymedia_send(void)
 {
 	uint32_t wait_count=0;
 	usb_packet_t *tx_packet;

--- a/teensy3/usb_keyboard.h
+++ b/teensy3/usb_keyboard.h
@@ -52,6 +52,9 @@ int usb_keyboard_press(uint8_t key, uint8_t modifier);
 int usb_keyboard_send(void);
 #ifdef KEYMEDIA_INTERFACE
 void usb_keymedia_release_all(void);
+int usb_keymedia_send(void);
+extern uint16_t keymedia_consumer_keys[4];
+extern uint8_t keymedia_system_keys[3];
 #endif
 extern uint8_t keyboard_modifier_keys;
 extern uint8_t keyboard_keys[6];

--- a/teensy4/usb_keyboard.c
+++ b/teensy4/usb_keyboard.c
@@ -83,7 +83,6 @@ static void usb_keymedia_press_consumer_key(uint16_t key);
 static void usb_keymedia_release_consumer_key(uint16_t key);
 static void usb_keymedia_press_system_key(uint8_t key);
 static void usb_keymedia_release_system_key(uint8_t key);
-static int usb_keymedia_send(void);
 #endif
 
 
@@ -653,7 +652,7 @@ void usb_keymedia_release_all(void)
 }
 
 // send the contents of keyboard_keys and keyboard_modifier_keys
-static int usb_keymedia_send(void)
+int usb_keymedia_send(void)
 {
 	uint8_t buffer[8];
 	const uint16_t *consumer = keymedia_consumer_keys;

--- a/teensy4/usb_keyboard.h
+++ b/teensy4/usb_keyboard.h
@@ -52,6 +52,9 @@ int usb_keyboard_press(uint8_t key, uint8_t modifier);
 int usb_keyboard_send(void);
 #ifdef KEYMEDIA_INTERFACE
 void usb_keymedia_release_all(void);
+int usb_keymedia_send(void);
+extern uint16_t keymedia_consumer_keys[4];
+extern uint8_t keymedia_system_keys[3];
 #endif
 extern uint8_t keyboard_modifier_keys;
 extern uint8_t keyboard_keys[6];
@@ -108,4 +111,3 @@ extern usb_keyboard_class Keyboard;
 #endif // __cplusplus
 
 #endif // KEYBOARD_INTERFACE
-


### PR DESCRIPTION
Here's a simple patch to resolve #558. I'd appreciate if this can be included as I need this for my keyboard, and would be useful for others as well.