### PR TITLE
Fix T4.1 PWM pin number in pwm.c

### DIFF
--- a/teensy4/pwm.c
+++ b/teensy4/pwm.c
@@ -111,7 +111,7 @@ const struct pwm_pin_info_struct pwm_pin_info[] = {
 //   FlexPWM3_0    PWM pin 53(T4.1)
 //   FlexPWM3_1    PWM pin 28, 29
 //   FlexPWM3_2
-//   FlexPWM3_3    PWM pin 41(T4.1)
+//   FlexPWM3_3    PWM pin 51(T4.1)
 //   FlexPWM4_0    PWM pin 22
 //   FlexPWM4_1    PWM pin 23
 //   FlexPWM4_2    PWM pin 2, 3


### PR DESCRIPTION
FLEXPWM3_PWM3_B is assigned to GPIO_EMC_22 (manual p302). This is wired to Teensy 4.1 Flash CS (according to the
schematic) which is pin 51.
The pinout reference card shows PWM on pin 51, not 41, so I think this is a typo.