### PR TITLE
Update CrashReport.cpp to print detail info

### DIFF
--- a/teensy4/CrashReport.cpp
+++ b/teensy4/CrashReport.cpp
@@ -13,7 +13,7 @@ struct arm_fault_info_struct {
         uint32_t xpsr;
         uint32_t crc;
 }; */
-
+extern unsigned long _ebss;
 
 size_t CrashReportClass::printTo(Print& p) const
 {
@@ -24,10 +24,81 @@ size_t CrashReportClass::printTo(Print& p) const
 	p.println(info->len);
 	p.print("  IPSR: ");
 	p.println(info->ipsr, HEX);
-	p.print("  CFSR: ");
-	p.println(info->cfsr, HEX);
-	p.print("  HTSR: ");
-	p.println(info->hfsr, HEX);
+
+    uint32_t _CFSR = info->cfsr;
+    if (_CFSR > 0) {
+	  p.print("  CFSR: ");
+	  p.println(info->cfsr, HEX);
+      if ((_CFSR & 0xff) > 0) {
+        //Memory Management Faults
+        if ((_CFSR & 1) == 1) {
+          p.println("\t(IACCVIOL) Instruction Access Violation");
+        } else  if (((_CFSR & (0x02)) >> 1) == 1) {
+          p.println("\t(DACCVIOL) Data Access Violation");
+        } else if (((_CFSR & (0x08)) >> 3) == 1) {
+          p.println("\t(MUNSTKERR) MemMange Fault on Unstacking");
+        } else if (((_CFSR & (0x10)) >> 4) == 1) {
+          p.println("\t(MSTKERR) MemMange Fault on stacking");
+        } else if (((_CFSR & (0x20)) >> 5) == 1) {
+          p.println("\t(MLSPERR) MemMange Fault on FP Lazy State");
+        }
+        if (((_CFSR & (0x80)) >> 7) == 1) {
+          p.print("\t(MMARVALID) Accessed Address: 0x");
+          p.print(info->mmfar, HEX);
+          if (info->mmfar < 32) p.print(" (nullptr)");
+          if ((info->mmfar >= (uint32_t)&_ebss) && (info->mmfar < (uint32_t)&_ebss + 32))
+            p.print(" (Stack problem)\n\tCheck for stack overflows, array bounds, etc.");
+          p.println();
+        }
+      }
+      //Bus Fault Status Register BFSR
+      if (((_CFSR & 0x100) >> 8) == 1) {
+        p.println("\t(IBUSERR) Instruction Bus Error");
+      } else  if (((_CFSR & (0x200)) >> 9) == 1) {
+        p.println("\t(PRECISERR) Data bus error(address in BFAR)");
+      } else if (((_CFSR & (0x400)) >> 10) == 1) {
+        p.println("\t(IMPRECISERR) Data bus error but address not related to instruction");
+      } else if (((_CFSR & (0x800)) >> 11) == 1) {
+        p.println("\t(UNSTKERR) Bus Fault on unstacking for a return from exception");
+      } else if (((_CFSR & (0x1000)) >> 12) == 1) {
+        p.println("\t(STKERR) Bus Fault on stacking for exception entry");
+      } else if (((_CFSR & (0x2000)) >> 13) == 1) {
+        p.println("\t(LSPERR) Bus Fault on FP lazy state preservation");
+      }
+      if (((_CFSR & (0x8000)) >> 15) == 1) {
+        p.print("\t(BFARVALID) Accessed Address: 0x");
+        p.println(info->bfar, HEX);
+      }
+      //Usage Fault Status Register UFSR
+      if (((_CFSR & 0x10000) >> 16) == 1) {
+        p.println("\t(UNDEFINSTR) Undefined instruction");
+      } else  if (((_CFSR & (0x20000)) >> 17) == 1) {
+        p.println("\t(INVSTATE) Instruction makes illegal use of EPSR)");
+      } else if (((_CFSR & (0x40000)) >> 18) == 1) {
+        p.println("\t(INVPC) Usage fault: invalid EXC_RETURN");
+      } else if (((_CFSR & (0x80000)) >> 19) == 1) {
+        p.println("\t(NOCP) No Coprocessor");
+      } else if (((_CFSR & (0x1000000)) >> 24) == 1) {
+        p.println("\t(UNALIGNED) Unaligned access UsageFault");
+      } else if (((_CFSR & (0x2000000)) >> 25) == 1) {
+        p.println("\t(DIVBYZERO) Divide by zero");
+      }
+  }
+
+    uint32_t _HFSR = info->hfsr;
+    if (_HFSR > 0) {
+	  p.print("  HTSR: ");
+	  p.println(info->hfsr, HEX);
+      //Memory Management Faults
+      if (((_HFSR & (0x02)) >> 1) == 1) {
+        p.println("\t(VECTTBL) Bus Fault on Vec Table Read");
+      } else if (((_HFSR & (0x40000000)) >> 30) == 1) {
+       p.println("\t(FORCED) Forced Hard Fault");
+	  } else if (((_HFSR & (0x80000000)) >> 31) == 31) {
+       p.println("\t(DEBUGEVT) Reserved for Debug");
+	  }
+    }
+
 	p.print("  MMFAR: ");
 	p.println(info->mmfar, HEX);
 	p.print("  BFAR: ");


### PR DESCRIPTION
Hi Paul, @KurtE @Defragster 

As mentioned I tried the unmodified version of crash report with the following:
`void setup() { delay(5000); uint32_t *y = 0; y[0]=5;}`
and it looks like it faulting - getting a blinking LED and nothing being printed in loop (i added some prints in loop just a test), but nothing is being printed to the serial monitor.

Anyways, I went ahead and added additional print info for CFSR and HFSR like Frank and the previous core.

I did not add the tempmon attachinterrupt or the unusedISR faults.  Wasn't sure if you wanted to add that to startup.c.
