### PR TITLE
Simplified clear & reverted to print No crash etc from the Crashrepor…

### DIFF
--- a/teensy4/CrashReport.h
+++ b/teensy4/CrashReport.h
@@ -6,7 +6,7 @@
 class CrashReportClass: public Printable {
 public:
 	virtual size_t printTo(Print& p) const;
-	virtual bool clear();
+	virtual void clear();
 };
 
 extern CrashReportClass CrashReport;


### PR DESCRIPTION
…t.cpp.
Morning Paul - @Defragster 
Did 2 things vs the way Tim did it.  I went back to my original clear where I just zeroed out the struct and added Tim's correction.

Also I added back in the else to print when no crash occurred or reset, i.e, "No Crash Reported or Crash was Cleared".  

Guess these two changes are a matter of style - so which ever you prefer.

Still can not figure why on the first pass of the crash it doesn't print the crash report - missing something.  Tried a couple things.  The if( info->len != 0 || info->crc == crc )  is just one variation I tried.

See thread posts starting at https://forum.pjrc.com/threads/66403-Re-enable-bootloader-interrupts-after-a-hard-fault-Teensy-4-1?p=281717&viewfull=1#post281717

