### PR TITLE
Update CrashRPT for Temp, Time, Panic temp and a cool off

### DIFF
--- a/teensy4/CrashReport.cpp
+++ b/teensy4/CrashReport.cpp
@@ -29,7 +29,6 @@ size_t CrashReportClass::printTo(Print& p) const
 	uint8_t mm = info->time % 60;
 	info->time /= 60;
 	uint8_t hh = info->time % 24;
-	p.println(__TIME__);
 	p.printf( "%02d:%02d:%02d\n", hh, mm, ss  );
 
 	p.print("  Temperature at time of fault: ");
@@ -161,6 +160,7 @@ size_t CrashReportClass::printTo(Print& p) const
   }
   if (SRSR & SRC_SRSR_TEMPSENSE_RST_B) {
     p.println("Reboot was caused by temperature sensor");
+	if(CCM_ANALOG_MISC1_IRQ_TEMPPANIC == 1) p.println("Panic Temp Exceeded");
   }
   return 1;
 }

--- a/teensy4/CrashReport.cpp
+++ b/teensy4/CrashReport.cpp
@@ -21,10 +21,22 @@ size_t CrashReportClass::printTo(Print& p) const
 {
   struct arm_fault_info_struct *info = (struct arm_fault_info_struct *)0x2027FF80;
 
-  if (isvalid(info)) {
-    p.println("CrashReport ... Hello World");
+  if (info->len > 0) {
+    p.println("CrashReport ... Hello World");	
+	p.print("  Fault occurred at: ");
+	uint8_t ss = info->time % 60;
+	info->time /= 60;
+	uint8_t mm = info->time % 60;
+	info->time /= 60;
+	uint8_t hh = info->time % 24;
+	p.println(__TIME__);
+	p.printf( "%02d:%02d:%02d\n", hh, mm, ss  );
+
+	p.print("  Temperature at time of fault: ");
+	p.print(info->temp); p.println(" degC");
+	
     p.print("  length: ");
-    p.println(info->len);
+    p.println(info->len);	
     p.print("  IPSR: ");
     p.println(info->ipsr, HEX);
 

--- a/teensy4/CrashReport.cpp
+++ b/teensy4/CrashReport.cpp
@@ -32,7 +32,7 @@ size_t CrashReportClass::printTo(Print& p) const
 	p.printf( "%02d:%02d:%02d\n", hh, mm, ss  );
 
 	p.print("  Temperature at time of fault: ");
-	p.print(info->temp); p.println(" degC");
+	p.print(info->temp, 1); p.println(" degC");
 	
     p.print("  length: ");
     p.println(info->len);	

--- a/teensy4/imxrt.h
+++ b/teensy4/imxrt.h
@@ -9837,7 +9837,7 @@ struct arm_fault_info_struct {
 	uint32_t ret;
 	uint32_t xpsr;
 	uint32_t crc;
-	int16_t  temp;
+	float  temp;
 	uint32_t time;
 };
 

--- a/teensy4/imxrt.h
+++ b/teensy4/imxrt.h
@@ -9837,6 +9837,8 @@ struct arm_fault_info_struct {
 	uint32_t ret;
 	uint32_t xpsr;
 	uint32_t crc;
+	int16_t  temp;
+	uint32_t time;
 };
 
 

--- a/teensy4/startup.c
+++ b/teensy4/startup.c
@@ -38,7 +38,7 @@ extern void analog_init(void); // analog.c
 extern void pwm_init(void); // pwm.c
 extern void tempmon_init(void);  //tempmon.c
 extern float tempmonGetTemp(void);
-//extern unsigned long rtc_get(void);
+extern unsigned long rtc_get(void);
 uint32_t set_arm_clock(uint32_t frequency); // clockspeed.c
 extern void __libc_init_array(void); // C++ standard library
 

--- a/teensy4/startup.c
+++ b/teensy4/startup.c
@@ -592,6 +592,9 @@ void unused_interrupt_vector(void)
 	USBPHY1_CTRL_SET = USBPHY_CTRL_SFTRST;
 	while (PIT_TFLG0 == 0) /* wait 0.1 second for PC to know USB unplugged */
 	// reboot
+	if(CCM_ANALOG_MISC1_IRQ_TEMPPANIC == 1) {
+		while(tempmonGetTemp() > 80)  { delay(100); }  // 5degs below High temp alarm.
+	}
 	SRC_GPR5 = 0x0BAD00F1;
 	SCB_AIRCR = 0x05FA0004;
 	while (1) ;

--- a/teensy4/startup.c
+++ b/teensy4/startup.c
@@ -37,6 +37,8 @@ void usb_pll_start();
 extern void analog_init(void); // analog.c
 extern void pwm_init(void); // pwm.c
 extern void tempmon_init(void);  //tempmon.c
+extern float tempmonGetTemp(void);
+//extern unsigned long rtc_get(void);
 uint32_t set_arm_clock(uint32_t frequency); // clockspeed.c
 extern void __libc_init_array(void); // C++ standard library
 
@@ -534,6 +536,8 @@ void unused_interrupt_vector(void)
 	info->bfar = SCB_BFAR;
 	info->ret = stack[6];
 	info->xpsr = stack[7];
+	info->temp = tempmonGetTemp();
+	info->time = rtc_get();
 	info->len = sizeof(*info) / 4;
 	// add CRC to crash report
 	crc = 0xFFFFFFFF;


### PR DESCRIPTION
Hi Paul
I added some more stuff into the crash report tested temp and RTC - so not sure ready for prime time but you can play with it some.  
1.  It pulls the temp at the time of the crash.
2.  Pulls in RTC time of the crash.
3.  Adds an additional note when the reboot cause is by temp (panic temp exceeded).
4.  I take a shot at adding in a cool down before reset but now sure thats going to work.  Have a look

One issue I found was the isvalid is always returning 0 - haven't really looked at why yet. But put in a workaround just so it trips for testing:
`if (info->len > 0) {`

Ok have a few other things to do. 
