### PR TITLE
Shutdown on Panic Alarm after CrashRPT printed.

### DIFF
--- a/teensy4/startup.c
+++ b/teensy4/startup.c
@@ -515,6 +515,7 @@ extern void usb_isr(void);
 //  R0
 // Code from :: https://community.nxp.com/thread/389002
 
+
 __attribute__((naked))
 void unused_interrupt_vector(void)
 {
@@ -592,14 +593,10 @@ void unused_interrupt_vector(void)
 	USBPHY1_CTRL_SET = USBPHY_CTRL_SFTRST;
 	while (PIT_TFLG0 == 0) /* wait 0.1 second for PC to know USB unplugged */
 	// reboot
-	if(CCM_ANALOG_MISC1_IRQ_TEMPPANIC == 1) {
-		while(tempmonGetTemp() > 80)  { delay(100); }  // 5degs below High temp alarm.
-	}
 	SRC_GPR5 = 0x0BAD00F1;
 	SCB_AIRCR = 0x05FA0004;
 	while (1) ;
 }
-
 
 __attribute__((section(".startup"), optimize("no-tree-loop-distribute-patterns")))
 static void memory_copy(uint32_t *dest, const uint32_t *src, uint32_t *dest_end)

--- a/teensy4/tempmon.c
+++ b/teensy4/tempmon.c
@@ -13,11 +13,11 @@ static uint32_t s_hotTemp, s_hotCount, s_roomC_hotC;
 static float s_hot_ROOM;
 
 void Panic_Temp_isr(void) {
-  __disable_irq();
-  IOMUXC_GPR_GPR16 = 0x00000007;
-  SNVS_LPCR |= SNVS_LPCR_TOP; //Switch off now
-  asm volatile ("dsb":::"memory");
-  while (1) asm ("wfi");
+  unused_interrupt_vector();
+  //IOMUXC_GPR_GPR16 = 0x00000007;
+  //SNVS_LPCR |= SNVS_LPCR_TOP; //Switch off now
+  //asm volatile ("dsb":::"memory");
+  //while (1) asm ("wfi");
 }
 
 FLASHMEM void tempmon_init(void)


### PR DESCRIPTION
Evening Paul - @Defragster  - @KurtE 

After a few headaches  and some help from Tim and reading the RM again I got the Crashrpt to trip on the panic alarm and printed before I decided to just do a shutdown instead of a cool off before report.  I posted this question on line as well but figure you guys are hours earlier than me.

Reason - you don't know what caused the over temp - just the overclocking or something more dangerous 