### PR TITLE
Added Sysclock setting to Crash Report

### DIFF
--- a/teensy4/CrashReport.cpp
+++ b/teensy4/CrashReport.cpp
@@ -33,9 +33,9 @@ size_t CrashReportClass::printTo(Print& p) const
 	uint8_t hh = info->time % 24;
 	p.printf( "%02d:%02d:%02d\n", hh, mm, ss  );
 
-	p.print("  Temperature at time of fault: ");
-	p.print(info->temp, 1); p.println(" degC");
-	
+	p.println("  Temperature and System Clock at time of fault: ");
+	p.printf( "    Temp = %f deg C,  Sys Clock = %u Mhz\n" , info->temp, F_CPU_ACTUAL/1000000 );
+
     p.print("  length: ");
     p.println(info->len);	
     p.print("  IPSR: ");


### PR DESCRIPTION
Good Morning Paul
Made 1 slight addition to the crash report.  I added printing the System clock to report.  Only affects crashreport.cpp.

Unless you want to crash the panic temp from shut down to cool down.  I can't see me making any other changes.  

Let us know when you want to freeze changes to crash reporting.

Thanks
Mike