### PR TITLE
move unused int vect to flash

### DIFF
--- a/teensy4/startup.c
+++ b/teensy4/startup.c
@@ -519,6 +519,7 @@ extern void usb_isr(void);
 // Code from :: https://community.nxp.com/thread/389002
 
 
+FLASHMEM
 __attribute__((naked))
 void unused_interrupt_vector(void)
 {


### PR DESCRIPTION
Saves some 100 Bytes RAM