### PR TITLE
Resolved: High Temp readings from Temp Monitor

### DIFF
--- a/teensy4/tempmon.c
+++ b/teensy4/tempmon.c
@@ -47,15 +47,15 @@ FLASHMEM void tempmon_init(void)
 
     //time to set alarm temperatures
   //Set High Alarm Temp
-  tempCodeVal = (uint32_t)(s_hotCount + (s_hotTemp - highAlarmTemp) * s_roomC_hotC / s_hot_ROOM);
+  tempCodeVal = ((float)s_hotCount + ((float)s_hotTemp - highAlarmTemp) * s_roomC_hotC / s_hot_ROOM);
     TEMPMON_TEMPSENSE0 |= (((uint32_t)(((uint32_t)(tempCodeVal)) << 20U)) & 0xFFF00000U);
   
   //Set Panic Alarm Temp
-  tempCodeVal = (uint32_t)(s_hotCount + (s_hotTemp - panicAlarmTemp) * s_roomC_hotC / s_hot_ROOM);
+  tempCodeVal = ((float)s_hotCount + ((float)s_hotTemp - panicAlarmTemp) * s_roomC_hotC / s_hot_ROOM);
     TEMPMON_TEMPSENSE2 |= (((uint32_t)(((uint32_t)(tempCodeVal)) << 16U)) & 0xFFF0000U);
   
   // Set Low Temp Alarm Temp
-  tempCodeVal = (uint32_t)(s_hotCount + (s_hotTemp - lowAlarmTemp) * s_roomC_hotC / s_hot_ROOM);
+  tempCodeVal = ((float)s_hotCount + ((float)s_hotTemp - lowAlarmTemp) * s_roomC_hotC / s_hot_ROOM);
     TEMPMON_TEMPSENSE2 |= (((uint32_t)(((uint32_t)(tempCodeVal)) << 0U)) & 0xFFFU);
   
   //Start temp monitoring

--- a/teensy4/tempmon.c
+++ b/teensy4/tempmon.c
@@ -9,8 +9,8 @@ static uint32_t highAlarmTemp   = 85U;
 static uint32_t lowAlarmTemp    = 25U;
 static uint32_t panicAlarmTemp  = 90U;
 
-static uint32_t s_hotTemp, s_hotCount, s_roomC_hotC;
-static float s_hot_ROOM;
+static uint32_t s_hotTemp, s_hotCount;
+static float s_hot_ROOM, s_roomC_hotC;
 
 extern void unused_interrupt_vector(void); // startup.c
 
@@ -42,8 +42,8 @@ FLASHMEM void tempmon_init(void)
     s_hotTemp = (uint32_t)(calibrationData & 0xFFU) >> 0x00U;
     s_hotCount = (uint32_t)(calibrationData & 0xFFF00U) >> 0X08U;
     roomCount = (uint32_t)(calibrationData & 0xFFF00000U) >> 0x14U;
-    s_hot_ROOM = s_hotTemp - 25.0f;
-    s_roomC_hotC = roomCount - s_hotCount;
+    s_hot_ROOM = (float) (s_hotTemp) - 25.0f;
+    s_roomC_hotC = (float) roomCount - (float) s_hotCount;
 
     //time to set alarm temperatures
   //Set High Alarm Temp

--- a/teensy4/tempmon.c
+++ b/teensy4/tempmon.c
@@ -80,7 +80,7 @@ float tempmonGetTemp(void)
     /* ready to read temperature code value */
     nmeas = (TEMPMON_TEMPSENSE0 & 0xFFF00U) >> 8U;
     /* Calculate temperature */
-    tmeas = s_hotTemp - (float)((nmeas - s_hotCount) * s_hot_ROOM / s_roomC_hotC);
+    tmeas = s_hotTemp - (((float)nmeas - (float)s_hotCount) * s_hot_ROOM / s_roomC_hotC);
 
     return tmeas;
 }


### PR DESCRIPTION
Morning Paul
Based on the discussion on the forum: https://forum.pjrc.com/threads/59813-Teensy-4-0-Internal-Temperature-measurement/page3 and @LAtimes pointing to the final fix: https://forum.pjrc.com/threads/59813-Teensy-4-0-Internal-Temperature-measurement?p=285127&viewfull=1#post285127 I updated tempmon.c to incorporate those changes.  

This resolves the issue I always had with tempmon reading high values for internal temperature that I never could figure out.  Looks like its now fixed.

EDIT:  Now that I woke up fixed another issue with setting Panic Alarm over 95degC. that resulted from change above and maybe there before as well.