### PR TITLE
T4 DMAChannel  - Implement triggerContinuously

### DIFF
--- a/teensy4/DMAChannel.h
+++ b/teensy4/DMAChannel.h
@@ -490,31 +490,10 @@ public:
 	// it will move data as rapidly as possible, without waiting.
 	// Normally this would be used with disableOnCompletion().
 	void triggerContinuously(void) {
-		// TODO: update this for IMXRT.  On Kinetis, a small handful
-		// of DMAMUX slots were dedicated to "always on".  On IMXRT,
-		// all of them can work as "always on" by setting their
-		// DMAMUX_CHCFG_A_ON bit.
-#if 0
-		volatile uint8_t *mux = (volatile uint8_t *)&DMAMUX0_CHCFG0;
-		mux[channel] = 0;
-#if DMAMUX_NUM_SOURCE_ALWAYS >= DMA_NUM_CHANNELS
-		mux[channel] = DMAMUX_SOURCE_ALWAYS0 + channel;	
-#else
-		// search for an unused "always on" source
-		unsigned int i = DMAMUX_SOURCE_ALWAYS0;
-		for (i = DMAMUX_SOURCE_ALWAYS0;
-		  i < DMAMUX_SOURCE_ALWAYS0 + DMAMUX_NUM_SOURCE_ALWAYS; i++) {
-			unsigned int ch;
-			for (ch=0; ch < DMA_NUM_CHANNELS; ch++) {
-				if (mux[ch] == i) break;
-			}
-			if (ch >= DMA_NUM_CHANNELS) {
-				mux[channel] = (i | DMAMUX_ENABLE);
-				return;
-			}
-		}
-#endif
-#endif
+		volatile uint32_t *mux = &DMAMUX_CHCFG0 + channel;
+		//mux = (volatile uint32_t *)&(DMAMUX_CHCFG0) + channel;
+		*mux = 0;
+		*mux = DMAMUX_CHCFG_A_ON | DMAMUX_CHCFG_ENBL;
 	}
 
 	// Manually trigger the DMA channel.


### PR DESCRIPTION
Paul,

In the arm_dcache_delete testing thread, I wanted to setup a test example where I wanted to copy memory using DMA into the area to test what areas are preserved or not preserved and to make sure that the different solutions worked as to get the updated memory after the DMA transfer.

So I tried setting up DMA operation like:
```
 dma.sourceBuffer((uint8_t*)low_buffer, sizeof(low_buffer));
  dma.destinationBuffer((uint8_t*)dmam.dmaBuffer, sizeof(dmam.dmaBuffer));
  dma.transferCount(sizeof(dmam.dmaBuffer));
  dma.disableOnCompletion();
  dma.enable();
  dma.clearComplete();
  dma.triggerContinuously();
```
And only 1 byte transferred.  I loooked at the triggerContinuously implementation and found it was a TODO and was doing nothing.

So i did more or less your comments and in some cases it appear to work.

However it only appears to work when the destination buffer is 32 byte aligned.

But I don't think that is specific to this change.   Decided to go ahead and issue this PR in case someone else tries this.