### PR TITLE
Adding startup_before_usb_hook

### DIFF
--- a/teensy3/mk20dx128.c
+++ b/teensy3/mk20dx128.c
@@ -677,6 +677,7 @@ static void startup_default_early_hook(void) {
 #endif
 }
 static void startup_default_late_hook(void) {}
+// aberridg - startup before USB
 static void startup_default_before_usb_hook(void) {}
 void startup_early_hook(void)		__attribute__ ((weak, alias("startup_default_early_hook")));
 void startup_before_usb_hook(void)		__attribute__ ((weak, alias("startup_default_before_usb_hook")));

--- a/teensy3/mk20dx128.c
+++ b/teensy3/mk20dx128.c
@@ -677,7 +677,9 @@ static void startup_default_early_hook(void) {
 #endif
 }
 static void startup_default_late_hook(void) {}
+static void startup_default_before_usb_hook(void) {}
 void startup_early_hook(void)		__attribute__ ((weak, alias("startup_default_early_hook")));
+void startup_before_usb_hook(void)		__attribute__ ((weak, alias("startup_default_before_usb_hook")));
 void startup_late_hook(void)		__attribute__ ((weak, alias("startup_default_late_hook")));
 
 
@@ -1120,6 +1122,9 @@ void ResetHandler(void)
 
 	//init_pins();
 	__enable_irq();
+	
+	//call startup hook as late as possible but before delays introduced by waiting for USB to be up
+	startup_before_usb_hook();
 
 	_init_Teensyduino_internal_();
 

--- a/teensy4/startup.c
+++ b/teensy4/startup.c
@@ -50,6 +50,7 @@ struct smalloc_pool extmem_smalloc_pool;
 extern int main (void);
 void startup_default_early_hook(void) {}
 void startup_early_hook(void)		__attribute__ ((weak, alias("startup_default_early_hook")));
+// aberridg - added startup_default_before_usb_hook for parity with T3
 void startup_default_before_usb_hook(void) {}
 void startup_before_usb_hook(void)		__attribute__ ((weak, alias("startup_default_before_usb_hook")));
 void startup_default_late_hook(void) {}

--- a/teensy4/startup.c
+++ b/teensy4/startup.c
@@ -50,6 +50,8 @@ struct smalloc_pool extmem_smalloc_pool;
 extern int main (void);
 void startup_default_early_hook(void) {}
 void startup_early_hook(void)		__attribute__ ((weak, alias("startup_default_early_hook")));
+void startup_default_before_usb_hook(void) {}
+void startup_before_usb_hook(void)		__attribute__ ((weak, alias("startup_default_before_usb_hook")));
 void startup_default_late_hook(void) {}
 void startup_late_hook(void)		__attribute__ ((weak, alias("startup_default_late_hook")));
 __attribute__((section(".startup"), optimize("no-tree-loop-distribute-patterns")))
@@ -140,6 +142,9 @@ void ResetHandler(void)
 #endif
 	startup_early_hook();
 	while (millis() < 20) ; // wait at least 20ms before starting USB
+	//call startup hook as late as possible but just before USB is initialized. Note - not as necessary
+	//here as it is for Teensy 3.x, but added here for consistency
+	startup_before_usb_hook();
 	usb_init();
 	analog_init();
 	pwm_init();


### PR DESCRIPTION
For external hardware watchdogs that need stroking after most services are up and running but before any delays introduced by USB init.
Re-creating this PR as my previous commits were removed by pull_bot