### PR TITLE
EventResponder: Make _triggered member variable volatile. Fix trailing whitespace.

### DIFF
--- a/teensy3/EventResponder.h
+++ b/teensy3/EventResponder.h
@@ -174,7 +174,7 @@ public:
 	EventResponder * waitForEvent(EventResponder *list, int listsize, int timeout);
 
 	static void runFromYield() {
-		if (!firstYield) return;  
+		if (!firstYield) return;
 		// First, check if yield was called from an interrupt
 		// never call normal handler functions from any interrupt context
 		uint32_t ipsr;
@@ -219,7 +219,7 @@ protected:
 	EventResponder *_next = nullptr;
 	EventResponder *_prev = nullptr;
 	EventType _type = EventTypeDetached;
-	bool _triggered = false;
+	volatile bool _triggered = false;
 	static EventResponder *firstYield;
 	static EventResponder *lastYield;
 	static EventResponder *firstInterrupt;

--- a/teensy4/EventResponder.h
+++ b/teensy4/EventResponder.h
@@ -173,7 +173,7 @@ public:
 	bool waitForEvent(EventResponderRef event, int timeout);
 	EventResponder * waitForEvent(EventResponder *list, int listsize, int timeout);
 	static void runFromYield() {
-		if (!firstYield) return;  
+		if (!firstYield) return;
 		// First, check if yield was called from an interrupt
 		// never call normal handler functions from any interrupt context
 		uint32_t ipsr;
@@ -218,7 +218,7 @@ protected:
 	EventResponder *_next = nullptr;
 	EventResponder *_prev = nullptr;
 	EventType _type = EventTypeDetached;
-	bool _triggered = false;
+	volatile bool _triggered = false;
 	static EventResponder *firstYield;
 	static EventResponder *lastYield;
 	static EventResponder *firstInterrupt;


### PR DESCRIPTION
Hello,

while trying to wait for an async SPI operation using an EventResponder instance on my teensy 4.1, the waiting loop never returned. Adding the volatile keyword to the _triggered member variable fixed the issue. Also deleting two trailing whitespaces. I have a custom CMake toolchain setup, but would think that there should be no real difference to the normal arduino/teensy development toolchain in this case. Anyways, the following code segment shows how I used the EventResponder in combination with SPI. Since I did not find a lot of examples on this sort of use case I'm not sure if many people tried to use the EventResponder like this? Did I misuse the bool operator?


```
static SPISettings SPI0_SETTINGS(26000000, MSBFIRST, SPI_MODE0);
static EventResponder evr;
  
inline void some_write_func(uint8_t reg, uint8_t * data, uint16_t dim) {
  
      uint8_t buf[dim + 1];
  
      buf[0] = 0x80 | reg;
      memcpy(&buf[1], data, dim);

      SPI.beginTransaction(SPI0_SETTINGS);
      digitalWriteFast(10, LOW);
      SPI.transfer(buf, nullptr, dim + 1, evr);
      while (!evr) {} // loops forever without _triggered being volatile
      digitalWriteFast(10, HIGH);
      SPI.endTransaction();
}

// some functions calling some_write_func
```


Cheers,
Philipp