### PR TITLE
T4 MTP event endpoint have callback function with counts

### DIFF
--- a/teensy4/usb_mtp.c
+++ b/teensy4/usb_mtp.c
@@ -59,6 +59,8 @@ static void rx_queue_transfer(int i);
 static void rx_event(transfer_t *t);
 extern volatile uint8_t usb_configuration;
 
+uint32_t mtp_txEventCount = 0;
+static void txEvent_event(transfer_t *t) { mtp_txEventCount++;}
 
 void usb_mtp_configure(void)
 {
@@ -77,7 +79,7 @@ void usb_mtp_configure(void)
 	rx_tail = 0;
 	usb_config_tx(MTP_TX_ENDPOINT, tx_packet_size, 0, NULL);
 	usb_config_rx(MTP_RX_ENDPOINT, rx_packet_size, 0, rx_event);
-	usb_config_tx(MTP_EVENT_ENDPOINT, MTP_EVENT_SIZE, 0, NULL);
+	usb_config_tx(MTP_EVENT_ENDPOINT, MTP_EVENT_SIZE, 0, txEvent_event);
 	int i;
 	for (i=0; i < RX_NUM; i++) rx_queue_transfer(i);
 }

--- a/teensy4/usb_mtp.h
+++ b/teensy4/usb_mtp.h
@@ -44,6 +44,9 @@ void usb_mtp_configure(void);
 int usb_mtp_recv(void *buffer, uint32_t timeout);
 int usb_mtp_available(void);
 int usb_mtp_send(const void *buffer, uint32_t len, uint32_t timeout);
+
+extern uint32_t mtp_txEventCount;
+
 #ifdef __cplusplus
 }
 #endif
@@ -57,6 +60,8 @@ public:
 	int available(void) {return usb_mtp_available(); }
 	int recv(void *buffer, uint32_t timeout) { return usb_mtp_recv(buffer, timeout); }
 	int send(const void *buffer, uint32_t len, uint32_t timeout) { return usb_mtp_send(buffer, len, timeout); }
+
+    uint32_t txEventCount() { return mtp_txEventCount; }
 };
 
 extern usb_mtp_class mtp;


### PR DESCRIPTION
So far not having the callback was causing issues where it would hang after first event sent...  When I tried to send second one...

@PaulStoffregen @mjs513 
Good Morning Paul,

With our testing we were finding that the sending of events was not working right with the initialization of the Event end point within core, which did not define a callback function to be called.  The one in MTP had a callback... So changed it to have a callback that increments increments a counter like was in MTP library and it appears to be now working for both Mike and myself. 