### PR TITLE
Stream::timedRead protected instead of private.

### DIFF
--- a/teensy3/Stream.h
+++ b/teensy3/Stream.h
@@ -62,12 +62,13 @@ class Stream : public Print
 	void clearReadError() { setReadError(0); }
   protected:
 	void setReadError(int err = 1) { read_error = err; }
-	unsigned long _timeout;
-  private:
-	char read_error;
 	int timedRead();
 	int timedPeek();
 	int peekNextDigit();
+
+	unsigned long _timeout;
+  private:
+	char read_error;
 };
 
 #endif

--- a/teensy4/Stream.h
+++ b/teensy4/Stream.h
@@ -62,12 +62,13 @@ class Stream : public Print
 	void clearReadError() { setReadError(0); }
   protected:
 	void setReadError(int err = 1) { read_error = err; }
-	unsigned long _timeout;
-  private:
-	char read_error;
 	int timedRead();
 	int timedPeek();
 	int peekNextDigit();
+
+	unsigned long _timeout;
+  private:
+	char read_error;
 };
 
 #endif


### PR DESCRIPTION
Probably not a big issue.  But came up again on forum:
https://forum.pjrc.com/threads/68345-TimedRead-is-private-in-Stream-h-for-Teensy-4

And there have been two issues on it:
https://github.com/PaulStoffregen/cores/issues/531
https://github.com/PaulStoffregen/cores/issues/388

I did a quick check in sources and found it was protected in all three of the Arduino code bases (avr, sam, samd), also with ESP, also with OpenCM/OpenCR...

There are some other changes in the Arduino ones which we could do but are not in the ESP sources

Their method:     int peekNextDigit(LookaheadMode lookahead, bool detectDecimal); // returns the next numeric digit in the stream or -1 if timeout

is different than the ones we have.  The ones we have are now marked private...  and they also added some defines:
enum LookaheadMode{
    SKIP_ALL,       // All invalid characters are ignored.
    SKIP_NONE,      // Nothing is skipped, and the stream is not touched unless the first waiting character is valid.
    SKIP_WHITESPACE // Only tabs, spaces, line feeds & carriage returns are skipped.
};

I have not yet made those changes to peekNextDigit

Probably not a big priority, but since I took a quick look thought I would make the change and PR...

Compiled program on T4.1 and T3.6