### PR TITLE
Faster memcpy not needed for GCC 10 (teensy4)

### DIFF
--- a/teensy4/memcpy-armv7m.S
+++ b/teensy4/memcpy-armv7m.S
@@ -26,7 +26,7 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#if defined (__ARM_ARCH_7M__) || defined (__ARM_ARCH_7EM__)
+#if (__GNUC__ < 10) && (defined (__ARM_ARCH_7M__) || defined (__ARM_ARCH_7EM__))
 /*
  * Let __ARM_FEATURE_UNALIGNED be set by the achitechture and the compiler flags:
  *   -munaligned-access


### PR DESCRIPTION
Builtin has exactly the same speed.

This is from #616. I volunteered to take over the commit.

One thing that was't clear from the conversation is should it be no. 1 or no. 2 (below)?
1. #if (__GNUC__ < 10) && (defined (__ARM_ARCH_7M__) || defined (__ARM_ARCH_7EM__))
2. #if ((__GNUC__ < 10) && defined (__ARM_ARCH_7M__)) || defined (__ARM_ARCH_7EM__)

This commit uses no. 1.