### PR TITLE
Data timing window holes

### DIFF
--- a/teensy4/usb_mtp.c
+++ b/teensy4/usb_mtp.c
@@ -90,10 +90,10 @@ void usb_mtp_configure(void)
 
 static void rx_queue_transfer(int i)
 {
+	NVIC_DISABLE_IRQ(IRQ_USB1);
 	void *buffer = rx_buffer + i * MTP_RX_SIZE_480;
 	arm_dcache_delete(buffer, rx_packet_size);
 	//memset(buffer, )
-	NVIC_DISABLE_IRQ(IRQ_USB1);
 	usb_prepare_transfer(rx_transfer + i, buffer, rx_packet_size, i);
 	usb_receive(MTP_RX_ENDPOINT, rx_transfer + i);
 	NVIC_ENABLE_IRQ(IRQ_USB1);

--- a/teensy4/usb_rawhid.c
+++ b/teensy4/usb_rawhid.c
@@ -76,10 +76,10 @@ void usb_rawhid_configure(void)
 
 static void rx_queue_transfer(int i)
 {
+	NVIC_DISABLE_IRQ(IRQ_USB1);
 	void *buffer = rx_buffer + i * RAWHID_RX_SIZE;
 	arm_dcache_delete(buffer, RAWHID_RX_SIZE);
 	//memset(buffer, )
-	NVIC_DISABLE_IRQ(IRQ_USB1);
 	usb_prepare_transfer(rx_transfer + i, buffer, RAWHID_RX_SIZE, i);
 	usb_receive(RAWHID_RX_ENDPOINT, rx_transfer + i);
 	NVIC_ENABLE_IRQ(IRQ_USB1);


### PR DESCRIPTION
@PaulStoffregen  @mjs513:

We were getting partial transfers...   And other issues in MTP whose code was based off of RAWHID code. 

Looked at Sermu and it protected earlier in the rx_queue_transfer...  So it did not grab the index before it disabled the interrupts. So something might change during that window fo time. 
Updated rawhid as well, as well, someone has or will hit it there as well

There may still be some issues in the MTP code, but this appears to me to help some.