### PR TITLE
FS.h - Override the print version of write buffer

### DIFF
--- a/teensy3/FS.h
+++ b/teensy3/FS.h
@@ -162,6 +162,12 @@ public:
 	size_t read(void *buf, size_t nbyte) {
 		return (f) ? f->read(buf, nbyte) : 0;
 	}
+	
+	// override print version
+	virtual size_t write(const uint8_t *buf, size_t size) {
+		return (f) ? f->write((void*)buf, size) : 0;
+	}
+
 	size_t write(const void *buf, size_t size) {
 		return (f) ? f->write(buf, size) : 0;
 	}

--- a/teensy4/FS.h
+++ b/teensy4/FS.h
@@ -162,6 +162,12 @@ public:
 	size_t read(void *buf, size_t nbyte) {
 		return (f) ? f->read(buf, nbyte) : 0;
 	}
+
+	// override print version
+	virtual size_t write(const uint8_t *buf, size_t size) {
+		return (f) ? f->write((void*)buf, size) : 0;
+	}
+
 	size_t write(const void *buf, size_t size) {
 		return (f) ? f->write(buf, size) : 0;
 	}


### PR DESCRIPTION
@PaulStoffregen  @mjs513:
Without this override, if a sketch does something like:

```
uint8_t my_buffer[2048];
...
myfile.write(my_buffer, sizeof(my_buffer));
```

When the write is called, the underlying file system write buffer function will be
called 2048 times with 1 byte at a time.

This bit me a couple of times now: 

Why: We have two write buffer methods as part of the File object within FS.

We have the one that is part of the Print class which is defined:
```
virtual size_t write(const uint8_t *buf, size_t size)
```

We also then have the one specifically added to the File Class:
```
	size_t write(const void *buf, size_t size) {
		return (f) ? f->write(buf, size) : 0;
	}
```
So already today if I cast the buffer to void *  the FileImpl method:
	virtual size_t write(const void *buf, size_t size) = 0;

Will be called once, but without the cast, the Print class default implementation, will be called, which loops through 
one byte at a time, calling the File.write(char) method which will then call through to the underlying FS...

This simple fix overriding the Print class version works.... Wondering if we should still leave in the void* version?


