### PR TITLE
T4. usb_mtp.c - on RX look at actual count of bytes transferred and use it

### DIFF
--- a/teensy4/usb_mtp.h
+++ b/teensy4/usb_mtp.h
@@ -44,6 +44,8 @@ void usb_mtp_configure(void);
 int usb_mtp_recv(void *buffer, uint32_t timeout);
 int usb_mtp_available(void);
 int usb_mtp_send(const void *buffer, uint32_t len, uint32_t timeout);
+int usb_mtp_rxSize(void);
+int usb_mtp_txSize(void);
 
 extern uint32_t mtp_txEventCount;
 
@@ -60,6 +62,8 @@ public:
 	int available(void) {return usb_mtp_available(); }
 	int recv(void *buffer, uint32_t timeout) { return usb_mtp_recv(buffer, timeout); }
 	int send(const void *buffer, uint32_t len, uint32_t timeout) { return usb_mtp_send(buffer, len, timeout); }
+    int rxSize(void) {return usb_mtp_rxSize(); }
+    int txSize(void) {return usb_mtp_txSize(); }
 
     uint32_t txEventCount() { return mtp_txEventCount; }
 };


### PR DESCRIPTION
@PaulStoffregen  @mjs513 -

We were running into a case where the host would send us a 0 length packet if on a SendObject the file fit exactly in full packets... Then it would send one that said no more data on that file.

Our code did not look in the transfer->status field to extract the count transferred.
The code now extracts that and only copies that many bytes and returns it to caller.

This helps clear up some of the issues and crashes we have been seeing. 

I am assuming you would prefer the simple fix here and not go off my other branch which added in support
for RawHid512... Although the tests using it were sort of nice as with it you do get 8 times the data throughput