### PR TITLE
Reduce chance of usbMIDI.send_now() causing duplicate MIDI packet

### DIFF
--- a/teensy3/usb_midi.c
+++ b/teensy3/usb_midi.c
@@ -194,10 +194,14 @@ void usb_midi_send_sysex_add_term_bytes(const uint8_t *data, uint32_t length, ui
 
 void usb_midi_flush_output(void)
 {
-	if (tx_noautoflush == 0 && tx_packet && tx_packet->index > 0) {
-		tx_packet->len = tx_packet->index * 4;
-		usb_tx(MIDI_TX_ENDPOINT, tx_packet);
-		tx_packet = NULL;
+	if (tx_noautoflush == 0) {
+		tx_noautoflush = 1;
+		if (tx_packet && tx_packet->index > 0) {
+			tx_packet->len = tx_packet->index * 4;
+			usb_tx(MIDI_TX_ENDPOINT, tx_packet);
+			tx_packet = NULL;
+		}
+		tx_noautoflush = 0;
 	}
 }
 


### PR DESCRIPTION
Reduces the chance of a call to usbMIDI.send_now() from user code resulting in duplicate MIDI packets.  usbMIDI.send_now() calls usb_midi_flush_output().  If the USB controller is already in this function when user code calls usbMIDI.send_now(), then a duplicate MIDI can be queued.