### PR TITLE
Fixed undefined reference error Teensy++ 2.0 DISK SDCARD + Keyboard

### DIFF
--- a/usb_disk/media_sdcard.c
+++ b/usb_disk/media_sdcard.c
@@ -68,10 +68,12 @@ void spi_ignore_bytes(uint8_t count)
 		spi_write(0xFF);
 	} while (--count);
 }
+inline void spi_select(void) __attribute__((always_inline));
 inline void spi_select(void)
 {
 	SPI_PORT &= ~(1<<SPI_SS_PIN);
 }
+inline void sd_deselect(void) __attribute__((always_inline));
 inline void sd_deselect(void)
 {
 	SPI_PORT |= (1<<SPI_SS_PIN);
@@ -295,6 +297,7 @@ void media_poll(void)
 	//return media_state;
 }
 
+inline uint32_t media_size(void) __attribute__((always_inline));
 inline uint32_t media_size(void)
 {
 	uint8_t r;


### PR DESCRIPTION
Fixed undefined reference error Teensy++ 2.0 DISK SDCARD + Keyboard

Reported here:

https://forum.pjrc.com/threads/58291-Error-compiling-for-board-Teensy-2-0-DISK-SDCARD-Keyboard

Confirmed (Teensyduino 1.55):

In file included from C:\teensy\hardware\teensy\avr\cores\teensy\usb_api.cpp:8:0:
c:\teensy\hardware\teensy\avr\cores\usb_disk\usb_api.cpp: In member function 'uint8_t usb_keyboard_class::unicode_to_keycode(uint16_t)':
c:\teensy\hardware\teensy\avr\cores\usb_disk\usb_api.cpp:85:38: warning: large integer implicitly truncated to unsigned type [-Woverflow]
if (cpoint == 10) return KEY_ENTER & 0x3FFF;
C:\Users\xia\AppData\Local\Temp\arduino_build_760981/core\core.a(usb.c.o): In function sd_command': usb.c:(.text.sd_command+0x18): undefined reference to spi_select'
C:\Users\xia\AppData\Local\Temp\arduino_build_760981/core\core.a(usb.c.o): In function media_poll': usb.c:(.text.media_poll+0x14): undefined reference to spi_select'
usb.c:(.text.media_poll+0x36): undefined reference to sd_deselect' usb.c:(.text.media_poll+0x88): undefined reference to sd_deselect'
usb.c:(.text.media_poll+0xb6): undefined reference to sd_deselect' usb.c:(.text.media_poll+0x10e): undefined reference to sd_deselect'
C:\Users\xia\AppData\Local\Temp\arduino_build_760981/core\core.a(usb.c.o): In function __vector_11': usb.c:(.text.__vector_11+0x6b8): undefined reference to media_size'
usb.c:(.text.__vector_11+0x710): undefined reference to media_size' usb.c:(.text.__vector_11+0xa0a): undefined reference to sd_deselect'
usb.c:(.text.__vector_11+0xbaa): undefined reference to `sd_deselect'
collect2.exe: error: ld returned 1 exit status
Error compiling for board Teensy++ 2.0.

Fixed: just adding some attribute((always_inline)) declarations.