### PR TITLE
Remove unused variable from AudioStream.cpp

### DIFF
--- a/teensy4/AudioStream.cpp
+++ b/teensy4/AudioStream.cpp
@@ -336,8 +336,6 @@ int AudioConnection::connect(AudioStream &source, unsigned char sourceOutput,
 	
 	if (!isConnected)
 	{
-		int cr;
-		
 		src = &source;
 		dst = &destination;
 		src_index = sourceOutput;


### PR DESCRIPTION
Remove compiler warning

No big one...

Just noticed compiler warning and decided to try to remove it