### PR TITLE
T4 Rawhid RECV allow 0 wait

### DIFF
--- a/teensy4/usb_rawhid.c
+++ b/teensy4/usb_rawhid.c
@@ -104,7 +104,7 @@ int usb_rawhid_recv(void *buffer, uint32_t timeout)
 	while (1) {
 		if (!usb_configuration) return -1; // usb not enumerated by host
 		if (tail != rx_head) break;
-		if (systick_millis_count - wait_begin_at > timeout)  {
+		if ((systick_millis_count - wait_begin_at > timeout) || !timeout) {
 			return 0;
 		}
 		yield();


### PR DESCRIPTION
T3.x code base would bail if timeout=0 after checking once if there was a packet,
where T4.x would wait 1ms before returning.

This is in respect to the thread: https://forum.pjrc.com/threads/70350-Teensy-4-0-RawHID-recv()-lock-up

Warning I only did an initial test to see that the rawhid test still runs.
But was told that the change did fix the issue on the forum thread.