### PR TITLE
Add USB_MIDI16_DUAL_SERIAL USB descriptor

### DIFF
--- a/teensy4/usb_desc.h
+++ b/teensy4/usb_desc.h
@@ -584,6 +584,47 @@ let me know?  http://forum.pjrc.com/forums/4-Suggestions-amp-Bug-Reports
   #define ENDPOINT3_CONFIG	ENDPOINT_RECEIVE_BULK + ENDPOINT_TRANSMIT_BULK
   #define ENDPOINT4_CONFIG	ENDPOINT_RECEIVE_BULK + ENDPOINT_TRANSMIT_BULK
 
+#elif defined(USB_MIDI16_DUAL_SERIAL)
+  #define VENDOR_ID             0x16C0
+  #define PRODUCT_ID            0x0489
+  #define BCD_DEVICE            0x0213
+  #define MANUFACTURER_NAME     {'T','e','e','n','s','y','d','u','i','n','o'}
+  #define MANUFACTURER_NAME_LEN 11
+  #define PRODUCT_NAME          {'T','e','e','n','s','y',' ','M','I','D','I','x','1','6',' ','D','u','a','l',' ','S','e','r','i','a','l'}
+  #define PRODUCT_NAME_LEN      26
+  #define EP0_SIZE              64
+  #define NUM_ENDPOINTS         7
+  #define NUM_INTERFACE         5
+  #define CDC_IAD_DESCRIPTOR    1
+  #define CDC_STATUS_INTERFACE  0
+  #define CDC_DATA_INTERFACE    1       // Serial
+  #define CDC_ACM_ENDPOINT      2
+  #define CDC_RX_ENDPOINT       3
+  #define CDC_TX_ENDPOINT       3
+  #define CDC_ACM_SIZE          16
+  #define CDC_RX_SIZE_480       512
+  #define CDC_TX_SIZE_480       512
+  #define CDC_RX_SIZE_12        64
+  #define CDC_TX_SIZE_12        64
+  #define CDC2_STATUS_INTERFACE 2       // SerialUSB1
+  #define CDC2_DATA_INTERFACE   3
+  #define CDC2_ACM_ENDPOINT     4
+  #define CDC2_RX_ENDPOINT      5
+  #define CDC2_TX_ENDPOINT      5
+  #define MIDI_INTERFACE        4       // MIDI
+  #define MIDI_NUM_CABLES       16
+  #define MIDI_TX_ENDPOINT      6
+  #define MIDI_TX_SIZE_12       64
+  #define MIDI_TX_SIZE_480      512
+  #define MIDI_RX_ENDPOINT      6
+  #define MIDI_RX_SIZE_12       64
+  #define MIDI_RX_SIZE_480      512
+  #define ENDPOINT2_CONFIG      ENDPOINT_RECEIVE_UNUSED + ENDPOINT_TRANSMIT_INTERRUPT
+  #define ENDPOINT3_CONFIG      ENDPOINT_RECEIVE_BULK + ENDPOINT_TRANSMIT_BULK
+  #define ENDPOINT4_CONFIG      ENDPOINT_RECEIVE_UNUSED + ENDPOINT_TRANSMIT_INTERRUPT
+  #define ENDPOINT5_CONFIG      ENDPOINT_RECEIVE_BULK + ENDPOINT_TRANSMIT_BULK
+  #define ENDPOINT6_CONFIG      ENDPOINT_RECEIVE_BULK + ENDPOINT_TRANSMIT_BULK
+
 #elif defined(USB_RAWHID)
   #define VENDOR_ID		0x16C0
   #define PRODUCT_ID		0x0486


### PR DESCRIPTION
Adds a new USB_MIDI16_DUAL_SERIAL board type that supports USB, serial MIDI, and dual serial.  Useful for using along with the TeensyDebug library.  

Use it by adding something like this to your platformio.ini config:
`build_unflags = -D USB_SERIAL`
`build_flags = -D USB_MIDI16_DUAL_SERIAL`

Used and tested in my project https://github.com/doctea/usb_midi_clocker.