### PR TITLE
Add AudioMemoryNoForceUpdate()

### DIFF
--- a/teensy3/AudioStream.cpp
+++ b/teensy3/AudioStream.cpp
@@ -61,7 +61,7 @@ AudioConnection* AudioStream::unused = NULL; // linked list of unused but not de
 
 // Set up the pool of audio data blocks
 // placing them all onto the free list
-void AudioStream::initialize_memory(audio_block_t *data, unsigned int num)
+void AudioStream::initialize_memory(audio_block_t *data, unsigned int num, bool force_update)
 {
 	unsigned int i;
 	unsigned int maxnum = MAX_AUDIO_MEMORY / AUDIO_BLOCK_SAMPLES / 2;
@@ -81,7 +81,7 @@ void AudioStream::initialize_memory(audio_block_t *data, unsigned int num)
 	for (i=0; i < num; i++) {
 		data[i].memory_pool_index = i;
 	}
-	if (update_scheduled == false) {
+	if (update_scheduled == false && force_update) {
 		// if no hardware I/O has taken responsibility for update,
 		// start a timer which will call update_all() at the correct rate
 		IntervalTimer *timer = new IntervalTimer();

--- a/teensy3/AudioStream.h
+++ b/teensy3/AudioStream.h
@@ -114,6 +114,13 @@ protected:
 	AudioStream::initialize_memory(data, num); \
 })
 
+#define AudioMemoryNoForceUpdate(num) ({ \
+	static DMAMEM audio_block_t data[num]; \
+	AudioStream::initialize_memory(data, num, false); \
+})
+
+#define CYCLE_COUNTER_APPROX_PERCENT(n) (((float)((uint32_t)(n) * 6400u) * (float)(AUDIO_SAMPLE_RATE_EXACT / AUDIO_BLOCK_SAMPLES)) / (float)(F_CPU_ACTUAL))
+
 #if defined(KINETISK)
 #define CYCLE_COUNTER_APPROX_PERCENT(n) (((n) + (F_CPU / 32 / AUDIO_SAMPLE_RATE * AUDIO_BLOCK_SAMPLES / 100)) / (F_CPU / 16 / AUDIO_SAMPLE_RATE * AUDIO_BLOCK_SAMPLES / 100))
 #elif defined(KINETISL)
@@ -151,7 +158,7 @@ public:
 			cpu_cycles_max = 0;
 			numConnections = 0;
 		}
-	static void initialize_memory(audio_block_t *data, unsigned int num);
+	static void initialize_memory(audio_block_t *data, unsigned int num, bool force_update = true);
 	int processorUsage(void) { return CYCLE_COUNTER_APPROX_PERCENT(cpu_cycles); }
 	int processorUsageMax(void) { return CYCLE_COUNTER_APPROX_PERCENT(cpu_cycles_max); }
 	void processorUsageMaxReset(void) { cpu_cycles_max = cpu_cycles; }

--- a/teensy4/AudioStream.cpp
+++ b/teensy4/AudioStream.cpp
@@ -53,7 +53,7 @@ void software_isr(void);
 
 // Set up the pool of audio data blocks
 // placing them all onto the free list
-FLASHMEM void AudioStream::initialize_memory(audio_block_t *data, unsigned int num)
+FLASHMEM void AudioStream::initialize_memory(audio_block_t *data, unsigned int num, bool force_update)
 {
 	unsigned int i;
 	unsigned int maxnum = MAX_AUDIO_MEMORY / AUDIO_BLOCK_SAMPLES / 2;
@@ -73,7 +73,7 @@ FLASHMEM void AudioStream::initialize_memory(audio_block_t *data, unsigned int n
 	for (i=0; i < num; i++) {
 		data[i].memory_pool_index = i;
 	}
-	if (update_scheduled == false) {
+	if (update_scheduled == false && force_update) {
 		// if no hardware I/O has taken responsibility for update,
 		// start a timer which will call update_all() at the correct rate
 		IntervalTimer *timer = new IntervalTimer();

--- a/teensy4/AudioStream.h
+++ b/teensy4/AudioStream.h
@@ -109,6 +109,11 @@ protected:
 	AudioStream::initialize_memory(data, num); \
 })
 
+#define AudioMemoryNoForceUpdate(num) ({ \
+	static DMAMEM audio_block_t data[num]; \
+	AudioStream::initialize_memory(data, num, false); \
+})
+
 #define CYCLE_COUNTER_APPROX_PERCENT(n) (((float)((uint32_t)(n) * 6400u) * (float)(AUDIO_SAMPLE_RATE_EXACT / AUDIO_BLOCK_SAMPLES)) / (float)(F_CPU_ACTUAL))
 
 #define AudioProcessorUsage() (CYCLE_COUNTER_APPROX_PERCENT(AudioStream::cpu_cycles_total))
@@ -142,7 +147,7 @@ public:
 			cpu_cycles_max = 0;
 			numConnections = 0;
 		}
-	static void initialize_memory(audio_block_t *data, unsigned int num);
+	static void initialize_memory(audio_block_t *data, unsigned int num, bool force_update = true);
 	float processorUsage(void) { return CYCLE_COUNTER_APPROX_PERCENT(cpu_cycles); }
 	float processorUsageMax(void) { return CYCLE_COUNTER_APPROX_PERCENT(cpu_cycles_max); }
 	void processorUsageMaxReset(void) { cpu_cycles_max = cpu_cycles; }


### PR DESCRIPTION
Although most users will need audio updates working, for development purposes it's sometime helpful to disable them and run updates from within the sketch. This feature adds that capability back in, which was removed in commit 503cd9f