### PR TITLE
Fix for Conflict with abs/round with stdlib (toolchain 11.3.1 issue)

### DIFF
--- a/teensy3/wiring.h
+++ b/teensy3/wiring.h
@@ -129,29 +129,38 @@ constexpr auto max(A&& a, B&& b) -> decltype(a < b ? std::forward<A>(a) : std::f
 #define SERIAL  0
 #define DISPLAY 1
 
+//commented out as a result of moving to 11.3.1 toolchain
 // undefine stdlib's abs if encountered
-#ifdef abs
+/*#ifdef abs
 #undef abs
 #endif
+*/
 
 #if __cplusplus >= 201103L && defined(__STRICT_ANSI__)
 #define typeof(a) decltype(a)
 #endif
 
+/* 11.3.1 toolchain change
 #define abs(x) ({ \
   typeof(x) _x = (x); \
   (_x > 0) ? _x : -_x; \
 })
+*/
+
 #define constrain(amt, low, high) ({ \
   typeof(amt) _amt = (amt); \
   typeof(low) _low = (low); \
   typeof(high) _high = (high); \
   (_amt < _low) ? _low : ((_amt > _high) ? _high : _amt); \
 })
+
+/* 11.3.1 toolchain change
 #define round(x) ({ \
   typeof(x) _x = (x); \
   (_x>=0) ? (long)(_x+0.5) : (long)(_x-0.5); \
 })
+*/
+
 #define radians(deg) ((deg)*DEG_TO_RAD)
 #define degrees(rad) ((rad)*RAD_TO_DEG)
 #define sq(x) ({ \

--- a/teensy4/wiring.h
+++ b/teensy4/wiring.h
@@ -153,25 +153,27 @@ constexpr auto max(A&& a, B&& b) -> decltype(a < b ? std::forward<A>(a) : std::f
 #define DISPLAY 1
 
 // undefine stdlib's abs if encountered
-#ifdef abs
-#undef abs
+/*#ifdef abs
+  #undef abs
 #endif
+*/
 
 #if __cplusplus >= 201103L && defined(__STRICT_ANSI__)
 #define typeof(a) decltype(a)
 #endif
 
-#define abs(x) ({ \
+/*#define abs(x) ({ \
   typeof(x) _x = (x); \
   (_x > 0) ? _x : -_x; \
 })
+*/
 #define constrain(amt, low, high) ({ \
   typeof(amt) _amt = (amt); \
   typeof(low) _low = (low); \
   typeof(high) _high = (high); \
   (_amt < _low) ? _low : ((_amt > _high) ? _high : _amt); \
 })
-#define round(x) ((long) __builtin_round(x))
+//#define round(x) ((long) __builtin_round(x))
 
 #define radians(deg) ((deg)*DEG_TO_RAD)
 #define degrees(rad) ((rad)*RAD_TO_DEG)


### PR DESCRIPTION
@PaulStoffregen  -- @flybrianfly

When testing some other libraries that we used [Eigen](https://github.com/bolderflight/eigen) and a [Ublox ](https://github.com/bolderflight/ublox) I was receiving a ton of errors all related to using abs and round defined in wiring.h.  Noticed that there was an open issue with brtaylor's Eigen library for the same thing when using toolchain 7,x.x.  So made the changes in wiring and it did indeed clear up the issue.  

See issue: https://forum.pjrc.com/threads/71074-Teensyduino-1-58-Beta-2?p=312709&viewfull=1#post312709

The PR makes the change for Teensy4 and Teensy3. 
