### PR TITLE
Call yield() from second/third USB serial bool()

### DIFF
--- a/teensy3/usb_serial2.h
+++ b/teensy3/usb_serial2.h
@@ -113,7 +113,9 @@ public:
         uint8_t numbits(void) { return usb_cdc2_line_coding[1] >> 16; }
         uint8_t dtr(void) { return (usb_cdc2_line_rtsdtr & USB_SERIAL_DTR) ? 1 : 0; }
         uint8_t rts(void) { return (usb_cdc2_line_rtsdtr & USB_SERIAL_RTS) ? 1 : 0; }
-        operator bool() { return usb_configuration && (usb_cdc2_line_rtsdtr & USB_SERIAL_DTR) &&
+        operator bool() {
+		yield();
+		return usb_configuration && (usb_cdc2_line_rtsdtr & USB_SERIAL_DTR) &&
 		((uint32_t)(systick_millis_count - usb_cdc2_line_rtsdtr_millis) >= 15);
 	}
 	size_t readBytes(char *buffer, size_t length) {

--- a/teensy3/usb_serial3.h
+++ b/teensy3/usb_serial3.h
@@ -113,7 +113,9 @@ public:
         uint8_t numbits(void) { return usb_cdc3_line_coding[1] >> 16; }
         uint8_t dtr(void) { return (usb_cdc3_line_rtsdtr & USB_SERIAL_DTR) ? 1 : 0; }
         uint8_t rts(void) { return (usb_cdc3_line_rtsdtr & USB_SERIAL_RTS) ? 1 : 0; }
-        operator bool() { return usb_configuration && (usb_cdc3_line_rtsdtr & USB_SERIAL_DTR) &&
+        operator bool() {
+		yield();
+		return usb_configuration && (usb_cdc3_line_rtsdtr & USB_SERIAL_DTR) &&
 		((uint32_t)(systick_millis_count - usb_cdc3_line_rtsdtr_millis) >= 15);
 	}
 	size_t readBytes(char *buffer, size_t length) {

--- a/teensy4/usb_serial.h
+++ b/teensy4/usb_serial.h
@@ -298,7 +298,9 @@ public:
         uint8_t numbits(void) { return usb_cdc2_line_coding[1] >> 16; }
         uint8_t dtr(void) { return (usb_cdc2_line_rtsdtr & USB_SERIAL_DTR) ? 1 : 0; }
         uint8_t rts(void) { return (usb_cdc2_line_rtsdtr & USB_SERIAL_RTS) ? 1 : 0; }
-        operator bool() { return usb_configuration && (usb_cdc2_line_rtsdtr & USB_SERIAL_DTR) &&
+        operator bool() {
+		yield();
+		return usb_configuration && (usb_cdc2_line_rtsdtr & USB_SERIAL_DTR) &&
                 ((uint32_t)(systick_millis_count - usb_cdc2_line_rtsdtr_millis) >= 15);
         }
         size_t readBytes(char *buffer, size_t length) {
@@ -386,7 +388,9 @@ public:
         uint8_t numbits(void) { return usb_cdc3_line_coding[1] >> 16; }
         uint8_t dtr(void) { return (usb_cdc3_line_rtsdtr & USB_SERIAL_DTR) ? 1 : 0; }
         uint8_t rts(void) { return (usb_cdc3_line_rtsdtr & USB_SERIAL_RTS) ? 1 : 0; }
-        operator bool() { return usb_configuration && (usb_cdc3_line_rtsdtr & USB_SERIAL_DTR) &&
+        operator bool() {
+		yield();
+		return usb_configuration && (usb_cdc3_line_rtsdtr & USB_SERIAL_DTR) &&
                 ((uint32_t)(systick_millis_count - usb_cdc3_line_rtsdtr_millis) >= 15);
         }
         size_t readBytes(char *buffer, size_t length) {


### PR DESCRIPTION
Calls to yield() were added to most USB serial implementations of bool(), but usb_serial2 and usb_serial3 were forgotten.

Fixes: fef5134667b81e11 ("Call yield() from Serial begin, available, operator bool")
Signed-off-by: Geert Uytterhoeven <geert@linux-m68k.org>