### PR TITLE
Allow AudioConnection constructor to have void parameter list

### DIFF
--- a/teensy3/AudioStream.cpp
+++ b/teensy3/AudioStream.cpp
@@ -209,28 +209,19 @@ audio_block_t * AudioStream::receiveWritable(unsigned int index)
 }
 
 /**************************************************************************************/
-// Full constructor with 4 parameters
-AudioConnection::AudioConnection(AudioStream &source, unsigned char sourceOutput,
-		AudioStream &destination, unsigned char destinationInput)
+// Constructor with no parameters: leave unconnected
+AudioConnection::AudioConnection()
+	: src(NULL), dst(NULL),
+	  src_index(0), dest_index(0),
+	  isConnected(false)
+
 {
-	// we are effectively unused right now, so
+	// we are unused right now, so
 	// link ourselves at the start of the unused list
 	next_dest = AudioStream::unused;
 	AudioStream::unused = this;
-	
-	isConnected = false;	  
-	connect(source,sourceOutput,destination,destinationInput); 
 }
 
-// Simplified constructor assuming channel 0 at both ends
-AudioConnection::AudioConnection(AudioStream &source, AudioStream &destination)
-{
-	next_dest = AudioStream::unused;
-	AudioStream::unused = this;
-	
-	isConnected = false;	  
-	connect(source, 0, destination,0);
-}
 
 // Destructor
 AudioConnection::~AudioConnection()

--- a/teensy3/AudioStream.h
+++ b/teensy3/AudioStream.h
@@ -86,9 +86,12 @@ typedef struct audio_block_struct {
 class AudioConnection
 {
 public:
-	AudioConnection(AudioStream &source, AudioStream &destination);
+	AudioConnection();
+	AudioConnection(AudioStream &source, AudioStream &destination)
+		: AudioConnection() { connect(source,destination); }
 	AudioConnection(AudioStream &source, unsigned char sourceOutput,
-		AudioStream &destination, unsigned char destinationInput);
+		AudioStream &destination, unsigned char destinationInput)
+		: AudioConnection() { connect(source,sourceOutput, destination,destinationInput); }
 	friend class AudioStream;
 	~AudioConnection(); 
 	int disconnect(void);

--- a/teensy4/AudioStream.cpp
+++ b/teensy4/AudioStream.cpp
@@ -201,28 +201,19 @@ audio_block_t * AudioStream::receiveWritable(unsigned int index)
 }
 
 /**************************************************************************************/
-// Full constructor with 4 parameters
-AudioConnection::AudioConnection(AudioStream &source, unsigned char sourceOutput,
-		AudioStream &destination, unsigned char destinationInput)
+// Constructor with no parameters: leave unconnected
+AudioConnection::AudioConnection() 
+	: src(NULL), dst(NULL),
+	  src_index(0), dest_index(0),
+	  isConnected(false)
+
 {
-	// we are effectively unused right now, so
+	// we are unused right now, so
 	// link ourselves at the start of the unused list
 	next_dest = AudioStream::unused;
 	AudioStream::unused = this;
-	
-	isConnected = false;	  
-	connect(source,sourceOutput,destination,destinationInput); 
 }
 
-// Simplified constructor assuming channel 0 at both ends
-AudioConnection::AudioConnection(AudioStream &source, AudioStream &destination)
-{
-	next_dest = AudioStream::unused;
-	AudioStream::unused = this;
-	
-	isConnected = false;	  
-	connect(source, 0, destination,0);
-}
 
 // Destructor
 AudioConnection::~AudioConnection()

--- a/teensy4/AudioStream.h
+++ b/teensy4/AudioStream.h
@@ -81,9 +81,12 @@ typedef struct audio_block_struct {
 class AudioConnection
 {
 public:
-	AudioConnection(AudioStream &source, AudioStream &destination);
+	AudioConnection();
+	AudioConnection(AudioStream &source, AudioStream &destination)
+		: AudioConnection() { connect(source,destination); }
 	AudioConnection(AudioStream &source, unsigned char sourceOutput,
-		AudioStream &destination, unsigned char destinationInput);
+		AudioStream &destination, unsigned char destinationInput)
+		: AudioConnection() { connect(source,sourceOutput, destination,destinationInput); }
 	friend class AudioStream;
 	~AudioConnection(); 
 	int disconnect(void);


### PR DESCRIPTION
This allows for creation of "empty" connection objects, which can be connected up later. See https://forum.pjrc.com/threads/71617-Default-constructor-for-AudioConnection

in addition, I've tidied up some duplicated code by making use of delegating constructors and member initializers, which should make it easier to maintain correctly in the future.

Implemented for both Teensy 3.x and 4.x, tested with TD 1.58beta2 to ensure no warnings!