### PR TITLE
Implement move semantics for File objects.

### DIFF
--- a/teensy/FS.h
+++ b/teensy/FS.h
@@ -92,7 +92,7 @@ private:
 
 
 
-// TODO: does this help in any way, or just extra useless code?
+// File move semantics require rvalue references, introduced in C++11.
 //#define FILE_USE_MOVE
 
 
@@ -130,11 +130,14 @@ public:
 		//Serial.printf("File copy ctor %x, refcount=%d\n", (int)f, get_refcount());
 	}
 #ifdef FILE_USE_MOVE
-	// Move constructor.
-	File(const File&& file) {
+	// Move constructor. Typically used when a File is passed by rvalue
+	// reference into a function, such as when using std::move(). The
+	// original file is closed, and the refcount of the underlying
+	// FileImpl is unchanged.
+	File(File&& file) {
 		f = file.f;
-		if (f) f->refcount++;
-		//Serial.printf("File copy ctor %x, refcount=%d\n", (int)f, get_refcount());
+		file.f = nullptr;
+		//Serial.printf("File move ctor %x, refcount=%d\n", (int)f, get_refcount());
 	}
 #endif
 	// Copy assignment.
@@ -147,11 +150,11 @@ public:
 	}
 #ifdef FILE_USE_MOVE
 	// Move assignment.
-	File& operator = (const File&& file) {
+	File& operator = (File&& file) {
 		//Serial.println("File move assignment");
-		if (file.f) file.f->refcount++;
 		if (f) { dec_refcount(); /*Serial.println("File move assignment autoclose");*/ }
 		f = file.f;
+		file.f = nullptr;
 		return *this;
 	}
 #endif

--- a/teensy4/FS.h
+++ b/teensy4/FS.h
@@ -92,7 +92,7 @@ private:
 
 
 
-// TODO: does this help in any way, or just extra useless code?
+// File move semantics require rvalue references, introduced in C++11.
 #define FILE_USE_MOVE
 
 
@@ -130,11 +130,14 @@ public:
 		//Serial.printf("File copy ctor %x, refcount=%d\n", (int)f, get_refcount());
 	}
 #ifdef FILE_USE_MOVE
-	// Move constructor.
-	File(const File&& file) {
+	// Move constructor. Typically used when a File is passed by rvalue
+	// reference into a function, such as when using std::move(). The
+	// original file is closed, and the refcount of the underlying
+	// FileImpl is unchanged.
+	File(File&& file) {
 		f = file.f;
-		if (f) f->refcount++;
-		//Serial.printf("File copy ctor %x, refcount=%d\n", (int)f, get_refcount());
+		file.f = nullptr;
+		//Serial.printf("File move ctor %x, refcount=%d\n", (int)f, get_refcount());
 	}
 #endif
 	// Copy assignment.
@@ -147,11 +150,11 @@ public:
 	}
 #ifdef FILE_USE_MOVE
 	// Move assignment.
-	File& operator = (const File&& file) {
+	File& operator = (File&& file) {
 		//Serial.println("File move assignment");
-		if (file.f) file.f->refcount++;
 		if (f) { dec_refcount(); /*Serial.println("File move assignment autoclose");*/ }
 		f = file.f;
+		file.f = nullptr;
 		return *this;
 	}
 #endif


### PR DESCRIPTION
The current implementation of the File move constructor and move assignment functions are identical to the copy constructor and copy assignment functions, respectively.

While move constructors and move assignments do not require specific semantics regarding the state of the moved-from object [1], many C++ libraries, including the C++ standard library, do employ semantics which guarantee that the moved-from object is left "empty", example [2].

By using proper semantics on File objects, we can avoid incrementing then decrementing the refcount of the underlying FileImpl.

[1]: https://en.cppreference.com/w/cpp/language/move_constructor
[2]: https://en.cppreference.com/w/cpp/container/vector/vector