### PR TITLE
Make _gettimeofday() weak

### DIFF
--- a/teensy3/pins_teensy.c
+++ b/teensy3/pins_teensy.c
@@ -386,6 +386,7 @@ void rtc_compensate(int adjust)
 	RTC_TCR = ((interval - 1) << 8) | tcr;
 }
 
+__attribute__((weak))
 int _gettimeofday(struct timeval *tv, void *ignore)
 {
 	uint32_t sec = RTC_TSR;
@@ -408,6 +409,8 @@ int _gettimeofday(struct timeval *tv, void *ignore)
 unsigned long rtc_get(void) { return 0; }
 void rtc_set(unsigned long t) { }
 void rtc_compensate(int adjust) { }
+
+__attribute__((weak))
 int _gettimeofday(struct timeval *tv, void *ignore) { return -1; }
 
 #endif

--- a/teensy4/rtc.c
+++ b/teensy4/rtc.c
@@ -71,6 +71,7 @@ void rtc_compensate(int adjust)
 
 // https://github.com/arduino-libraries/ArduinoBearSSL/issues/54
 // https://forum.pjrc.com/threads/70966
+__attribute__((weak))
 int _gettimeofday(struct timeval *tv, void *ignore)
 {
 	uint32_t hi1 = SNVS_HPRTCMR;


### PR DESCRIPTION
The reason is similar to the reason for making _write() weak: an application may wish to override the behaviour.