### PR TITLE
Fix build with LTO

### DIFF
--- a/teensy3/EventResponder.cpp
+++ b/teensy3/EventResponder.cpp
@@ -42,9 +42,9 @@ bool EventResponder::runningFromYield = false;
 
 // TODO: interrupt disable/enable needed in many places!!!
 // BUGBUG: See if file name order makes difference?
-uint8_t _serialEvent_default __attribute__((weak)) PROGMEM = 0 ;	
-uint8_t _serialEventUSB1_default __attribute__((weak)) PROGMEM = 0 ;	
-uint8_t _serialEventUSB2_default __attribute__((weak)) PROGMEM = 0 ;	
+extern const uint8_t _serialEvent_default __attribute__((weak)) PROGMEM = 0 ;
+extern const uint8_t _serialEventUSB1_default __attribute__((weak)) PROGMEM = 0 ;
+extern const uint8_t _serialEventUSB2_default __attribute__((weak)) PROGMEM = 0 ;
 
 void EventResponder::triggerEventNotImmediate()
 {

--- a/teensy3/serialEvent.cpp
+++ b/teensy3/serialEvent.cpp
@@ -3,4 +3,4 @@
 void serialEvent() __attribute__((weak));
 void serialEvent() {
 }
-uint8_t _serialEvent_default PROGMEM = 1;	
+const uint8_t _serialEvent_default PROGMEM = 1;

--- a/teensy4/EventResponder.cpp
+++ b/teensy4/EventResponder.cpp
@@ -42,9 +42,9 @@ bool EventResponder::runningFromYield = false;
 
 // TODO: interrupt disable/enable needed in many places!!!
 // BUGBUG: See if file name order makes difference?
-uint8_t _serialEvent_default __attribute__((weak)) PROGMEM = 0 ;	
-uint8_t _serialEventUSB1_default __attribute__((weak)) PROGMEM = 0 ;	
-uint8_t _serialEventUSB2_default __attribute__((weak)) PROGMEM = 0 ;	
+extern const uint8_t _serialEvent_default __attribute__((weak)) PROGMEM = 0 ;
+extern const uint8_t _serialEventUSB1_default __attribute__((weak)) PROGMEM = 0 ;
+extern const uint8_t _serialEventUSB2_default __attribute__((weak)) PROGMEM = 0 ;
 
 void EventResponder::triggerEventNotImmediate()
 {

--- a/teensy4/serialEvent.cpp
+++ b/teensy4/serialEvent.cpp
@@ -3,4 +3,4 @@
 void serialEvent() __attribute__((weak));
 void serialEvent() {
 }
-uint8_t _serialEvent_default PROGMEM = 1;	
+const uint8_t _serialEvent_default PROGMEM = 1;


### PR DESCRIPTION
Make _serialEvent_default "const" and also make the weak definitions "extern" (aka "public"). The first change resolves the section type conflicts and the second change resolves the "weak declaration must be public" errors.

See also: https://gcc.gnu.org/legacy-ml/gcc-help/2017-12/msg00021.html