### PR TITLE
Fix a startup issue with non-default optimisation option

### DIFF
--- a/teensy4/startup.c
+++ b/teensy4/startup.c
@@ -509,6 +509,11 @@ FLASHMEM void usb_pll_start()
 	}
 }
 
+// For some reason compiling this file with e.g. -Og causes an issue, resulting
+// in the Teensy never starting up and enumerating, and the user having to press
+// the Program button to get back to bootloader mode. Changing to -O2 optimisation
+// for this one function seems to fix the issue.
+__attribute__((optimize("O2")))
 FLASHMEM void reset_PFD()
 {	
 	//Reset PLL2 PFDs, set default frequencies:


### PR DESCRIPTION
For some reason compiling `startup.c` with e.g. -Og causes an issue, resulting in the Teensy never starting up and enumerating, and the user having to press the Program button to get back to bootloader mode. Changing to -O2 optimisation for the `reset_PFD()` function seems to fix the issue.

As discussed in https://forum.pjrc.com/threads/71846-Teensy4-1-optimisation-0g-00-fails-to-start, for example. Fairly sure there are multiple similar reports / threads. A good way to provoke it is to try to use the Audio and TeensyDebug libraries together.