### PR TITLE
Add option for custom USB configuration

### DIFF
--- a/teensy3/usb_desc.h
+++ b/teensy3/usb_desc.h
@@ -115,8 +115,12 @@ If these instructions are missing steps or could be improved, please
 let me know?  http://forum.pjrc.com/forums/4-Suggestions-amp-Bug-Reports
 */
 
+#if defined(USB_CUSTOM)
+#include "usb_custom.h"  // use custom include file to set up USB configuration
+                         // requires to set include path, so that usb_custom.h
+                         // is found in user sketch directory
 
-#if defined(USB_SERIAL)
+#elif defined(USB_SERIAL)
   #define VENDOR_ID		0x16C0
   #define PRODUCT_ID		0x0483
   #define DEVICE_CLASS		2	// 2 = Communication Class

--- a/teensy4/usb_desc.h
+++ b/teensy4/usb_desc.h
@@ -111,7 +111,12 @@ let me know?  http://forum.pjrc.com/forums/4-Suggestions-amp-Bug-Reports
 */
 
 
-#if defined(USB_SERIAL)
+#if defined(USB_CUSTOM)
+#include "usb_custom.h"  // use custom include file to set up USB configuration
+                         // requires to set include path, so that usb_custom.h
+                         // is found in user sketch directory
+
+#elif defined(USB_SERIAL)
   #define VENDOR_ID		0x16C0
   #define PRODUCT_ID		0x0483
   #define MANUFACTURER_NAME	{'T','e','e','n','s','y','d','u','i','n','o'}


### PR DESCRIPTION
Setting -DUSB_CUSTOM and -I./include allows to specify a custom USB configuration from sketch file include/usb_custom.h

I use this together with platformio to handle a use case where I need a very specific USB configuration "FlightSim + dual Serial". It wouldn't make any sense to include this in the standard USB configurations, yet it is a valid use case. Therefore, I suggest to allow custom USB configurations. In my specific use case, my usb_custom.h file looks like this:

```
#if defined(__IMXRT1062__)
// Teensy 4.x

#define VENDOR_ID		0x16C0
#define PRODUCT_ID		0x0488
#define BCD_DEVICE		0x0212
#define MANUFACTURER_NAME	{'T','e','e','n','s','y','d','u','i','n','o'}
#define MANUFACTURER_NAME_LEN	11
#define PRODUCT_NAME		{'T','e','e','n','s','y',' ','F','l','i','g','h','t',' ','S','i','m',' ','C','o','n','t','r','o','l','s'}
#define PRODUCT_NAME_LEN	26
#define EP0_SIZE              64
#define NUM_ENDPOINTS         6
#define NUM_INTERFACE         5
#define CDC_IAD_DESCRIPTOR    1       // Serial
#define CDC_STATUS_INTERFACE  0
#define CDC_DATA_INTERFACE    1
#define CDC_ACM_ENDPOINT      2
#define CDC_RX_ENDPOINT       3
#define CDC_TX_ENDPOINT       3
#define CDC_ACM_SIZE          16
#define CDC_RX_SIZE_480       512
#define CDC_TX_SIZE_480       512
#define CDC_RX_SIZE_12        64
#define CDC_TX_SIZE_12        64
#define CDC2_STATUS_INTERFACE 2       // SerialUSB1
#define CDC2_DATA_INTERFACE   3
#define CDC2_ACM_ENDPOINT     4
#define CDC2_RX_ENDPOINT      5
#define CDC2_TX_ENDPOINT      5
#define ENDPOINT2_CONFIG	ENDPOINT_RECEIVE_UNUSED + ENDPOINT_TRANSMIT_INTERRUPT
#define ENDPOINT3_CONFIG	ENDPOINT_RECEIVE_BULK + ENDPOINT_TRANSMIT_BULK
#define ENDPOINT4_CONFIG	ENDPOINT_RECEIVE_UNUSED + ENDPOINT_TRANSMIT_INTERRUPT
#define ENDPOINT5_CONFIG	ENDPOINT_RECEIVE_BULK + ENDPOINT_TRANSMIT_BULK
#define FLIGHTSIM_INTERFACE	4	// Flight Sim Control
#define FLIGHTSIM_TX_ENDPOINT	6
#define FLIGHTSIM_TX_SIZE	64
#define FLIGHTSIM_TX_INTERVAL	1
#define FLIGHTSIM_RX_ENDPOINT	6
#define FLIGHTSIM_RX_SIZE	64
#define FLIGHTSIM_RX_INTERVAL	1
#define ENDPOINT6_CONFIG	ENDPOINT_RECEIVE_BULK + ENDPOINT_TRANSMIT_BULK

#elif defined(__MK66FX1M0__) || defined(__MK64FX512__) || defined(__MK20DX256__) || defined(__MK20DX128__) || defined(__MKL26Z64__)
// Teensy 3.x

#define VENDOR_ID		0x16C0
#define PRODUCT_ID		0x0488
#define BCD_DEVICE		0x0211
#define MANUFACTURER_NAME	{'T','e','e','n','s','y','d','u','i','n','o'}
#define MANUFACTURER_NAME_LEN	11
#define PRODUCT_NAME		{'T','e','e','n','s','y',' ','F','l','i','g','h','t',' ','S','i','m',' ','C','o','n','t','r','o','l','s'}
#define PRODUCT_NAME_LEN	26
#define EP0_SIZE		64
#define NUM_ENDPOINTS         9
#define NUM_USB_BUFFERS	20
#define NUM_INTERFACE		5
#define CDC_IAD_DESCRIPTOR	1	// Serial
#define CDC_STATUS_INTERFACE	0
#define CDC_DATA_INTERFACE	1
#define CDC_ACM_ENDPOINT	2
#define CDC_RX_ENDPOINT	3
#define CDC_TX_ENDPOINT	4
#define CDC_ACM_SIZE		16
#define CDC_RX_SIZE		64
#define CDC_TX_SIZE		64
#define CDC2_STATUS_INTERFACE	2	// SerialUSB1
#define CDC2_DATA_INTERFACE	3
#define CDC2_ACM_ENDPOINT	5
#define CDC2_RX_ENDPOINT	6
#define CDC2_TX_ENDPOINT	7
#define CDC2_ACM_SIZE		16
#define CDC2_RX_SIZE		64
#define CDC2_TX_SIZE		64
#define ENDPOINT2_CONFIG	ENDPOINT_TRANSMIT_ONLY
#define ENDPOINT3_CONFIG	ENDPOINT_RECEIVE_ONLY
#define ENDPOINT4_CONFIG	ENDPOINT_TRANSMIT_ONLY
#define ENDPOINT5_CONFIG	ENDPOINT_TRANSMIT_ONLY
#define ENDPOINT6_CONFIG	ENDPOINT_RECEIVE_ONLY
#define ENDPOINT7_CONFIG	ENDPOINT_TRANSMIT_ONLY
#define FLIGHTSIM_INTERFACE	4	// Flight Sim Control
#define FLIGHTSIM_TX_ENDPOINT	8
#define FLIGHTSIM_TX_SIZE	64
#define FLIGHTSIM_TX_INTERVAL	1
#define FLIGHTSIM_RX_ENDPOINT	9
#define FLIGHTSIM_RX_SIZE	64
#define FLIGHTSIM_RX_INTERVAL	1
#define ENDPOINT8_CONFIG	ENDPOINT_TRANSMIT_ONLY
#define ENDPOINT9_CONFIG	ENDPOINT_RECEIVE_ONLY
#else

#pragma error "USB customizing only works for Teensy 3.x or 4.x"
#endif
```
