### PR TITLE
Change _write() to return -1 if the file is stdin

### DIFF
--- a/teensy3/Print.cpp
+++ b/teensy3/Print.cpp
@@ -86,7 +86,11 @@ extern "C" {
 __attribute__((weak))
 int _write(int file, char *ptr, int len)
 {
-	if (file >= 0 && file <= 2) file = (int)&Serial;
+	if (file == 0) {  // stdin
+		return -1;
+	} else if (1 <= file && file <= 2) {  // stdout & stderr
+		file = (int)&Serial;
+	}
 	((class Print *)file)->write((uint8_t *)ptr, len);
 	return len;
 }

--- a/teensy4/Print.cpp
+++ b/teensy4/Print.cpp
@@ -92,7 +92,11 @@ extern "C" {
 __attribute__((weak))
 int _write(int file, char *ptr, int len)
 {
-	if (file >= 0 && file <= 2) file = (int)&Serial;
+	if (file == 0) {  // stdin
+		return -1;
+	} else if (1 <= file && file <= 2) {  // stdout & stderr
+		file = (int)&Serial;
+	}
 	((class Print *)file)->write((uint8_t *)ptr, len);
 	return len;
 }


### PR DESCRIPTION
Note that ideally, `errno` should be set if the file is `stdin`. I'll create a separate PR for that. Returning zero seems like a reasonable choice for now.