### PR TITLE
Change _write() to return Print->write() return value

### DIFF
--- a/teensy3/Print.cpp
+++ b/teensy3/Print.cpp
@@ -87,8 +87,7 @@ __attribute__((weak))
 int _write(int file, char *ptr, int len)
 {
 	if (file >= 0 && file <= 2) file = (int)&Serial;
-	((class Print *)file)->write((uint8_t *)ptr, len);
-	return len;
+	return ((class Print *)file)->write((uint8_t *)ptr, len);
 }
 }
 

--- a/teensy4/Print.cpp
+++ b/teensy4/Print.cpp
@@ -93,8 +93,7 @@ __attribute__((weak))
 int _write(int file, char *ptr, int len)
 {
 	if (file >= 0 && file <= 2) file = (int)&Serial;
-	((class Print *)file)->write((uint8_t *)ptr, len);
-	return len;
+	return ((class Print *)file)->write((uint8_t *)ptr, len);
 }
 }
 


### PR DESCRIPTION
This change accommodates the underlying `Print->write()`'s write count, so that implementations correctly return actual bytes written.