### PR TITLE
Fix UK keyboard compile warning

### DIFF
--- a/teensy/keylayouts.h
+++ b/teensy/keylayouts.h
@@ -1446,8 +1446,8 @@ extern "C"{
 
 #define SHIFT_MASK		0x0040
 #define ALTGR_MASK		0x0080
-#define KEYCODE_TYPE		uint8_t
-#define KEYCODE_MASK		0x00FF
+#define KEYCODE_TYPE		uint16_t
+#define KEYCODE_MASK		0x07FF
 #define KEY_NON_US_100		63
 
 #define ASCII_20	KEY_SPACE				// 32  

--- a/teensy3/keylayouts.h
+++ b/teensy3/keylayouts.h
@@ -1446,8 +1446,8 @@ extern "C"{
 
 #define SHIFT_MASK		0x0040
 #define ALTGR_MASK		0x0080
-#define KEYCODE_TYPE		uint8_t
-#define KEYCODE_MASK		0x00FF
+#define KEYCODE_TYPE		uint16_t
+#define KEYCODE_MASK		0x07FF
 #define KEY_NON_US_100		63
 
 #define ASCII_20	KEY_SPACE				// 32  

--- a/teensy4/keylayouts.h
+++ b/teensy4/keylayouts.h
@@ -1446,8 +1446,8 @@ extern "C"{
 
 #define SHIFT_MASK		0x0040
 #define ALTGR_MASK		0x0080
-#define KEYCODE_TYPE		uint8_t
-#define KEYCODE_MASK		0x00FF
+#define KEYCODE_TYPE		uint16_t
+#define KEYCODE_MASK		0x07FF
 #define KEY_NON_US_100		63
 
 #define ASCII_20	KEY_SPACE				// 32  


### PR DESCRIPTION
Because this keyboard defines KEYCODE_EXTRA00, usb_keyboard.c's unicode_to_keycode() can return a 16-bit quantity.

See:
https://forum.pjrc.com/threads/71926-Button-Press-detector?p=319143&viewfull=1#post319143