### PR TITLE
Ensure all _serialEvent_default definitions and declarations match

### DIFF
--- a/teensy3/serialEvent.cpp
+++ b/teensy3/serialEvent.cpp
@@ -3,4 +3,4 @@
 void serialEvent() __attribute__((weak));
 void serialEvent() {
 }
-const uint8_t _serialEvent_default PROGMEM = 1;
+extern const uint8_t _serialEvent_default PROGMEM = 1;

--- a/teensy4/serialEvent.cpp
+++ b/teensy4/serialEvent.cpp
@@ -3,4 +3,4 @@
 void serialEvent() __attribute__((weak));
 void serialEvent() {
 }
-const uint8_t _serialEvent_default PROGMEM = 1;
+extern const uint8_t _serialEvent_default PROGMEM = 1;


### PR DESCRIPTION
Make sure they all have 'extern const' so that the weak versions get properly overridden.

See: https://github.com/PaulStoffregen/cores/issues/681

Fixes #681