### PR TITLE
User configurable interrupt handling for EventResponder

### DIFF
--- a/teensy3/EventResponder.cpp
+++ b/teensy3/EventResponder.cpp
@@ -77,7 +77,7 @@ void EventResponder::triggerEventNotImmediate()
 				_prev->_next = this;
 				lastInterrupt = this;
 			}
-			SCB_ICSR = SCB_ICSR_PENDSVSET; // set PendSV interrupt
+			event_responder_set_pend_sv(); // set PendSV interrupt
 		} else {
 			// detached, easy :-)
 		}
@@ -314,14 +314,16 @@ void MillisTimer::runFromTimer()
 			timer = listActive;
 		}
 	}
-	bool irq = disableTimerInterrupt();
-	MillisTimer *waiting = listWaiting;
-	listWaiting = nullptr; // TODO: use STREX to avoid interrupt disable
-	enableTimerInterrupt(irq);
-	while (waiting) {
-		MillisTimer *next = waiting->_next;
-		waiting->addToActiveList();
-		waiting = next;
+	if (listWaiting) {
+		bool irq = disableTimerInterrupt();
+		MillisTimer *waiting = listWaiting;
+		listWaiting = nullptr; // TODO: use STREX to avoid interrupt disable
+		enableTimerInterrupt(irq);
+		while (waiting) {
+			MillisTimer *next = waiting->_next;
+			waiting->addToActiveList();
+			waiting = next;
+		}
 	}
 }
 
@@ -351,5 +353,15 @@ extern "C" void systick_isr_with_timer_events(void)
 	MillisTimer::runFromTimer();
 }
 
+extern "C" __attribute__((weak)) void setup_systick_with_timer_events() 
+{
+	SCB_SHPR3 = SCB_SHPR3 | 0x00FF0000; // configure PendSV, lowest priority
+	// Make sure we are using the systic ISR that process this
+	_VectorsRam[15] = systick_isr_with_timer_events;
+	__asm volatile ("dsb st" ::: "memory");
+}
 
-
+extern "C" __attribute__((weak)) void event_responder_set_pend_sv() 
+{
+	SCB_ICSR = SCB_ICSR_PENDSVSET; // set PendSV interrupt
+}

--- a/teensy3/EventResponder.h
+++ b/teensy3/EventResponder.h
@@ -61,6 +61,10 @@
  */
 extern "C" void systick_isr_with_timer_events(void);
 
+extern "C" void setup_systick_with_timer_events();
+
+extern "C" void event_responder_set_pend_sv();
+
 class EventResponder;
 typedef EventResponder& EventResponderRef;
 typedef void (*EventResponderFunction)(EventResponderRef);
@@ -113,9 +117,7 @@ public:
 		detachNoInterrupts();
 		_function = function;
 		_type = EventTypeInterrupt;
-		SCB_SHPR3 |= 0x00FF0000; // configure PendSV, lowest priority
-		// Make sure we are using the systic ISR that process this
-		_VectorsRam[15] = systick_isr_with_timer_events;
+		setup_systick_with_timer_events();
 		enableInterrupts(irq);
 	}
 

--- a/teensy4/EventResponder.cpp
+++ b/teensy4/EventResponder.cpp
@@ -77,7 +77,7 @@ void EventResponder::triggerEventNotImmediate()
 				_prev->_next = this;
 				lastInterrupt = this;
 			}
-			SCB_ICSR = SCB_ICSR_PENDSVSET; // set PendSV interrupt
+			event_responder_set_pend_sv(); // set PendSV interrupt
 		} else {
 			// detached, easy :-)
 		}
@@ -314,14 +314,16 @@ void MillisTimer::runFromTimer()
 			timer = listActive;
 		}
 	}
-	bool irq = disableTimerInterrupt();
-	MillisTimer *waiting = listWaiting;
-	listWaiting = nullptr; // TODO: use STREX to avoid interrupt disable
-	enableTimerInterrupt(irq);
-	while (waiting) {
-		MillisTimer *next = waiting->_next;
-		waiting->addToActiveList();
-		waiting = next;
+	if (listWaiting) {
+		bool irq = disableTimerInterrupt();
+		MillisTimer *waiting = listWaiting;
+		listWaiting = nullptr; // TODO: use STREX to avoid interrupt disable
+		enableTimerInterrupt(irq);
+		while (waiting) {
+			MillisTimer *next = waiting->_next;
+			waiting->addToActiveList();
+			waiting = next;
+		}
 	}
 }
 
@@ -362,3 +364,15 @@ extern "C" void systick_isr_with_timer_events(void)
 	MillisTimer::runFromTimer();
 }
 
+extern "C" __attribute__((weak)) void setup_systick_with_timer_events()
+{
+	SCB_SHPR3 = SCB_SHPR3 | 0x00FF0000; // configure PendSV, lowest priority
+	// Make sure we are using the systic ISR that process this
+	_VectorsRam[15] = systick_isr_with_timer_events;
+	__asm volatile ("dsb st" ::: "memory");
+}
+
+extern "C" __attribute__((weak)) void event_responder_set_pend_sv()
+{
+	SCB_ICSR = SCB_ICSR_PENDSVSET; // set PendSV interrupt
+}

--- a/teensy4/EventResponder.h
+++ b/teensy4/EventResponder.h
@@ -61,6 +61,10 @@
  */
 extern "C" void systick_isr_with_timer_events(void);
 
+extern "C" void setup_systick_with_timer_events();
+
+extern "C" void event_responder_set_pend_sv();
+
 class EventResponder;
 typedef EventResponder& EventResponderRef;
 typedef void (*EventResponderFunction)(EventResponderRef);
@@ -113,9 +117,7 @@ public:
 		detachNoInterrupts();
 		_function = function;
 		_type = EventTypeInterrupt;
-		SCB_SHPR3 |= 0x00FF0000; // configure PendSV, lowest priority
-		// Make sure we are using the systic ISR that process this
-		_VectorsRam[15] = systick_isr_with_timer_events;
+		setup_systick_with_timer_events();
 		enableInterrupts(irq);
 	}
 


### PR DESCRIPTION
This way the PendSV interrupt can also be used for other components, e.g. for an RTOS. 
Of course, the default behavior is not changed. I also added a small optimization that checks `listWaiting` before deactivating interrupts. 