### PR TITLE
Make _sbrk() weak

### DIFF
--- a/teensy3/mk20dx128.c
+++ b/teensy3/mk20dx128.c
@@ -1180,6 +1180,7 @@ char *__brkval = (char *)&_ebss;
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-parameter"
 
+__attribute__((weak))
 void * _sbrk(int incr)
 {
 	char *prev, *stack;

--- a/teensy4/startup.c
+++ b/teensy4/startup.c
@@ -652,6 +652,7 @@ extern unsigned long _heap_end;
 
 char *__brkval = (char *)&_heap_start;
 
+__attribute__((weak))
 void * _sbrk(int incr)
 {
         char *prev = __brkval;


### PR DESCRIPTION
Same reason as for making _write() weak: an application may wish to override the behaviour for custom memory management.