### PR TITLE
Fix a bunch of "unused parameter" warnings

### DIFF
--- a/teensy3/EventResponder.h
+++ b/teensy3/EventResponder.h
@@ -83,7 +83,7 @@ public:
 	// Attach a function to be called from yield().  This should be the
 	// default way to use EventResponder.  Calls from yield() allow use
 	// of Arduino libraries, String, Serial, etc.
-	void attach(EventResponderFunction function, uint8_t priority=128) {
+	void attach(EventResponderFunction function, uint8_t priority __attribute__((unused)) = 128) {
 		bool irq = disableInterrupts();
 		detachNoInterrupts();
 		_function = function;
@@ -108,7 +108,7 @@ public:
 	// this as attachImmediate.  On ARM and other platforms with software
 	// interrupts, this allow fast interrupt-based response, but with less
 	// disruption to other libraries requiring their own interrupts.
-	void attachInterrupt(EventResponderFunction function, uint8_t priority=128) {
+	void attachInterrupt(EventResponderFunction function, uint8_t priority __attribute__((unused)) = 128) {
 		bool irq = disableInterrupts();
 		detachNoInterrupts();
 		_function = function;
@@ -121,7 +121,7 @@ public:
 
 	// Attach a function to be called as its own thread.  Boards not running
 	// a RTOS or pre-emptive scheduler shall implement this as attach().
-	void attachThread(EventResponderFunction function, void *param=nullptr) {
+	void attachThread(EventResponderFunction function, void *param __attribute__((unused)) = nullptr) {
 		attach(function); // for non-RTOS usage, compile as default attach
 	}
 

--- a/teensy3/new.cpp
+++ b/teensy3/new.cpp
@@ -45,12 +45,12 @@ void operator delete[](void * ptr)
   free(ptr);
 }
 
-void operator delete(void * ptr, size_t size)
+void operator delete(void * ptr, size_t size __attribute__((unused)))
 {
   free(ptr);
 }
 
-void operator delete[](void * ptr, size_t size)
+void operator delete[](void * ptr, size_t size __attribute__((unused)))
 {
   free(ptr);
 }

--- a/teensy4/EventResponder.h
+++ b/teensy4/EventResponder.h
@@ -83,7 +83,7 @@ public:
 	// Attach a function to be called from yield().  This should be the
 	// default way to use EventResponder.  Calls from yield() allow use
 	// of Arduino libraries, String, Serial, etc.
-	void attach(EventResponderFunction function, uint8_t priority=128) {
+	void attach(EventResponderFunction function, uint8_t priority __attribute__((unused)) = 128) {
 		bool irq = disableInterrupts();
 		detachNoInterrupts();
 		_function = function;
@@ -108,7 +108,7 @@ public:
 	// this as attachImmediate.  On ARM and other platforms with software
 	// interrupts, this allow fast interrupt-based response, but with less
 	// disruption to other libraries requiring their own interrupts.
-	void attachInterrupt(EventResponderFunction function, uint8_t priority=128) {
+	void attachInterrupt(EventResponderFunction function, uint8_t priority __attribute__((unused)) = 128) {
 		bool irq = disableInterrupts();
 		detachNoInterrupts();
 		_function = function;
@@ -121,7 +121,7 @@ public:
 
 	// Attach a function to be called as its own thread.  Boards not running
 	// a RTOS or pre-emptive scheduler shall implement this as attach().
-	void attachThread(EventResponderFunction function, void *param=nullptr) {
+	void attachThread(EventResponderFunction function, void *param __attribute__((unused)) = nullptr) {
 		attach(function); // for non-RTOS usage, compile as default attach
 	}
 

--- a/teensy4/analog.c
+++ b/teensy4/analog.c
@@ -95,7 +95,7 @@ int analogRead(uint8_t pin)
 	}
 }
 
-void analogReference(uint8_t type)
+void analogReference(uint8_t type __attribute__((unused)))
 {
 }
 

--- a/teensy4/avr_emulation.h
+++ b/teensy4/avr_emulation.h
@@ -78,7 +78,7 @@ class SPDRemulation;
 class SPCRemulation
 {
 public:
-	inline SPCRemulation & operator = (int val) __attribute__((always_inline)) {
+	inline SPCRemulation & operator = (int val __attribute__((unused))) __attribute__((always_inline)) {
 /*
 		uint32_t ctar, mcr, sim6;
 		//serial_print("SPCR=");
@@ -139,7 +139,7 @@ public:
 */
 		return *this;
 	}
-	inline SPCRemulation & operator |= (int val) __attribute__((always_inline)) {
+	inline SPCRemulation & operator |= (int val __attribute__((unused))) __attribute__((always_inline)) {
 /*
 		uint32_t sim6;
 		//serial_print("SPCR |= ");
@@ -196,7 +196,7 @@ public:
 */
 		return *this;
 	}
-	inline SPCRemulation & operator &= (int val) __attribute__((always_inline)) {
+	inline SPCRemulation & operator &= (int val __attribute__((unused))) __attribute__((always_inline)) {
 /*
 		//serial_print("SPCR &= ");
 		//serial_phex(val);
@@ -242,7 +242,7 @@ public:
 */
 		return *this;
 	}
-	inline int operator & (int val) const __attribute__((always_inline)) {
+	inline int operator & (int val __attribute__((unused))) const __attribute__((always_inline)) {
 		int ret = 0;
 /*		
 		//serial_print("SPCR & ");
@@ -298,13 +298,13 @@ public:
 */
 		return ret;
 	}
-	inline void setMOSI(uint8_t pin) __attribute__((always_inline)) {
+	inline void setMOSI(uint8_t pin __attribute__((unused))) __attribute__((always_inline)) {
 	}
-	inline void setMOSI_soft(uint8_t pin) __attribute__((always_inline)) {
+	inline void setMOSI_soft(uint8_t pin __attribute__((unused))) __attribute__((always_inline)) {
 	}
-	inline void setMISO(uint8_t pin) __attribute__((always_inline)) {
+	inline void setMISO(uint8_t pin __attribute__((unused))) __attribute__((always_inline)) {
 	}
-	inline void setSCK(uint8_t pin) __attribute__((always_inline)) {
+	inline void setSCK(uint8_t pin __attribute__((unused))) __attribute__((always_inline)) {
 	}
 	friend class SPSRemulation;
 	friend class SPIFIFOclass;
@@ -323,7 +323,7 @@ extern SPCRemulation SPCR;
 class SPSRemulation
 {
 public:
-	inline SPSRemulation & operator = (int val) __attribute__((always_inline)) {
+	inline SPSRemulation & operator = (int val __attribute__((unused))) __attribute__((always_inline)) {
 		//serial_print("SPSR=");
 		//serial_phex(val);
 		//serial_print("\n");
@@ -343,7 +343,7 @@ public:
 */		
 		return *this;
 	}
-	inline SPSRemulation & operator |= (int val) __attribute__((always_inline)) {
+	inline SPSRemulation & operator |= (int val __attribute__((unused))) __attribute__((always_inline)) {
 /*
 		//serial_print("SPSR |= ");
 		//serial_phex(val);
@@ -352,7 +352,7 @@ public:
 */
 		return *this;
 	}
-	inline SPSRemulation & operator &= (int val) __attribute__((always_inline)) {
+	inline SPSRemulation & operator &= (int val __attribute__((unused))) __attribute__((always_inline)) {
 /*
 		//serial_print("SPSR &= ");
 		//serial_phex(val);

--- a/teensy4/new.cpp
+++ b/teensy4/new.cpp
@@ -45,12 +45,12 @@ void operator delete[](void * ptr)
 	free(ptr);
 }
 
-void operator delete(void * ptr, size_t size)
+void operator delete(void * ptr, size_t size __attribute__((unused)))
 {
 	free(ptr);
 }
 
-void operator delete[](void * ptr, size_t size)
+void operator delete[](void * ptr, size_t size __attribute__((unused)))
 {
 	free(ptr);
 }

--- a/teensy4/pins_arduino.h
+++ b/teensy4/pins_arduino.h
@@ -153,7 +153,7 @@ extern const struct digital_pin_bitband_and_config_table_struct digital_pin_to_i
 
 #define NOT_ON_TIMER 0
 static inline uint8_t digitalPinToTimer(uint8_t) __attribute__((always_inline, unused));
-static inline uint8_t digitalPinToTimer(uint8_t pin)
+static inline uint8_t digitalPinToTimer(uint8_t pin __attribute__((unused)))
 {
 	// TODO: does anything meaningful use this?
 	return NOT_ON_TIMER;

--- a/teensy4/pwm.c
+++ b/teensy4/pwm.c
@@ -165,7 +165,7 @@ void flexpwmWrite(IMXRT_FLEXPWM_t *p, unsigned int submodule, uint8_t channel, u
 	p->MCTRL |= FLEXPWM_MCTRL_LDOK(mask);
 }
 
-void flexpwmFrequency(IMXRT_FLEXPWM_t *p, unsigned int submodule, uint8_t channel, float frequency)
+void flexpwmFrequency(IMXRT_FLEXPWM_t *p, unsigned int submodule, uint8_t channel __attribute__((unused)), float frequency)
 {
 	uint16_t mask = 1 << submodule;
 	uint32_t olddiv = p->SM[submodule].VAL1;

--- a/teensy4/rtc.c
+++ b/teensy4/rtc.c
@@ -65,14 +65,14 @@ void rtc_set(unsigned long t)
 	SNVS_HPCR |= SNVS_HPCR_RTC_EN | SNVS_HPCR_HP_TS;
 }
 
-void rtc_compensate(int adjust)
+void rtc_compensate(int adjust __attribute__((unused)))
 {
 }
 
 // https://github.com/arduino-libraries/ArduinoBearSSL/issues/54
 // https://forum.pjrc.com/threads/70966
 __attribute__((weak))
-int _gettimeofday(struct timeval *tv, void *ignore)
+int _gettimeofday(struct timeval *tv, void *ignore __attribute__((unused)))
 {
 	uint32_t hi1 = SNVS_HPRTCMR;
 	uint32_t lo1 = SNVS_HPRTCLR;

--- a/teensy4/sm_util.c
+++ b/teensy4/sm_util.c
@@ -38,7 +38,7 @@ static int smalloc_valid_tag(struct smalloc_hdr *shdr)
 	return 0;
 }
 
-static void smalloc_do_crash(struct smalloc_pool *spool, const void *p)
+static void smalloc_do_crash(struct smalloc_pool *spool __attribute__((unused)), const void *p __attribute__((unused)))
 {
 	char *c = NULL;
 	*c = 'X';

--- a/teensy4/startup.c
+++ b/teensy4/startup.c
@@ -667,13 +667,13 @@ void * _sbrk(int incr)
 }
 
 __attribute__((weak))
-int _read(int file, char *ptr, int len)
+int _read(int file __attribute__((unused)), char *ptr __attribute__((unused)), int len __attribute__((unused)))
 {
 	return 0;
 }
 
 __attribute__((weak))
-int _close(int fd)
+int _close(int fd __attribute__((unused)))
 {
 	return -1;
 }
@@ -681,26 +681,26 @@ int _close(int fd)
 #include <sys/stat.h>
 
 __attribute__((weak))
-int _fstat(int fd, struct stat *st)
+int _fstat(int fd __attribute__((unused)), struct stat *st)
 {
 	st->st_mode = S_IFCHR;
 	return 0;
 }
 
 __attribute__((weak))
-int _isatty(int fd)
+int _isatty(int fd __attribute__((unused)))
 {
 	return 1;
 }
 
 __attribute__((weak))
-int _lseek(int fd, long long offset, int whence)
+int _lseek(int fd __attribute__((unused)), long long offset __attribute__((unused)), int whence __attribute__((unused)))
 {
 	return -1;
 }
 
 __attribute__((weak))
-void _exit(int status)
+void _exit(int status __attribute__((unused)))
 {
 	while (1) asm ("WFI");
 }

--- a/teensy4/usb_serial.h
+++ b/teensy4/usb_serial.h
@@ -77,7 +77,7 @@ public:
 	// is not used.  Communication occurs at USB native speed.  For
 	// compatibility with Arduino code, Serial.begin waits up to 2 seconds
 	// for your PC to open the virtual serial port.
-        void begin(long baud_unused) {
+        void begin(long baud_unused __attribute__((unused))) {
 		uint32_t millis_begin = systick_millis_count;
 		while (!(*this)) {
 			uint32_t elapsed = systick_millis_count - millis_begin;


### PR DESCRIPTION
Discovered when building with -Wall and -Wextra (those include
-Wunused-parameter).