### PR TITLE
Fix a couple "signedness comparison" warnings

### DIFF
--- a/teensy3/nonstd.c
+++ b/teensy3/nonstd.c
@@ -204,7 +204,7 @@ char * dtostrf(float val, int width, unsigned int precision, char *buf)
 			s = fcvtf(val, newPrecision, &newDecimalPoint, &sign);
 
 			// if rounded up to new digit (e.g. 0.09 to 0.1), move decimal point
-			if (newDecimalPoint - decpt == precision + 1) decpt++;
+			if ((unsigned int)(newDecimalPoint - decpt) == precision + 1) decpt++;
 		}
 	}
 

--- a/teensy4/nonstd.c
+++ b/teensy4/nonstd.c
@@ -204,7 +204,7 @@ char * dtostrf(float val, int width, unsigned int precision, char *buf)
 			s = fcvtf(val, newPrecision, &newDecimalPoint, &sign);
 
 			// if rounded up to new digit (e.g. 0.09 to 0.1), move decimal point
-			if (newDecimalPoint - decpt == precision + 1) decpt++;
+			if ((unsigned int)(newDecimalPoint - decpt) == precision + 1) decpt++;
 		}
 	}
 

--- a/teensy4/usb_serial.c
+++ b/teensy4/usb_serial.c
@@ -152,7 +152,7 @@ static void rx_event(transfer_t *t)
 			// a previous packet is still buffered
 			uint32_t ii = rx_list[head];
 			uint32_t count = rx_count[ii];
-			if (len <= CDC_RX_SIZE_480 - count) {
+			if ((uint32_t)len <= CDC_RX_SIZE_480 - count) {
 				// previous buffer has enough free space for this packet's data
 				memcpy(rx_buffer + ii * CDC_RX_SIZE_480 + count,
 					rx_buffer + i * CDC_RX_SIZE_480, len);

--- a/teensy4/usb_serial2.c
+++ b/teensy4/usb_serial2.c
@@ -136,7 +136,7 @@ static void rx_event(transfer_t *t)
 			// a previous packet is still buffered
 			uint32_t ii = rx_list[head];
 			uint32_t count = rx_count[ii];
-			if (len <= CDC_RX_SIZE_480 - count) {
+			if ((uint32_t)len <= CDC_RX_SIZE_480 - count) {
 				// previous buffer has enough free space for this packet's data
 				memcpy(rx_buffer + ii * CDC_RX_SIZE_480 + count,
 					rx_buffer + i * CDC_RX_SIZE_480, len);

--- a/teensy4/usb_serial3.c
+++ b/teensy4/usb_serial3.c
@@ -136,7 +136,7 @@ static void rx_event(transfer_t *t)
 			// a previous packet is still buffered
 			uint32_t ii = rx_list[head];
 			uint32_t count = rx_count[ii];
-			if (len <= CDC_RX_SIZE_480 - count) {
+			if ((uint32_t)len <= CDC_RX_SIZE_480 - count) {
 				// previous buffer has enough free space for this packet's data
 				memcpy(rx_buffer + ii * CDC_RX_SIZE_480 + count,
 					rx_buffer + i * CDC_RX_SIZE_480, len);


### PR DESCRIPTION
Disovered with -Wextra (-Wsign-compare).

I'll leave the SMalloc ones alone for now, to make it easier to do any updates in the future.