### PR TITLE
Fix an old-style-declaration warning in usb_midi.c

### DIFF
--- a/teensy3/usb_midi.c
+++ b/teensy3/usb_midi.c
@@ -205,7 +205,7 @@ void usb_midi_flush_output(void)
 	}
 }
 
-void static sysex_byte(uint8_t b)
+static void sysex_byte(uint8_t b)
 {
 	if (usb_midi_handleSysExPartial && usb_midi_msg_sysex_len >= USB_MIDI_SYSEX_MAX) {
 		// when buffer is full, send another chunk to partial handler.

--- a/teensy4/usb_midi.c
+++ b/teensy4/usb_midi.c
@@ -244,7 +244,7 @@ void usb_midi_send_sysex_add_term_bytes(const uint8_t *data, uint32_t length, ui
 	}
 }
 
-void static sysex_byte(uint8_t b)
+static void sysex_byte(uint8_t b)
 {
 	if (usb_midi_handleSysExPartial && usb_midi_msg_sysex_len >= USB_MIDI_SYSEX_MAX) {
 		// when buffer is full, send another chunk to partial handler.


### PR DESCRIPTION
Discovered with -Wextra (-Wold-style-declaration).