### PR TITLE
Change internal Print::write_error to int from char

### DIFF
--- a/teensy3/Print.h
+++ b/teensy3/Print.h
@@ -118,7 +118,7 @@ class Print
   protected:
 	void setWriteError(int err = 1) { write_error = err; }
   private:
-	char write_error;
+	int write_error;
 	size_t printFloat(double n, uint8_t digits);
 #ifdef __MKL26Z64__
 	size_t printNumberDec(unsigned long n, uint8_t sign);

--- a/teensy4/Print.h
+++ b/teensy4/Print.h
@@ -164,7 +164,7 @@ class Print
   protected:
 	void setWriteError(int err = 1) { write_error = err; }
   private:
-	char write_error;
+	int write_error;
 	size_t printFloat(double n, uint8_t digits);
 	size_t printNumber(unsigned long n, uint8_t base, uint8_t sign);
 	size_t printNumber64(uint64_t n, uint8_t base, uint8_t sign);


### PR DESCRIPTION
This prevents information from being lost.

Fixes #697.