### PR TITLE
add a small fix to default ISR to handle SPSEL

### DIFF
--- a/teensy4/startup.c
+++ b/teensy4/startup.c
@@ -586,7 +586,7 @@ void unused_interrupt_vector(void)
 	asm volatile("mrs %0, ipsr\n" : "=r" (ipsr) :: "memory");
 	info = (struct arm_fault_info_struct *)0x2027FF80;
 	info->ipsr = ipsr;
-	asm volatile("mrs %0, msp\n" : "=r" (stack) :: "memory");
+	asm volatile("tst lr, #4\nite eq\nmrseq %0, msp\nmrsne %0, psp\n" : "=r" (stack) :: "memory");
 	info->cfsr = SCB_CFSR;
 	info->hfsr = SCB_HFSR;
 	info->mmfar = SCB_MMFAR;


### PR DESCRIPTION
The unused_interrupt_vector() only interpreted msp (main stack pointer), leading to errors if user code chose to use psp (process stack pointer). The fix checks the appropriate bit in the link register and loads the correct stack pointer. Inspired by: https://developer.arm.com/documentation/ka004005/latest