### PR TITLE
Optionally process all triggered EventResponder events on a single yield() call

### DIFF
--- a/teensy3/EventResponder.cpp
+++ b/teensy3/EventResponder.cpp
@@ -35,6 +35,7 @@
 #include "EventResponder.h"
 
 EventResponder * EventResponder::firstYield = nullptr;
+EventResponder * EventResponder::nextYield = nullptr;
 EventResponder * EventResponder::lastYield = nullptr;
 EventResponder * EventResponder::firstInterrupt = nullptr;
 EventResponder * EventResponder::lastInterrupt = nullptr;
@@ -46,25 +47,58 @@ extern const uint8_t _serialEvent_default __attribute__((weak)) PROGMEM = 0 ;
 extern const uint8_t _serialEventUSB1_default __attribute__((weak)) PROGMEM = 0 ;
 extern const uint8_t _serialEventUSB2_default __attribute__((weak)) PROGMEM = 0 ;
 
-void EventResponder::triggerEventNotImmediate()
+void EventResponder::triggerEventNotImmediate(bool _nextYield)
 {
 	bool irq = disableInterrupts();
 	if (_triggered == false) {
 		// not already triggered
-		if (_type == EventTypeYield) {
+		if (_type == EventTypeYield)
+		{
 			// normal type, called from yield()
-			if (firstYield == nullptr) {
+			if (firstYield == nullptr)
+			{
+				// empty list
 				_next = nullptr;
 				_prev = nullptr;
 				firstYield = this;
 				lastYield = this;
-			} else {
+
+				// if necessary, mark end of items which
+				// must be responded to on next yield()
+				if (_nextYield)
+					nextYield = this;
+			}
+			else if (_nextYield)
+			{
+				// must get response on next yield(), and
+				// at least one event is already pending
+				if (nullptr != nextYield) // this is NOT the first "nextYield" event
+				{
+					_next = nextYield->_next;
+					_prev = nextYield;
+					nextYield->_next = this; // last of the nextYield events
+					_next->_prev = this;
+				}
+				else // this IS first nextYield event, event list isn't empty
+				{
+					_next = firstYield;
+					_prev = nullptr;
+					firstYield = this; // put at front of list
+					_next->_prev = this;
+				}
+				nextYield = this; // mark end of nextYield events
+			}
+			else
+			{
+				// put in at end of list
 				_next = nullptr;
 				_prev = lastYield;
 				_prev->_next = this;
 				lastYield = this;
 			}
-		} else if (_type == EventTypeInterrupt) {
+		}
+		else if (_type == EventTypeInterrupt)
+		{
 			// interrupt, called from software interrupt
 			if (firstInterrupt == nullptr) {
 				_next = nullptr;
@@ -105,7 +139,8 @@ void EventResponder::runFromInterrupt()
 			}
 			enableInterrupts(irq);
 			first->_triggered = false;
-			(*(first->_function))(*first);
+			if (nullptr != first->_function)
+				(*(first->_function))(*first);
 		} else {
 			enableInterrupts(irq);
 			break;
@@ -119,6 +154,11 @@ bool EventResponder::clearEvent()
 	bool irq = disableInterrupts();
 	if (_triggered) {
 		if (_type == EventTypeYield) {
+			// deal with possibility we're clearing the
+			// last nextYield event
+			if (this == nextYield)
+				nextYield = _prev; // could be nullptr, that's OK
+
 			if (_prev) {
 				_prev->_next = _next;
 			} else {
@@ -153,6 +193,11 @@ void EventResponder::detachNoInterrupts()
 {
 	if (_type == EventTypeYield) {
 		if (_triggered) {
+			// deal with possibility we're detaching the
+			// last nextYield event
+			if (this == nextYield)
+				nextYield = _prev; // could be nullptr, that's OK
+
 			if (_prev) {
 				_prev->_next = _next;
 			} else {

--- a/teensy4/EventResponder.cpp
+++ b/teensy4/EventResponder.cpp
@@ -39,6 +39,7 @@ EventResponder * EventResponder::lastYield = nullptr;
 EventResponder * EventResponder::firstInterrupt = nullptr;
 EventResponder * EventResponder::lastInterrupt = nullptr;
 bool EventResponder::runningFromYield = false;
+bool EventResponder::_processAllEvents = false;
 
 // TODO: interrupt disable/enable needed in many places!!!
 // BUGBUG: See if file name order makes difference?

--- a/teensy4/EventResponder.cpp
+++ b/teensy4/EventResponder.cpp
@@ -35,6 +35,7 @@
 #include "EventResponder.h"
 
 EventResponder * EventResponder::firstYield = nullptr;
+EventResponder * EventResponder::nextYield = nullptr;
 EventResponder * EventResponder::lastYield = nullptr;
 EventResponder * EventResponder::firstInterrupt = nullptr;
 EventResponder * EventResponder::lastInterrupt = nullptr;
@@ -44,25 +45,58 @@ bool EventResponder::_processAllEvents = false;
 // TODO: interrupt disable/enable needed in many places!!!
 // BUGBUG: See if file name order makes difference?
 
-void EventResponder::triggerEventNotImmediate()
+void EventResponder::triggerEventNotImmediate(bool _nextYield)
 {
 	bool irq = disableInterrupts();
 	if (_triggered == false) {
 		// not already triggered
-		if (_type == EventTypeYield) {
+		if (_type == EventTypeYield)
+		{
 			// normal type, called from yield()
-			if (firstYield == nullptr) {
+			if (firstYield == nullptr)
+			{
+				// empty list
 				_next = nullptr;
 				_prev = nullptr;
 				firstYield = this;
 				lastYield = this;
-			} else {
+
+				// if necessary, mark end of items which
+				// must be responded to on next yield()
+				if (_nextYield)
+					nextYield = this;
+			}
+			else if (_nextYield)
+			{
+				// must get response on next yield(), and
+				// at least one event is already pending
+				if (nullptr != nextYield) // this is NOT the first "nextYield" event
+				{
+					_next = nextYield->_next;
+					_prev = nextYield;
+					nextYield->_next = this; // last of the nextYield events
+					_next->_prev = this;
+				}
+				else // this IS first nextYield event, event list isn't empty
+				{
+					_next = firstYield;
+					_prev = nullptr;
+					firstYield = this; // put at front of list
+					_next->_prev = this;
+				}
+				nextYield = this; // mark end of nextYield events
+			}
+			else
+			{
+				// put in at end of list
 				_next = nullptr;
 				_prev = lastYield;
 				_prev->_next = this;
 				lastYield = this;
 			}
-		} else if (_type == EventTypeInterrupt) {
+		}
+		else if (_type == EventTypeInterrupt)
+		{
 			// interrupt, called from software interrupt
 			if (firstInterrupt == nullptr) {
 				_next = nullptr;
@@ -103,7 +137,8 @@ void EventResponder::runFromInterrupt()
 			}
 			enableInterrupts(irq);
 			first->_triggered = false;
-			(*(first->_function))(*first);
+			if (nullptr != first->_function)
+				(*(first->_function))(*first);
 		} else {
 			enableInterrupts(irq);
 			break;
@@ -117,6 +152,11 @@ bool EventResponder::clearEvent()
 	bool irq = disableInterrupts();
 	if (_triggered) {
 		if (_type == EventTypeYield) {
+			// deal with possibility we're clearing the
+			// last nextYield event
+			if (this == nextYield)
+				nextYield = _prev; // could be nullptr, that's OK
+
 			if (_prev) {
 				_prev->_next = _next;
 			} else {
@@ -151,6 +191,11 @@ void EventResponder::detachNoInterrupts()
 {
 	if (_type == EventTypeYield) {
 		if (_triggered) {
+			// deal with possibility we're detaching the
+			// last nextYield event
+			if (this == nextYield)
+				nextYield = _prev; // could be nullptr, that's OK
+
 			if (_prev) {
 				_prev->_next = _next;
 			} else {
@@ -230,7 +275,7 @@ void MillisTimer::addToActiveList() // only called by runFromTimer()
 		_prev = nullptr;
 		listActive->_prev = this;
 		// Decrement the next items wait time be our wait time as to properly handle waits for all other items...
-		listActive->_ms -= _ms;	
+		listActive->_ms -= _ms;
 		listActive = this;
 	} else {
 		// add this timer somewhere after the first already on the list

--- a/teensy4/EventResponder.h
+++ b/teensy4/EventResponder.h
@@ -185,6 +185,7 @@ public:
 	// used with a scheduler or RTOS.
 	bool waitForEvent(EventResponderRef event, int timeout);
 	EventResponder * waitForEvent(EventResponder *list, int listsize, int timeout);
+
 	static void runFromYield() {
 		if (!firstYield) return;
 		// First, check if yield was called from an interrupt


### PR DESCRIPTION
Previous code required one yield() call for each triggered event in the list, potentially leading to high latency if many EventResponder objects are in use in a system with long intervals between calls to yield().

This update _optionally_ changes that behaviour. The user can either:
- use `EventResponder::processAllEvents(true);` to ensure every triggered event is processed on the next yield()
- use a new `triggerEventNextYield()` function with the same syntax as `triggerEvent()` to get finer-grained control
If the latter method is used, one event triggered using `triggerEvent()` will be responded to on each yield(), along with _all_ events triggered by `triggerEventNextYield()`.

This change also allows `EventTypeYield` responders to work in a manner consistent with `EventTypeInterrupt` ones, which are all run as soon as `runFromInterrupt()` fires.

As implemented, an event cannot be "promoted" to a "next yield" type if it was previously triggered by `triggerEvent()`, unless `clearEvent()` is called first.