### PR TITLE
Add some checksum

### DIFF
--- a/teensy4/CrashReport.cpp
+++ b/teensy4/CrashReport.cpp
@@ -199,7 +199,7 @@ size_t CrashReportClass::printTo(Print& p) const
 	  asm volatile ("dsb":::"memory");
 	  while (1) asm ("wfi");
   }
-  if (bc->bitmask) {
+  if (bc->bitmask && bc->bitmask == bc->checksum) {
     for (int i=0; i < 6; i++) {
       if (bc->bitmask & (1 << i)) {
         p.print("  Breadcrumb #");
@@ -212,8 +212,15 @@ size_t CrashReportClass::printTo(Print& p) const
       }
     }
     *(volatile uint32_t *)(&bc->bitmask) = 0;
+    *(volatile uint32_t *)(&bc->checksum) = 0;
     arm_dcache_flush((void *)bc, sizeof(struct crashreport_breadcrumbs_struct));
   }
+    else if (bc->bitmask) {
+      p.print("FALSE Panic Breadcrumb printing! BUGBUG DEBUG >>bitmask==");
+      p.println(bc->bitmask, HEX);
+      p.print("FALSE Panic Breadcrumb printing! BUGBUG DEBUG >>checksum==");
+      p.println(bc->checksum, HEX);
+    }
   cleardata(info);
   return 1;
 }

--- a/teensy4/CrashReport.h
+++ b/teensy4/CrashReport.h
@@ -16,6 +16,7 @@ public:
 			num--;
 			bc->value[num] = value;
 			bc->bitmask |= (1 << num);
+			bc->checksum = bc->bitmask;
 			arm_dcache_flush((void *)bc, sizeof(struct crashreport_breadcrumbs_struct));
 		}
 	}


### PR DESCRIPTION
Stored RAM2 values give false breadcrumb printing unrelated to a CrashReport

Many times a CrashReport on first run will cause BreadCrumb printing of unrelated garbage

This quick fix writes bitmask to checksum and verifies they are equal before printing.

WARNING for TEST there is a BUGBUG DEBUG else{} in the code that shows as below from extra code in CrashReport.cpp
If you see this as a worthy addition I can resubmit with lines 218-223 removed
Without that exclusion code it would read the bitmask bit and display values.
Print below shows the values stored in the T_4.0 here on upload and sample crash caused.

CrashReport:
  A problem occurred at (system time) 0:40:53
  Code was executing from address 0xFFFFFFFE
  CFSR: 83
	(IACCVIOL) Instruction Access Violation
	(MMARVALID) Accessed Address: 0x0 (nullptr)
	  Check code at 0xFFFFFFFE - very likely a bug!
	  Run "addr2line -e mysketch.ino.elf 0xFFFFFFFE" for filename & line number.
  HTSR: 40000000
	(FORCED) Forced Hard Fault
  Temperature inside the chip was 36.89 °C
  Startup CPU clock speed is 600MHz
  Reboot was caused by auto reboot after fault or bad interrupt detected
**FALSE Panic Breadcrumb printing! BUGBUG DEBUG >>bitmask==45C48D85
FALSE Panic Breadcrumb printing! BUGBUG DEBUG >>checksum==145D6C65**