### PR TITLE
Fix extmem_calloc() to use calloc() in the fallback case

### DIFF
--- a/teensy4/extmem.c
+++ b/teensy4/extmem.c
@@ -34,7 +34,12 @@ void extmem_free(void *ptr)
 
 void *extmem_calloc(size_t nmemb, size_t size)
 {
-	return extmem_malloc(nmemb * size);
+#ifdef HAS_EXTRAM
+	// Note: It is assumed that the pool was created with do_zero set to true
+	void *ptr = sm_malloc_pool(&extmem_smalloc_pool, nmemb*size);
+	if (ptr) return ptr;
+#endif
+	return calloc(nmemb, size);
 }
 
 void *extmem_realloc(void *ptr, size_t size)
@@ -46,5 +51,3 @@ void *extmem_realloc(void *ptr, size_t size)
 #endif
 	return realloc(ptr, size);
 }
-
-


### PR DESCRIPTION
Fixes #711.

See also: https://forum.pjrc.com/threads/72572-Teensyduino-1-59-Beta-2?p=324475&viewfull=1#post324475
