### PR TITLE
Fix IPAddress cast and comparison operators to be const

### DIFF
--- a/teensy3/IPAddress.h
+++ b/teensy3/IPAddress.h
@@ -73,16 +73,16 @@ public:
 
 	// Overloaded cast operator to allow IPAddress objects to be used where a pointer
 	// to a four-byte uint8_t array is expected
-	operator uint32_t () {
+	operator uint32_t () const {
 		return _address.dword;
 	}
-	bool operator==(const IPAddress& addr) {
+	bool operator==(const IPAddress& addr) const {
 		return _address.dword == addr._address.dword;
 	}
-	bool operator!=(const IPAddress& addr) {
+	bool operator!=(const IPAddress& addr) const {
 		return _address.dword != addr._address.dword;
 	}
-	bool operator==(const uint8_t* addr) {
+	bool operator==(const uint8_t* addr) const {
 		// TODO: use unaligned read on Cortex-M4
 		return (_address.bytes[0] == addr[0]
 			&& _address.bytes[1] == addr[1]

--- a/teensy4/IPAddress.h
+++ b/teensy4/IPAddress.h
@@ -73,16 +73,16 @@ public:
 
 	// Overloaded cast operator to allow IPAddress objects to be used where a pointer
 	// to a four-byte uint8_t array is expected
-	operator uint32_t () {
+	operator uint32_t () const {
 		return _address.dword;
 	}
-	bool operator==(const IPAddress& addr) {
+	bool operator==(const IPAddress& addr) const {
 		return _address.dword == addr._address.dword;
 	}
-	bool operator!=(const IPAddress& addr) {
+	bool operator!=(const IPAddress& addr) const {
 		return _address.dword != addr._address.dword;
 	}
-	bool operator==(const uint8_t* addr) {
+	bool operator==(const uint8_t* addr) const {
 		// TODO: use unaligned read on Cortex-M4
 		return (_address.bytes[0] == addr[0]
 			&& _address.bytes[1] == addr[1]


### PR DESCRIPTION
This will make it much easier to use these operators, especially when working with `const` `IPAddress`es, without having to `const_cast` away the `const` before using them. Also the Arduino version has these.