### PR TITLE
Fix compile error for non-void-returning inplace_functions

### DIFF
--- a/teensy3/inplace_function.h
+++ b/teensy3/inplace_function.h
@@ -3,7 +3,7 @@
 // https://github.com/WG21-SG14/SG14/blob/master/SG14/inplace_function.h
 //
 // For use with Teensy, allow uninitialized to be no-operation without error
-#define SG14_INPLACE_FUNCTION_THROW(x)
+#define SG14_INPLACE_FUNCTION_THROW(x) return static_cast<R>(0)
 
 /*
  * Boost Software License - Version 1.0 - August 17th, 2003

--- a/teensy4/inplace_function.h
+++ b/teensy4/inplace_function.h
@@ -3,7 +3,7 @@
 // https://github.com/WG21-SG14/SG14/blob/master/SG14/inplace_function.h
 //
 // For use with Teensy, allow uninitialized to be no-operation without error
-#define SG14_INPLACE_FUNCTION_THROW(x)
+#define SG14_INPLACE_FUNCTION_THROW(x) return static_cast<R>(0)
 
 /*
  * Boost Software License - Version 1.0 - August 17th, 2003


### PR DESCRIPTION
The error occurs when testing for or calling an unassigned function.

Here's a test program:
```c++
stdext::inplace_function<bool()> func;

void setup() {
  Serial.begin(115200);
  while (!Serial && millis() < 4000) {
    // Wait for Serial
  }

  // Either this:
  func();

  // Or this will cause the issue:
  if (func == nullptr) {
    printf("Here\r\n");
  }
}

void loop() {
}
```