### PR TITLE
Increase initial size of usb_string_serial_number by 2 on Teensy3/Teensy4

### DIFF
--- a/teensy3/usb_desc.c
+++ b/teensy3/usb_desc.c
@@ -1678,9 +1678,9 @@ struct usb_string_descriptor_struct usb_string_product_name_default = {
         PRODUCT_NAME
 };
 struct usb_string_descriptor_struct usb_string_serial_number_default = {
-        12,
+        24,
         3,
-        {0,0,0,0,0,0,0,0,0,0}
+        {0,0,0,0,0,0,0,0,0,0,0,0}  // uint16_t
 };
 #ifdef MIDI_INTERFACE
         struct usb_string_descriptor_struct usb_string_midi_port1_default = {

--- a/teensy4/usb_desc.c
+++ b/teensy4/usb_desc.c
@@ -2743,9 +2743,9 @@ PROGMEM const struct usb_string_descriptor_struct usb_string_product_name_defaul
         PRODUCT_NAME
 };
 struct usb_string_descriptor_struct usb_string_serial_number_default = {
-        12,
+        24,
         3,
-        {0,0,0,0,0,0,0,0,0,0}
+        {0,0,0,0,0,0,0,0,0,0,0,0}  // uint16_t
 };
 #ifdef MTP_INTERFACE
 PROGMEM const struct usb_string_descriptor_struct usb_string_mtp = {


### PR DESCRIPTION
I was auditing the code and noticed two things:


1. The initial size is 12, which is: not equal to 10 * 2, 0, or 10
2. The data is copied from a buffer of size 11, so the size should be at least 11.

I am unsure if the default value should be `bLength=24` or `bLength=2`, both seem somewhat valid to me.