### PR TITLE
Ensure that the usb_string_serial_number_default descriptor is correctly initailized at startup

### DIFF
--- a/teensy3/usb_desc.c
+++ b/teensy3/usb_desc.c
@@ -1678,7 +1678,7 @@ struct usb_string_descriptor_struct usb_string_product_name_default = {
         PRODUCT_NAME
 };
 struct usb_string_descriptor_struct usb_string_serial_number_default = {
-        12,
+        22,
         3,
         {0,0,0,0,0,0,0,0,0,0}
 };

--- a/teensy4/usb_desc.c
+++ b/teensy4/usb_desc.c
@@ -2743,7 +2743,7 @@ PROGMEM const struct usb_string_descriptor_struct usb_string_product_name_defaul
         PRODUCT_NAME
 };
 struct usb_string_descriptor_struct usb_string_serial_number_default = {
-        12,
+        22,
         3,
         {0,0,0,0,0,0,0,0,0,0}
 };


### PR DESCRIPTION
Builds off

https://github.com/PaulStoffregen/cores/pull/722

sorry i force pushed without reopenning the request, so github forces me to make a new one.

I am somewhat confused by the screenshot you sent (I was reading the section early)

Given that it is initialized to 0's, my thoughts is that maybe it should be `2` and not `22`.

Again, this is more an intellectual conversation since it gets reinitialized below during bootup