### PR TITLE
Serial port half duplex if inverted should Pull down not up

### DIFF
--- a/teensy3/serial1.c
+++ b/teensy3/serial1.c
@@ -224,16 +224,20 @@ void serial_format(uint32_t format)
 
 		// Lets try to make use of bitband address to set the direction for ue...
 		#if defined(KINETISL)
+		uint32_t pin_cfg = PORT_PCR_DSE | PORT_PCR_SRE | PORT_PCR_MUX(3) | PORT_PCR_PE;
+		if ((format & 0x20) == 0) pin_cfg |=  PORT_PCR_PS;  // if not inverted PU else leve as PD
 		switch (tx_pin_num) {
-			case 1:  CORE_PIN1_CONFIG = PORT_PCR_DSE | PORT_PCR_SRE | PORT_PCR_MUX(3) | PORT_PCR_PE | PORT_PCR_PS ; break;
-			case 5:  CORE_PIN5_CONFIG = PORT_PCR_DSE | PORT_PCR_SRE | PORT_PCR_MUX(3) | PORT_PCR_PE | PORT_PCR_PS; break;
-			case 4:  CORE_PIN4_CONFIG = PORT_PCR_DSE | PORT_PCR_SRE | PORT_PCR_MUX(2) | PORT_PCR_PE | PORT_PCR_PS; break;
-			case 24: CORE_PIN24_CONFIG = PORT_PCR_DSE | PORT_PCR_SRE | PORT_PCR_MUX(4) | PORT_PCR_PE | PORT_PCR_PS; break;
+			case 1:  CORE_PIN1_CONFIG = pin_cfg; break;
+			case 5:  CORE_PIN5_CONFIG = pin_cfg; break;
+			case 4:  CORE_PIN4_CONFIG = pin_cfg; break;
+			case 24: CORE_PIN24_CONFIG = pin_cfg; break;
 		}
 		half_duplex_mode = 1; 
 		#else
 		volatile uint32_t *reg = portConfigRegister(tx_pin_num);
-		*reg = PORT_PCR_DSE | PORT_PCR_SRE | PORT_PCR_MUX(3) | PORT_PCR_PE | PORT_PCR_PS; // pullup on output pin;
+		uint32_t pin_cfg = PORT_PCR_DSE | PORT_PCR_SRE | PORT_PCR_MUX(3) | PORT_PCR_PE;
+		if ((format & 0x20) == 0) pin_cfg |=  PORT_PCR_PS;  // if not inverted PU else leve as PD
+		*reg = pin_cfg;
 		transmit_pin = (uint8_t*)GPIO_BITBAND_PTR(UART0_C3, C3_TXDIR_BIT);
 		#endif
 

--- a/teensy3/serial2.c
+++ b/teensy3/serial2.c
@@ -224,11 +224,15 @@ void serial2_format(uint32_t format)
 		// Lets try to make use of bitband address to set the direction for ue...
 		#if defined(KINETISL)
 		//CORE_PIN10_CONFIG = PORT_PCR_DSE | PORT_PCR_SRE | PORT_PCR_MUX(1) | PORT_PCR_PE | PORT_PCR_PS;
-		CORE_PIN10_CONFIG = PORT_PCR_PE | PORT_PCR_PS | PORT_PCR_PFE | PORT_PCR_MUX(3);
+		uint32_t pin_cfg = PORT_PCR_PE | PORT_PCR_PFE | PORT_PCR_MUX(3);
+		if ((format & 0x20) == 0) pin_cfg |=  PORT_PCR_PS;  // if not inverted PU else leve as PD
+		CORE_PIN10_CONFIG = pin_cfg;
 		half_duplex_mode = 1;
 		#else
 		volatile uint32_t *reg = portConfigRegister(tx_pin_num);
-		*reg = PORT_PCR_DSE | PORT_PCR_SRE | PORT_PCR_MUX(3) | PORT_PCR_PE | PORT_PCR_PS; // pullup on output pin;
+		uint32_t pin_cfg = PORT_PCR_DSE | PORT_PCR_SRE | PORT_PCR_MUX(3) | PORT_PCR_PE;
+		if ((format & 0x20) == 0) pin_cfg |=  PORT_PCR_PS;  // if not inverted PU else leve as PD
+		*reg = pin_cfg;
 		transmit_pin = (uint8_t*)GPIO_BITBAND_PTR(UART1_C3, C3_TXDIR_BIT);
 		#endif
 

--- a/teensy3/serial3.c
+++ b/teensy3/serial3.c
@@ -207,14 +207,18 @@ void serial3_format(uint32_t format)
 
 		// Lets try to make use of bitband address to set the direction for ue...
 		#if defined(KINETISL)
+		uint32_t pin_cfg = PORT_PCR_PE | PORT_PCR_PFE | PORT_PCR_MUX(3);
+		if ((format & 0x20) == 0) pin_cfg |=  PORT_PCR_PS;  // if not inverted PU else leve as PD
 		switch (tx_pin_num) {
-			case 8:  CORE_PIN8_CONFIG = PORT_PCR_PE | PORT_PCR_PS | PORT_PCR_PFE | PORT_PCR_MUX(3); break;
-			case 20: CORE_PIN20_CONFIG = PORT_PCR_PE | PORT_PCR_PS | PORT_PCR_PFE | PORT_PCR_MUX(3); break;
+			case 8:  CORE_PIN8_CONFIG = pin_cfg; break;
+			case 20: CORE_PIN20_CONFIG = pin_cfg; break;
 		}
 		half_duplex_mode = 1; 
 		#else
 		volatile uint32_t *reg = portConfigRegister(tx_pin_num);
-		*reg = PORT_PCR_DSE | PORT_PCR_SRE | PORT_PCR_MUX(3) | PORT_PCR_PE | PORT_PCR_PS; // pullup on output pin;
+		uint32_t pin_cfg = PORT_PCR_DSE | PORT_PCR_SRE | PORT_PCR_MUX(3) | PORT_PCR_PE;
+		if ((format & 0x20) == 0) pin_cfg |=  PORT_PCR_PS;  // if not inverted PU else leve as PD
+		*reg = pin_cfg;
 		transmit_pin = (uint8_t*)GPIO_BITBAND_PTR(UART2_C3, C3_TXDIR_BIT);
 		#endif
 

--- a/teensy3/serial4.c
+++ b/teensy3/serial4.c
@@ -175,7 +175,9 @@ void serial4_format(uint32_t format)
 	if ((format & SERIAL_HALF_DUPLEX) != 0) {
 		UART3_C1 |= UART_C1_LOOPS | UART_C1_RSRC;
 		volatile uint32_t *reg = portConfigRegister(tx_pin_num);
-		*reg = PORT_PCR_DSE | PORT_PCR_SRE | PORT_PCR_MUX(3) | PORT_PCR_PE | PORT_PCR_PS; // pullup on output pin;
+		uint32_t pin_cfg = PORT_PCR_DSE | PORT_PCR_SRE | PORT_PCR_MUX(3) | PORT_PCR_PE;
+		if ((format & 0x20) == 0) pin_cfg |=  PORT_PCR_PS;  // if not inverted PU else leve as PD
+		*reg = pin_cfg;
 
 		// Lets try to make use of bitband address to set the direction for ue...
 		#if defined(KINETISL)

--- a/teensy3/serial5.c
+++ b/teensy3/serial5.c
@@ -167,7 +167,9 @@ void serial5_format(uint32_t format)
 	if ((format & SERIAL_HALF_DUPLEX) != 0) {
 		UART4_C1 |= UART_C1_LOOPS | UART_C1_RSRC;
 		volatile uint32_t *reg = portConfigRegister(tx_pin_num);
-		*reg = PORT_PCR_DSE | PORT_PCR_SRE | PORT_PCR_MUX(3) | PORT_PCR_PE | PORT_PCR_PS; // pullup on output pin;
+		uint32_t pin_cfg = PORT_PCR_DSE | PORT_PCR_SRE | PORT_PCR_MUX(3) | PORT_PCR_PE;
+		if ((format & 0x20) == 0) pin_cfg |=  PORT_PCR_PS;  // if not inverted PU else leve as PD
+		*reg = pin_cfg;
 
 		// Lets try to make use of bitband address to set the direction for ue...
 		transmit_pin = (uint8_t*)GPIO_BITBAND_PTR(UART4_C3, C3_TXDIR_BIT);

--- a/teensy3/serial6.c
+++ b/teensy3/serial6.c
@@ -167,7 +167,9 @@ void serial6_format(uint32_t format)
 	if ((format & SERIAL_HALF_DUPLEX) != 0) {
 		UART5_C1 |= UART_C1_LOOPS | UART_C1_RSRC;
 		volatile uint32_t *reg = portConfigRegister(tx_pin_num);
-		*reg = PORT_PCR_DSE | PORT_PCR_SRE | PORT_PCR_MUX(3) | PORT_PCR_PE | PORT_PCR_PS; // pullup on output pin;
+		uint32_t pin_cfg = PORT_PCR_DSE | PORT_PCR_SRE | PORT_PCR_MUX(3) | PORT_PCR_PE;
+		if ((format & 0x20) == 0) pin_cfg |=  PORT_PCR_PS;  // if not inverted PU else leve as PD
+		*reg = pin_cfg;
 
 		// Lets try to make use of bitband address to set the direction for ue...
 		transmit_pin = (uint8_t*)GPIO_BITBAND_PTR(UART5_C3, C3_TXDIR_BIT);

--- a/teensy3/serial6_lpuart.c
+++ b/teensy3/serial6_lpuart.c
@@ -243,7 +243,9 @@ void serial6_format(uint32_t format)
 		BITBAND_SET_BIT(LPUART0_CTRL, CTRL_LOOPS_BIT);
 		BITBAND_SET_BIT(LPUART0_CTRL, CTRL_RSRC_BIT);
 
-		CORE_PIN48_CONFIG = PORT_PCR_PE | PORT_PCR_PS | PORT_PCR_PFE | PORT_PCR_MUX(5);
+		uint32_t pin_cfg = PORT_PCR_PE | PORT_PCR_PFE | PORT_PCR_MUX(5);
+		if ((format & 0x20) == 0) pin_cfg |=  PORT_PCR_PS;  // if not inverted PU else leve as PD
+		CORE_PIN48_CONFIG = pin_cfg;
 
 		// Lets try to make use of bitband address to set the direction for ue...
 		transmit_pin = (uint8_t*)GPIO_BITBAND_PTR(LPUART0_CTRL, CTRL_TXDIR_BIT);

--- a/teensy4/HardwareSerial.cpp
+++ b/teensy4/HardwareSerial.cpp
@@ -210,7 +210,12 @@ void HardwareSerial::begin(uint32_t baud, uint16_t format)
 	if ((format & 0x0F) == 0x04) ctrl |=  LPUART_CTRL_R9T8; // 8N2 is 9 bit with 9th bit always 1
 
 	// Bit 5 TXINVERT
-	if (format & 0x20) ctrl |= LPUART_CTRL_TXINV;		// tx invert
+	if (format & 0x20) {
+		ctrl |= LPUART_CTRL_TXINV;		// tx invert
+
+		// if half duplex mode - PU on TX should be PD. 
+		if (half_duplex_mode_) *(portControlRegister(hardware->tx_pins[tx_pin_index_].pin)) &=  ~IOMUXC_PAD_PUS(3);
+	}
 
 	// Now see if the user asked for Half duplex:
 	if (half_duplex_mode_) ctrl |= (LPUART_CTRL_LOOPS | LPUART_CTRL_RSRC);


### PR DESCRIPTION
As per a few threads up on the forum, such as:
https://forum.pjrc.com/threads/72740-Serial-Half-Duplex-Support

I believe this will also hit, it trying to convert DUFF library for SDI-12 to use Serial code in core versus roll your own.

I did quick and dirty test sketch to try it on different uarts. Only tried on Serial1 on T4.x as same code for all uarts.

Tried on all of them on T3.5 except 6, as was lazy and did not want to get to the bottom pad.  Dif confirm it compiles for T3.6, T3.2 and LC

```
#define SERIALX Serial1
void setup() {
  // put your setup code here, to run once:
  //SERIALX.begin(1200, SERIAL_7E1 | SERIAL_HALF_DUPLEX);
  SERIALX.begin(1200, SERIAL_7E1_RXINV_TXINV | SERIAL_HALF_DUPLEX);
  pinMode(LED_BUILTIN, OUTPUT);
}
int loop_count = 0;
void loop() {
  SERIALX.printf("Loop count: %u\n", ++loop_count);
  digitalToggleFast(LED_BUILTIN);
  delay(1000);
}
```