### PR TITLE
support multiple startup hook functions for Teensy 4.x

### DIFF
--- a/teensy4/avr/pgmspace.h
+++ b/teensy4/avr/pgmspace.h
@@ -31,6 +31,10 @@
 #define FLASHMEM __attribute__((section(".flashmem")))
 #define EXTMEM __attribute__((section(".externalram")))
 
+#define REGISTER_EARLY_STARTUP(f) static void (* f ## _eh_ptr)(void) __attribute__ ((section(".early_hook"),used)) = f
+#define REGISTER_MIDDLE_STARTUP(f) static void (* f ## _mh_ptr)(void) __attribute__ ((section(".middle_hook"),used)) = f
+#define REGISTER_LATE_STARTUP(f) static void (* f ## _lh_ptr)(void) __attribute__ ((section(".late_hook"),used)) = f
+
 #define PGM_P  const char *
 #define PSTR(str) ({static const char data[] PROGMEM = (str); &data[0];})
 

--- a/teensy4/imxrt1062.ld
+++ b/teensy4/imxrt1062.ld
@@ -23,6 +23,15 @@ SECTIONS
 		KEEP(*(.startup))
 		*(.flashmem*)
 		. = ALIGN(4);
+		_startup_early_array = .;
+		KEEP(*(.early_hook))
+		LONG(0);
+		_startup_middle_array = .;
+		KEEP(*(.middle_hook))
+		LONG(0);
+		_startup_late_array = .;
+		KEEP(*(.late_hook))
+		LONG(0);
 		KEEP(*(.init))
 		__preinit_array_start = .;
 		KEEP (*(.preinit_array))

--- a/teensy4/imxrt1062_mm.ld
+++ b/teensy4/imxrt1062_mm.ld
@@ -23,6 +23,15 @@ SECTIONS
 		KEEP(*(.startup))
 		*(.flashmem*)
 		. = ALIGN(4);
+		_startup_early_array = .;
+		KEEP(*(.early_hook))
+		LONG(0);
+		_startup_middle_array = .;
+		KEEP(*(.middle_hook))
+		LONG(0);
+		_startup_late_array = .;
+		KEEP(*(.late_hook))
+		LONG(0);
 		KEEP(*(.init))
 		__preinit_array_start = .;
 		KEEP (*(.preinit_array))

--- a/teensy4/imxrt1062_t41.ld
+++ b/teensy4/imxrt1062_t41.ld
@@ -24,6 +24,15 @@ SECTIONS
 		KEEP(*(.startup))
 		*(.flashmem*)
 		. = ALIGN(4);
+		_startup_early_array = .;
+		KEEP(*(.early_hook))
+		LONG(0);
+		_startup_middle_array = .;
+		KEEP(*(.middle_hook))
+		LONG(0);
+		_startup_late_array = .;
+		KEEP(*(.late_hook))
+		LONG(0);
 		KEEP(*(.init))
 		__preinit_array_start = .;
 		KEEP (*(.preinit_array))


### PR DESCRIPTION
If multiple libraries both override the same startup_*_hook function (or a library overrides it when a sketch wants to use it), they can't be used together since it causes a duplicate symbol error.
This PR makes arrays for each startup hook stage (early/middle/late) so multiple functions can be registered to run. Any function can be registered as a startup hook by using the REGISTER_*_STARTUP() macros to insert them into the appropriate array.

The original hook functions (startup_early_hook/startup_middle_hook/startup_late_hook) are still called for backwards compatibility with existing code.
