### PR TITLE
Fix Teensy 4 Compilation with USB_DISABLED Flag

### DIFF
--- a/teensy4/usb.c
+++ b/teensy4/usb.c
@@ -1111,4 +1111,8 @@ void usb_init(void)
 {
 }
 
+void usb_isr(void)
+{
+}
+
 #endif // defined(NUM_ENDPOINTS)

--- a/teensy4/usb_serial.h
+++ b/teensy4/usb_serial.h
@@ -223,6 +223,7 @@ public:
 };
 
 extern usb_serial_class Serial;
+extern void serialEvent(void) __attribute__((weak));
 #endif // __cplusplus
 
 #endif // !defined(USB_DISABLED)


### PR DESCRIPTION
Testing with 1.59 I discovered that Teensy 4.0 does not compile when the `USB_DISABLED` flag is set. This PR fixes that issue with two small corrections.

First, a declaration for `serialEvent()` is added to the dummy `Serial` interface block. This was removed during the serial event rework for 1.59, but should be present for the dummy interface.

Second, a dummy `usb_isr()` function definition was added for situations where the core is compiled with no USB endpoints defined (`NUM_ENDPOINTS`). This function is invoked by the `unused_interrupt_vector()` function in `startup.c`, and without a definition was causing a linker error.

I haven't done any testing in hardware, but the core now compiles at least.