### PR TITLE
fix leap year calculation bug in makeTime()

### DIFF
--- a/teensy4/Time.cpp
+++ b/teensy4/Time.cpp
@@ -103,16 +103,17 @@ uint32_t makeTime(const DateTimeFields &tm)
   uint32_t seconds;
 
   // seconds from 1970 till 1 jan 00:00:00 of the given year
-  seconds = (tm.year - 70) * (SECS_PER_DAY * 365);
-  for (i = 70; i < tm.year; i++) {
-    if (LEAP_YEAR(i - 70)) {
+  int year = tm.year - 70;
+  seconds = year * (SECS_PER_DAY * 365);
+  for (i = 0; i < year; i++) {
+    if (LEAP_YEAR(i)) {
       seconds += SECS_PER_DAY;   // add extra days for leap years
     }
   }
 
   // add days for this year, months start from 1
   for (i = 0; i < tm.mon; i++) {
-    if ( (i == 1) && LEAP_YEAR(tm.year)) {
+    if ( (i == 1) && LEAP_YEAR(year)) {
       seconds += SECS_PER_DAY * 29;
     } else {
       seconds += SECS_PER_DAY * monthDays[i];


### PR DESCRIPTION
makeTime() has a bug when checking if the specified year is a leap year, caused by failing to subtract 70 from the DateTimeFields.year.

This function will demonstrate:
```
void printDateTime() {
  uint32_t now;
  DateTimeFields dt;
  // uncomment to test current time:
//  now = rtc_get();
  // otherwise use this time to demonstrate the bug in makeTime()
  now = 1715350435; // 2024-05-10 14:13:55
  breakTime(now, dt);
  now = makeTime(dt);

  Serial.printf("%04u-%02u-%02u %02u:%02u:%02u", dt.year+1900, dt.mon+1, dt.mday, dt.hour, dt.min, dt.sec);
  Serial.printf(" -> %u -> ", now);
  breakTime(now, dt);
  Serial.printf("%04u-%02u-%02u %02u:%02u:%02u", dt.year+1900, dt.mon+1, dt.mday, dt.hour, dt.min, dt.sec);
  Serial.println();
}
```
Output from current code:
```
2024-05-10 14:13:55 -> 1715264035 -> 2024-05-09 14:13:55
```

Expected output (after applying PR):
```
2024-05-10 14:13:55 -> 1715350435 -> 2024-05-10 14:13:55
```
