### PR TITLE
add missing overrides for global operator new

### DIFF
--- a/teensy4/new.cpp
+++ b/teensy4/new.cpp
@@ -23,7 +23,8 @@
  * SOFTWARE.
  */
 
-#include <stdlib.h>
+#include <cstdlib>
+#include <new>
 
 void * operator new(size_t size)
 {
@@ -55,3 +56,32 @@ void operator delete[](void * ptr, size_t size __attribute__((unused)))
 	free(ptr);
 }
 
+void * operator new(size_t size, std::align_val_t align)
+{
+	return aligned_alloc((size_t)align, size);
+}
+
+void * operator new[](size_t size, std::align_val_t align)
+{
+	return aligned_alloc((size_t)align, size);
+}
+
+void operator delete(void * ptr, std::align_val_t align __attribute__((unused)))
+{
+	free(ptr);
+}
+
+void operator delete[](void * ptr, std::align_val_t align __attribute__((unused)))
+{
+	free(ptr);
+}
+
+void operator delete(void * ptr, size_t size __attribute__((unused)), std::align_val_t align __attribute__((unused)))
+{
+	free(ptr);
+}
+
+void operator delete[](void * ptr, size_t size __attribute__((unused)), std::align_val_t align __attribute__((unused)))
+{
+	free(ptr);
+}


### PR DESCRIPTION
Updating the toolchain to support C++17 added some new overloads for operators new and delete to support overly-aligned allocations. Overrides for these are missing from Teensyduino which results in the newlib defaults being used (which link in a bunch of exception throwing/handling stuff that we don't want).

(The delete overrides aren't all that important, they're just there to ensure any memory allocated with our new operators is deallocated using the appropriate method i.e. via free() ).