### PR TITLE
Add printf format compiler checks for Print::printf()

### DIFF
--- a/teensy3/Print.h
+++ b/teensy3/Print.h
@@ -111,9 +111,7 @@ class Print
 	size_t println(const Printable &obj)		{ return obj.printTo(*this) + println(); }
 	int getWriteError() { return write_error; }
 	void clearWriteError() { setWriteError(0); }
-	// format warnings are too pedantic - disable until newer toolchain offers better...
-	// https://forum.pjrc.com/threads/62473?p=256873&viewfull=1#post256873
-	int printf(const char *format, ...) /*__attribute__ ((format (printf, 2, 3)))*/;
+	int printf(const char *format, ...) __attribute__((format(printf, 2, 3)));
 	int printf(const __FlashStringHelper *format, ...);
 	int vprintf(const char *format, va_list ap) { return vdprintf((int)this, format, ap); }
   protected:

--- a/teensy3/usb_seremu.h
+++ b/teensy3/usb_seremu.h
@@ -36,6 +36,7 @@
 #if defined(SEREMU_INTERFACE)
 
 #include <inttypes.h>
+#include <stdarg.h>
 
 #if F_CPU >= 20000000
 
@@ -94,6 +95,13 @@ public:
         size_t write(int n) { return write((uint8_t)n); }
 	virtual int availableForWrite() { return usb_seremu_write_buffer_free(); }
 	using Print::write;
+	int printf(const char *format, ...) {
+		va_list args;
+		va_start(args, format);
+		int retval = vprintf(format, args);
+		va_end(args);
+		return retval;
+	}
         void send_now(void) { usb_seremu_flush_output(); };
         uint32_t baud(void) { return 9600; }
         uint8_t stopbits(void) { return 1; }
@@ -132,6 +140,13 @@ public:
 	size_t write(int n) { return 1; }
 	virtual int availableForWrite() { return 0; }
 	using Print::write;
+	int printf(const char *format, ...) {
+		va_list args;
+		va_start(args, format);
+		int retval = vprintf(format, args);
+		va_end(args);
+		return retval;
+	}
 	void send_now(void) { }
 	uint32_t baud(void) { return 0; }
 	uint8_t stopbits(void) { return 1; }

--- a/teensy3/usb_serial.h
+++ b/teensy3/usb_serial.h
@@ -36,6 +36,7 @@
 #if (defined(CDC_STATUS_INTERFACE) && defined(CDC_DATA_INTERFACE)) || defined(USB_DISABLED)
 
 #include <inttypes.h>
+#include <stdarg.h>
 
 #if F_CPU >= 20000000 && !defined(USB_DISABLED)
 
@@ -104,6 +105,13 @@ public:
 	size_t write(int n) { return write((uint8_t)n); }
 	virtual int availableForWrite() { return usb_serial_write_buffer_free(); }
 	using Print::write;
+	int printf(const char *format, ...) {
+		va_list args;
+		va_start(args, format);
+		int retval = vprintf(format, args);
+		va_end(args);
+		return retval;
+	}
         void send_now(void) { usb_serial_flush_output(); }
         uint32_t baud(void) { return usb_cdc_line_coding[0]; }
         uint8_t stopbits(void) { uint8_t b = usb_cdc_line_coding[1]; if (!b) b = 1; return b; }
@@ -157,6 +165,13 @@ public:
 	size_t write(int n) { return 1; }
 	virtual int availableForWrite() { return 0; }
 	using Print::write;
+	int printf(const char *format, ...) {
+		va_list args;
+		va_start(args, format);
+		int retval = vprintf(format, args);
+		va_end(args);
+		return retval;
+	}
         void send_now(void) { }
         uint32_t baud(void) { return 0; }
         uint8_t stopbits(void) { return 1; }

--- a/teensy4/Print.h
+++ b/teensy4/Print.h
@@ -153,7 +153,7 @@ class Print
 	void clearWriteError() { setWriteError(0); }
 
 	// printf is a C standard function which allows you to print any number of variables using a somewhat cryptic format string
-	int printf(const char *format, ...);
+	int printf(const char *format, ...) __attribute__((format(printf, 2, 3)));
 	// printf is a C standard function which allows you to print any number of variables using a somewhat cryptic format string
 	int printf(const __FlashStringHelper *format, ...);
 	// vprintf is a C standard function that allows you to print a variable argument list with a format string

--- a/teensy4/usb_seremu.h
+++ b/teensy4/usb_seremu.h
@@ -34,6 +34,7 @@
 
 #if defined(SEREMU_INTERFACE) && !defined(CDC_STATUS_INTERFACE) && !defined(CDC_DATA_INTERFACE)
 
+#include <stdarg.h>
 #include <stdint.h>
 
 // C language implementation
@@ -92,6 +93,13 @@ public:
         size_t write(int n) { return write((uint8_t)n); }
 	virtual int availableForWrite() { return usb_seremu_write_buffer_free(); }
 	using Print::write;
+	int printf(const char *format, ...) {
+		va_list args;
+		va_start(args, format);
+		int retval = vprintf(format, args);
+		va_end(args);
+		return retval;
+	}
         void send_now(void) { usb_seremu_flush_output(); };
         uint32_t baud(void) { return 9600; }
         uint8_t stopbits(void) { return 1; }

--- a/teensy4/usb_serial.h
+++ b/teensy4/usb_serial.h
@@ -31,6 +31,7 @@
 #pragma once
 
 #include "usb_desc.h"
+#include <stdarg.h>
 #include <stdint.h>
 
 #if (defined(CDC_STATUS_INTERFACE) && defined(CDC_DATA_INTERFACE)) || defined(USB_DISABLED)
@@ -129,6 +130,13 @@ public:
 	// transmit.
 	virtual int availableForWrite() { return usb_serial_write_buffer_free(); }
 	using Print::write;
+	int printf(const char *format, ...) {
+		va_list args;
+		va_start(args, format);
+		int retval = vprintf(format, args);
+		va_end(args);
+		return retval;
+	}
 	// Cause any previously transmitted data written to buffers to be actually
 	// sent over the USB cable to your PC as soon as possible.  Normally writes
 	// are combined to efficiently use maximum size USB packets.  Use of send_now()
@@ -212,6 +220,13 @@ public:
     size_t write(int n) { return 1; }
     virtual int availableForWrite() { return 0; }
     using Print::write;
+	int printf(const char *format, ...) {
+		va_list args;
+		va_start(args, format);
+		int retval = vprintf(format, args);
+		va_end(args);
+		return retval;
+	}
         void send_now(void) { }
         uint32_t baud(void) { return 0; }
         uint8_t stopbits(void) { return 1; }
@@ -291,6 +306,13 @@ public:
         size_t write(int n) { return write((uint8_t)n); }
         virtual int availableForWrite() { return usb_serial2_write_buffer_free(); }
         using Print::write;
+	int printf(const char *format, ...) {
+		va_list args;
+		va_start(args, format);
+		int retval = vprintf(format, args);
+		va_end(args);
+		return retval;
+	}
         void send_now(void) { usb_serial2_flush_output(); }
         uint32_t baud(void) { return usb_cdc2_line_coding[0]; }
         uint8_t stopbits(void) { uint8_t b = usb_cdc2_line_coding[1]; if (!b) b = 1; return b; }
@@ -381,6 +403,13 @@ public:
         size_t write(int n) { return write((uint8_t)n); }
         virtual int availableForWrite() { return usb_serial3_write_buffer_free(); }
         using Print::write;
+	int printf(const char *format, ...) {
+		va_list args;
+		va_start(args, format);
+		int retval = vprintf(format, args);
+		va_end(args);
+		return retval;
+	}
         void send_now(void) { usb_serial3_flush_output(); }
         uint32_t baud(void) { return usb_cdc3_line_coding[0]; }
         uint8_t stopbits(void) { uint8_t b = usb_cdc3_line_coding[1]; if (!b) b = 1; return b; }


### PR DESCRIPTION
This will help catch unintended printf() arguments.