### PR TITLE
Create an audio block pre-filled with silence

### DIFF
--- a/teensy3/AudioStream.h
+++ b/teensy3/AudioStream.h
@@ -169,6 +169,7 @@ protected:
 	bool active;
 	unsigned char num_inputs;
 	static audio_block_t * allocate(void);
+	static audio_block_t* allocate_silent(void);
 	static void release(audio_block_t * block);
 	void transmit(audio_block_t *block, unsigned char index = 0);
 	audio_block_t * receiveReadOnly(unsigned int index = 0);

--- a/teensy4/AudioStream.cpp
+++ b/teensy4/AudioStream.cpp
@@ -39,6 +39,8 @@
 #define NUM_MASKS  (((MAX_AUDIO_MEMORY / AUDIO_BLOCK_SAMPLES / 2) + 31) / 32)
 
 audio_block_t * AudioStream::memory_pool;
+PROGMEM static const audio_block_t silent_block = {0,0,0,{0}};
+extern "C" { audio_block_t* silent_block_ptr = (audio_block_t*) &silent_block; }
 uint32_t AudioStream::memory_pool_available_mask[NUM_MASKS];
 uint16_t AudioStream::memory_pool_first_mask;
 
@@ -128,12 +130,25 @@ audio_block_t * AudioStream::allocate(void)
 	return block;
 }
 
+
+// "Allocate" the silent block. The caller doesn't
+// actually own it, and must NOT write to it! However, 
+// it may be transmitted and released as usual.
+audio_block_t* AudioStream::allocate_silent(void)
+{
+	return (audio_block_t*) &silent_block;
+}
+
+
 // Release ownership of a data block.  If no
 // other streams have ownership, the block is
-// returned to the free pool
+// returned to the free pool.
+//
+// An attempt to release a nullptr or the silent
+// block is ignored.
 void AudioStream::release(audio_block_t *block)
 {
-	//if (block == NULL) return;
+	if (nullptr == block || &silent_block == block) return;
 	uint32_t mask = (0x80000000 >> (31 - (block->memory_pool_index & 0x1F)));
 	uint32_t index = block->memory_pool_index >> 5;
 
@@ -161,9 +176,15 @@ void AudioStream::transmit(audio_block_t *block, unsigned char index)
 {
 	for (AudioConnection *c = destination_list; c != NULL; c = c->next_dest) {
 		if (c->src_index == index) {
-			if (c->dst->inputQueue[c->dest_index] == NULL) {
-				c->dst->inputQueue[c->dest_index] = block;
-				block->ref_count++;
+			if (c->dst->inputQueue[c->dest_index] == NULL) 
+			{
+				if (&silent_block != block) // it's a real block
+				{
+					c->dst->inputQueue[c->dest_index] = block;
+					block->ref_count++; // only real blocks have reference counts
+				}
+				// if we "transmit" the silent block, then leave
+				// the inputQueue entry as nullptr, which means "silence"
 			}
 		}
 	}

--- a/teensy4/AudioStream.h
+++ b/teensy4/AudioStream.h
@@ -160,6 +160,7 @@ protected:
 	bool active;
 	unsigned char num_inputs;
 	static audio_block_t * allocate(void);
+	static audio_block_t* allocate_silent(void);
 	static void release(audio_block_t * block);
 	void transmit(audio_block_t *block, unsigned char index = 0);
 	audio_block_t * receiveReadOnly(unsigned int index = 0);


### PR DESCRIPTION
In theory passing a NULL pointer to an audio block implies a silent block, i.e. all zeroes. In many cases this can be dealt with simply, but on other occasions code is significantly simplified if a genuine audio block pre-filled with silent data is available. An example is a reverb tail when its source suddenly starts emitting NULL blocks; there are also multiple instances where hardware output objects have private zerodata[] arrays which could be replaced by using this common structure.

This modification adds an `AudioStream::allocate_silent()` function, which yields a "genuine" silent block for use on such occasions. It has the restriction that its data are read-only, but it can be transmitted and released as with any other block, so no special treatment is needed by "downstream" code. Any number of copies may be allocated at one time (the reference count is never modified), even if the block pool is exhausted.

At the time of writing this extension is not used within the (separately maintained) Audio library, but once part of the cores it will be possible to update the Audio library to make use of it, hopefully improving its clarity and efficiency.