### PR TITLE
remove XBAR1_IN10 from pin_to_xbar_info

### DIFF
--- a/teensy4/HardwareSerial.cpp
+++ b/teensy4/HardwareSerial.cpp
@@ -728,7 +728,6 @@ const pin_to_xbar_info_t PROGMEM pin_to_xbar_info[] = {
 	{8,  14, 1, &IOMUXC_XBAR1_IN14_SELECT_INPUT, 0x1},
 	{30, 23, 1, &IOMUXC_XBAR1_IN23_SELECT_INPUT, 0x0},
 	{31, 22, 1, &IOMUXC_XBAR1_IN22_SELECT_INPUT, 0x0},
-	{32, 10, 1, nullptr, 0},
 	{33,  9, 3, &IOMUXC_XBAR1_IN09_SELECT_INPUT, 0x0},
 
 #ifdef ARDUINO_TEENSY41


### PR DESCRIPTION
Searching the reference manual for `XBAR1_IN10` yields a single line, but there are no occurences of `XBAR1_IN10_SELECT_INPUT`.
![2024-08-28-130023-screenshot](https://github.com/user-attachments/assets/0648a238-b33d-4437-a6d5-384df8610079)

Additionally, it appears that `pin_to_xbar_info` is only used in `HardwareSerial` and there is no uart associated with `GPIO_B0_12`:
![2024-08-28-130244-screenshot](https://github.com/user-attachments/assets/9ef5c564-9dee-437e-8fd2-e3308b1b4672)


