### PR TITLE
do not enable cts when setting alternate rx xbar pin

### DIFF
--- a/teensy4/HardwareSerial.cpp
+++ b/teensy4/HardwareSerial.cpp
@@ -318,7 +318,7 @@ void HardwareSerialIMXRT::setRX(uint8_t pin)
 				//  configure the pin. 
 				*(portControlRegister(pin)) = IOMUXC_PAD_DSE(7) | IOMUXC_PAD_PKE | IOMUXC_PAD_PUE | IOMUXC_PAD_PUS(3) | IOMUXC_PAD_HYS;;
 				*(portConfigRegister(pin)) = pin_to_xbar_info[i].mux_val;
-				port->MODIR |= LPUART_MODIR_TXCTSE;
+
 				if (pin_to_xbar_info[i].select_input_register) *(pin_to_xbar_info[i].select_input_register) = pin_to_xbar_info[i].select_val;
 				//Serial.printf("SerialX::begin stat:%x ctrl:%x fifo:%x water:%x\n", port->STAT, port->CTRL, port->FIFO, port->WATER );
 				//Serial.printf("  PINCFG: %x MODIR: %x\n", port->PINCFG, port->MODIR);	


### PR DESCRIPTION
`SerialHardware.setRx()` currently enables CTS if the provided pin is an xbar pin. AFAICT this prevents the pin from being used for rx, and also results in the tx buffer filling up (assuming you are sending data) and causes the program to halt.

### Testing

You can use this sketch to confirm that tx buffer fills up after using `setRX()` with an xbar pin:
```cpp
#define SERIAL_INTERFACE Serial1
#define SERIAL_BAUD_RATE 1000000

void setup() {
  while (!Serial) {}
  Serial.begin(9600);

  SERIAL_INTERFACE.begin(SERIAL_BAUD_RATE);
  SERIAL_INTERFACE.setRX(3);
}

uint8_t value = 0;
void loop() {
  Serial.printf("tx %d (availableForWrite=%d)\n", value, SERIAL_INTERFACE.availableForWrite());
  SERIAL_INTERFACE.write(value++);
}
```
```
tx 0 (availableForWrite=63)
tx 1 (availableForWrite=63)
tx 2 (availableForWrite=63)
tx 3 (availableForWrite=63)
tx 4 (availableForWrite=62)
tx 5 (availableForWrite=61)
tx 6 (availableForWrite=60)
tx 7 (availableForWrite=59)
tx 8 (availableForWrite=58)
tx 9 (availableForWrite=57)

... trend continues ...

tx 62 (availableForWrite=4)
tx 63 (availableForWrite=3)
tx 64 (availableForWrite=2)
tx 65 (availableForWrite=1)
tx 66 (availableForWrite=0)

...program halts...
```

To confirm this patch works you can setup two teensy4.x wired to use xbar pins for rx, and then make sure they can communicate back and forth.

Here is the setup I used to test:
![PXL_20240901_171556740 (1)](https://github.com/user-attachments/assets/d22cc232-c588-4d52-8f60-80a2b4c047c4)
I'm running the same sketch on both devices, and using pin 41 to set the mode each device will run as.


Here is my sketch:
```cpp
#include <Arduino.h>

#define SERIAL_INTERFACE Serial1
#define SERIAL_BAUD_RATE 1000000

const uint8_t ledPin = 13;
const uint8_t modePin = 41;
const uint8_t rxPin = 4;
bool isMaster = false;

void blink(int on = 100, int off = 100) {
  digitalWrite(ledPin, HIGH);
  delay(on);
  digitalWrite(ledPin, LOW);
  delay(off);
}

void setup() {
  Serial.begin(9600);

  pinMode(ledPin, OUTPUT);
  pinMode(modePin, INPUT);

  delay(100);
  isMaster = digitalRead(modePin);

  SERIAL_INTERFACE.begin(SERIAL_BAUD_RATE);
  SERIAL_INTERFACE.setRX(rxPin);

  if (isMaster) {
    blink(500, 100);
  } else {
    blink(100, 500);
  }
}

void loop() {
  if (isMaster) {
    uint8_t value = random(255) + 1;
    Serial.printf("tx %d (availableForWrite=%d)", value, SERIAL_INTERFACE.availableForWrite());
    SERIAL_INTERFACE.write(value);
    while (!SERIAL_INTERFACE.available()) {
      delay(1);
    }

    uint8_t response = SERIAL_INTERFACE.read();
    if (response != value) {
      Serial.printf(" FAILED %d (expected %d)\n", response, value);
      blink(500, 100);
      SERIAL_INTERFACE.clear();
    } else {
      Serial.printf(" OK\n", response, value);
    }

    delay(10);
  } else {
    int length = SERIAL_INTERFACE.available();
    for (int i = 0; i < length; i++) {
      uint8_t value = SERIAL_INTERFACE.read();
      Serial.printf("rx %d\n", value);
      SERIAL_INTERFACE.write(value);
      if (value == 0) {
        blink();
      }
    }
  }
}
```

Against this branch you see the expected output in the serial console for the _master_ device:
```
tx 61 (availableForWrite=63) OK
tx 22 (availableForWrite=63) OK
tx 141 (availableForWrite=63) OK
tx 128 (availableForWrite=63) OK
tx 182 (availableForWrite=63) OK
tx 232 (availableForWrite=63) OK
tx 101 (availableForWrite=63) OK

... random number round trips continue ...
```

Against the `master` branch, you'll see the first tx message and nothing else.


