### PR TITLE
AudioStream: Add destructor.  Enables dynamic creation and destruction.

### DIFF
--- a/teensy3/AudioStream.cpp
+++ b/teensy3/AudioStream.cpp
@@ -208,6 +208,31 @@ audio_block_t * AudioStream::receiveWritable(unsigned int index)
 	return in;
 }
 
+//Define the destructor for AudioStream.  
+//The contract here is that the user has already disconnected all or
+//destroyed all of the AudioConnections.  Therefore, the clean-up activities
+//that remain are to remove this instance from the update list and
+//to release any audio_block_t pointers in this instance's input queue.
+AudioStream::~AudioStream(void)
+{
+	//remove this instance from the update list
+	__disable_irq(); //make sure no update() happens while we're changing the update list
+	AudioStream *p = first_update;
+	while (p != NULL) {
+		if (p->next_update == this) {
+			p->next_update = this->next_update; //remove the pointer to this instance and replace it with the next instance
+		}
+		p = p->next_update; //go to next step in linked list
+	}
+	__enable_irq();
+
+	//release any audio blocks held in the input queue for this instance of AudioStream
+	for (int i=0; i<num_inputs; i++) {
+		audio_block_t *block = inputQueue[i];
+		if  (block != NULL) release(block);
+	}
+}
+
 /**************************************************************************************/
 // Constructor with no parameters: leave unconnected
 AudioConnection::AudioConnection()

--- a/teensy3/AudioStream.h
+++ b/teensy3/AudioStream.h
@@ -154,6 +154,7 @@ public:
 			cpu_cycles_max = 0;
 			numConnections = 0;
 		}
+	virtual ~AudioStream(void);
 	static void initialize_memory(audio_block_t *data, unsigned int num);
 	int processorUsage(void) { return CYCLE_COUNTER_APPROX_PERCENT(cpu_cycles); }
 	int processorUsageMax(void) { return CYCLE_COUNTER_APPROX_PERCENT(cpu_cycles_max); }

--- a/teensy4/AudioStream.h
+++ b/teensy4/AudioStream.h
@@ -145,6 +145,7 @@ public:
 			cpu_cycles_max = 0;
 			numConnections = 0;
 		}
+	virtual ~AudioStream(void);
 	static void initialize_memory(audio_block_t *data, unsigned int num);
 	float processorUsage(void) { return CYCLE_COUNTER_APPROX_PERCENT(cpu_cycles); }
 	float processorUsageMax(void) { return CYCLE_COUNTER_APPROX_PERCENT(cpu_cycles_max); }


### PR DESCRIPTION
There's been great work on dynamic creation and destruction of AudioConnection instances.  But, one has not been able to dynamically destroy AudioStream instances.  In my view, the main limitation is that the user had no way of removing an AudioStream instance from the AudioStream update list.

This pull request adds a destructor to AudioStream.  Now, when the instance is destroyed, it removes the pointer from the update list.

The user must still remember to close out all of the AudioConnections that use the destroyed AudioStream instance, but that's at least possible for the user to do.  Without AudioStream having a destructor, there is no way for the user to remove the instance to the update list.

This pull request includes both Teensy3 and Teensy4.  It has been tested on a Teensy 4.1 and a Teensy 3.6.