### PR TITLE
[USB] Improve documentation for wRequestAndType=0xF8C0 case

### DIFF
--- a/teensy4/usb.c
+++ b/teensy4/usb.c
@@ -531,7 +531,7 @@ static void endpoint0_setup(uint64_t setupdata)
 		endpoint0_receive(NULL, 0, 0);
 		return;
 #ifdef EXPERIMENTAL_INTERFACE
-	  case 0xF8C0: // GET_MS_DESCRIPTOR (bRequest=0xF8 because microsoft_os_string_desc)
+	  case 0xF8C0: // GET_MS_DESCRIPTOR (bmRequestType=0xC0, bRequest=0xF8 because microsoft_os_string_desc)
 		if ((setup.wIndex & 0xFF00) != 0) break; // 1=Genre, 4=Compat ID, 5=Properties
 		setup.wIndex |= 0xEE00; // alter wIndex and treat as normal USB descriptor
 		__attribute__((fallthrough));


### PR DESCRIPTION
Document that `bmRequestType=0xC0` for `GET_MS_DESCRIPTOR` based on https://learn.microsoft.com/en-us/windows-hardware/drivers/network/mb-interface-model-supplement