### PR TITLE
Move "core_pins.h" include from source to header file

### DIFF
--- a/teensy4/usb_seremu.c
+++ b/teensy4/usb_seremu.c
@@ -30,11 +30,9 @@
 
 #include "usb_dev.h"
 #include "usb_seremu.h"
-#include "core_pins.h" // for yield()
 #include <string.h> // for memcpy()
 #include "avr/pgmspace.h" // for PROGMEM, DMAMEM, FASTRUN
 #include "debug/printf.h"
-#include "core_pins.h"
 
 #if defined(SEREMU_INTERFACE) && !defined(CDC_STATUS_INTERFACE) && !defined(CDC_DATA_INTERFACE)
 

--- a/teensy4/usb_seremu.h
+++ b/teensy4/usb_seremu.h
@@ -31,6 +31,7 @@
 #pragma once
 
 #include "usb_desc.h"
+#include "core_pins.h" // for yield()
 
 #if defined(SEREMU_INTERFACE) && !defined(CDC_STATUS_INTERFACE) && !defined(CDC_DATA_INTERFACE)
 

--- a/teensy4/usb_serial.c
+++ b/teensy4/usb_serial.c
@@ -36,7 +36,6 @@
 #include "avr/pgmspace.h" // for PROGMEM, DMAMEM, FASTRUN
 
 #include "debug/printf.h"
-#include "core_pins.h"
 
 // defined by usb_dev.h -> usb_desc.h
 #if defined(CDC_STATUS_INTERFACE) && defined(CDC_DATA_INTERFACE)

--- a/teensy4/usb_serial.h
+++ b/teensy4/usb_serial.h
@@ -30,6 +30,7 @@
 
 #pragma once
 
+#include "core_pins.h"
 #include "usb_desc.h"
 #include <stdint.h>
 


### PR DESCRIPTION
Fixes the following errors _if_ attempting to compile `usb_serial.h` as C++ code:
```
usb_serial.h:93:25: error: 'yield' was not declared in this scope
usb_serial.h:177:45: error: 'millis' was not declared in this scope
```

Fixes the following errors _if_ attempting to compile `usb_seremu.h` as C++ code:
```
usb_seremu.h:68:41: error: 'systick_millis_count' was not declared in this scope
usb_seremu.h:79:25: error: 'yield' was not declared in this scope
usb_seremu.h:102:27: error: 'yield' was not declared in this scope
```

I can also update the `teensy` and `teensy3` implementation the same way if desired.

## Motivation
I want to improve compatibility with C++11 (and newer), so that I can eventually use `constexpr` in USB-related code.