### PR TITLE
HardwareSerial::attachRts - new optional parameter to invert signal

### DIFF
--- a/teensy4/HardwareSerial.cpp
+++ b/teensy4/HardwareSerial.cpp
@@ -244,11 +244,13 @@ void HardwareSerialIMXRT::begin(uint32_t baud, uint16_t format)
 
 inline void HardwareSerialIMXRT::rts_assert()
 {
-	DIRECT_WRITE_LOW(rts_pin_baseReg_, rts_pin_bitmask_);
+	if (rts_pin_invert_) DIRECT_WRITE_HIGH(rts_pin_baseReg_, rts_pin_bitmask_);
+	else DIRECT_WRITE_LOW(rts_pin_baseReg_, rts_pin_bitmask_);
 }
 
 inline void HardwareSerialIMXRT::rts_deassert()
 {
+	if (rts_pin_invert_) DIRECT_WRITE_LOW(rts_pin_baseReg_, rts_pin_bitmask_);
 	DIRECT_WRITE_HIGH(rts_pin_baseReg_, rts_pin_bitmask_);
 }
 
@@ -359,12 +361,13 @@ void HardwareSerialIMXRT::setTX(uint8_t pin, bool opendrain)
 }
 
 
-bool HardwareSerialIMXRT::attachRts(uint8_t pin)
+bool HardwareSerialIMXRT::attachRts(uint8_t pin, bool invert_signal)
 {
 	if (!(hardware->ccm_register & hardware->ccm_value)) return 0;
 	if (pin < CORE_NUM_DIGITAL) {
 		rts_pin_baseReg_ = PIN_TO_BASEREG(pin);
 		rts_pin_bitmask_ = PIN_TO_BITMASK(pin);
+		rts_pin_invert_ = invert_signal;
 		pinMode(pin, OUTPUT);
 		rts_assert();
 	} else {

--- a/teensy4/HardwareSerial.h
+++ b/teensy4/HardwareSerial.h
@@ -239,7 +239,8 @@ public:
 	// Configure RTS flow control.  The pin will be LOW when Teensy is able to
 	// receive more data, or HIGH when the serial device should pause transmission.
 	// All digital pins are supported.
-	bool attachRts(uint8_t pin);
+	// The optional invert_signal parameter will invert these signals.
+	bool attachRts(uint8_t pin, bool invert_signal=false);
 	// Configure CTS flow control.  Teensy will transmit when this pin is LOw
 	// and will pause transmission when the pin is HIGH.  Only specific pins are
 	// supported.  See https://www.pjrc.com/teensy/td_uart.html
@@ -327,6 +328,7 @@ private:
 
 	volatile uint32_t 	*rts_pin_baseReg_ = 0;
 	uint32_t 			rts_pin_bitmask_ = 0;
+	bool				rts_pin_invert_ = false;
 
   	inline void rts_assert();
   	inline void rts_deassert();


### PR DESCRIPTION
Added  parameter to attachRts that if set will invert the signals:
```
bool attachRts(uint8_t pin, bool invert_signal=false);
```

This should allow more flexibility in connecting two teensy 4.x boards to each other and using the CTS/RTS between the two boards for flow control.

This is in response to the thread:
https://forum.pjrc.com/index.php?threads/teensy-4-0-4-1-serial1-attachcts.75899/#post-350107

Where I felt somewhat strange to require someone to have to use hardware inverters to do this.