### PR TITLE
[USB] Reorder "core_pins.h" includes for C++ compatibility

### DIFF
--- a/teensy4/usb.c
+++ b/teensy4/usb.c
@@ -1,6 +1,7 @@
 #include "usb_dev.h"
 #define USB_DESC_LIST_DEFINE
 #include "usb_desc.h"
+#include "core_pins.h" // for delay()
 #include "usb_serial.h"
 #include "usb_seremu.h"
 #include "usb_rawhid.h"
@@ -12,7 +13,6 @@
 #include "usb_midi.h"
 #include "usb_audio.h"
 #include "usb_mtp.h"
-#include "core_pins.h" // for delay()
 #include "avr/pgmspace.h"
 #include <string.h>
 #include "debug/printf.h"

--- a/teensy4/usb_seremu.c
+++ b/teensy4/usb_seremu.c
@@ -29,12 +29,11 @@
  */
 
 #include "usb_dev.h"
-#include "usb_seremu.h"
 #include "core_pins.h" // for yield()
+#include "usb_seremu.h"
 #include <string.h> // for memcpy()
 #include "avr/pgmspace.h" // for PROGMEM, DMAMEM, FASTRUN
 #include "debug/printf.h"
-#include "core_pins.h"
 
 #if defined(SEREMU_INTERFACE) && !defined(CDC_STATUS_INTERFACE) && !defined(CDC_DATA_INTERFACE)
 


### PR DESCRIPTION
Move the `core_pins.h` includes in `usb.c` and `usb_seremu.c` up to enable building the sources as C++ code. The `core_pins.h` include needs to be placed above the `usb_serial.h` and `usb_seremu.h` includes, since these headers contain C++ code that depends on functions in `core_pins.h`.

Fixes the following compiler errors _if_ renaming the sources in question from `.c` to `.cpp`: In file included from teensy4\usb.cpp:5:
```
teensy4\usb_seremu.h: In member function 'void usb_seremu_class::begin(long int)': teensy4\usb_seremu.h:68:41: error: 'systick_millis_count' was not declared in this scope
   68 |                 uint32_t millis_begin = systick_millis_count;
      |                                         ^~~~~~~~~~~~~~~~~~~~
teensy4\usb_seremu.h:79:25: error: 'yield' was not declared in this scope
   79 |                         yield();
      |                         ^~~~~
teensy4\usb_seremu.h: In member function 'usb_seremu_class::operator bool()':
teensy4\usb_seremu.h:102:27: error: 'yield' was not declared in this scope
  102 |         operator bool() { yield(); return usb_configuration && usb_seremu_online; }
      |                           ^~~~~
In file included from teensy4\usb_seremu.cpp:32:
teensy4\usb_seremu.h: In member function 'void usb_seremu_class::begin(long int)':
teensy4\usb_seremu.h:68:41: error: 'systick_millis_count' was not declared in this scope
   68 |                 uint32_t millis_begin = systick_millis_count;
      |                                         ^~~~~~~~~~~~~~~~~~~~
teensy4\usb_seremu.h:79:25: error: 'yield' was not declared in this scope
   79 |                         yield();
      |                         ^~~~~
teensy4\usb_seremu.h: In member function 'usb_seremu_class::operator bool()':
teensy4\usb_seremu.h:102:27: error: 'yield' was not declared in this scope
  102 |         operator bool() { yield(); return usb_configuration && usb_seremu_online; }
      |                           ^~~~~
```