### PR TITLE
writing to DMA TCD requires volatile pointer

### DIFF
--- a/teensy4/DMAChannel.h
+++ b/teensy4/DMAChannel.h
@@ -376,12 +376,13 @@ protected:
 	static inline void copy_tcd(TCD_t *dst, const TCD_t *src) {
 		dst->CSR &= ~DMA_TCD_CSR_DONE;
 		const uint32_t *p = (const uint32_t *)src;
-		uint32_t *q = (uint32_t *)dst;
+		volatile uint32_t *q = (uint32_t *)dst;
 		uint32_t t1, t2, t3, t4;
 		t1 = *p++; t2 = *p++; t3 = *p++; t4 = *p++;
 		*q++ = t1; *q++ = t2; *q++ = t3; *q++ = t4;
 		t1 = *p++; t2 = *p++; t3 = *p++; t4 = *p++;
 		*q++ = t1; *q++ = t2; *q++ = t3; *q++ = t4;
+		asm volatile("dmb");
 	}
 };
 


### PR DESCRIPTION
When copying a TCD to the DMA Channel registers, a volatile pointer should be used to ensure the writes happen in the correct order.


A memory barrier is added at the end to ensure the memory-mapped registers have been updated before the DMA channel is triggered, either implicitly (by another hardware peripheral) or explicitly (writing to DMA_SSRT).

Full explanation: https://forum.pjrc.com/index.php?threads/teensyduino-1-60-beta-3.75976/page-2#post-354566