### PR TITLE
fix signature of _lseek() stub

### DIFF
--- a/teensy4/startup.c
+++ b/teensy4/startup.c
@@ -758,7 +758,7 @@ int _isatty(int fd __attribute__((unused)))
 }
 
 __attribute__((weak))
-int _lseek(int fd __attribute__((unused)), long long offset __attribute__((unused)), int whence __attribute__((unused)))
+off_t _lseek(int fd __attribute__((unused)), off_t offset __attribute__((unused)), int whence __attribute__((unused)))
 {
 	return -1;
 }


### PR DESCRIPTION
The function signature for the default _lseek stub is incorrect, the second parameter is a signed 32-bit value rather than 64-bits. The incorrect signature triggers a warning when the stub is replaced with a proper _lseek function (with correct signature, since the arguments aren't interpreted correctly with the bad one) and LTO is used.