### PR TITLE
Add new PSRAM ID and sizes

### DIFF
--- a/teensy4/startup.c
+++ b/teensy4/startup.c
@@ -548,7 +548,7 @@ FLASHMEM void configure_external_ram()
         uint32_t rsz = flexspi2_psram_id(0);
         if (rsz > 0) {
                 uint32_t rad = rsz << 20; // next PSRAM address
-                external_psram_size = rid;
+                external_psram_size = rsz;
                 FLEXSPI2_FLSHA1CR0 = rsz << 10;
                 
                 flexspi2_command(4, 0);


### PR DESCRIPTION
Adds ISSI PSRAM, with ability to use 4MB/8MB/16MB chips.
Limit is still 16MB (see comments) but should be able to support 64MB via two 32MB PSRAM.
Changed how the region is determined to make all decisions on sizes in one place.

