### PR TITLE
enable continuous read mode for onboard flash

### DIFF
--- a/teensy4/bootdata.c
+++ b/teensy4/bootdata.c
@@ -84,9 +84,9 @@ uint32_t FlexSPI_NOR_Config[128] = {
 	0,			// dataValidTime
 	0x00000000,		// busyBitPolarity,busyOffset
 
-	0x0A1804EB,		// lookupTable[0]		0x80
-	0x26043206,		// lookupTable[1]
-	0,			// lookupTable[2]
+	0x0A1804EB,		// lookupTable[0]		0x80 READ: CMD_SDR(1) 0xEB, RADDR_SDR(4) 24 bits,
+	0x32041E20,		// lookupTable[1]				MODE8_SDR(4) 0x20, DUMMY_SDR(4) 4 cycles,
+	0x7C012604,		// lookupTable[2]				READ_SDR(4) 4 bytes, JUMP_ON_CS
 	0,			// lookupTable[3]
 
 	0x24040405,		// lookupTable[4]		0x90


### PR DESCRIPTION
This speeds up read operations for the external flash chip by enabling continuous read mode; successive read commands don't need to send the 0xEB command byte which saves 8 FlexSPI clock cycles for every read.

The 0xFF command is used to turn off continuous reading to allow other flash commands to be issued, taken from the Winbond flash datasheet: "It is recommended to input FFh on IO0 for the next instruction (8 clocks), to ensure M4 = 1 and return the device to normal operation."