### PR TITLE
Improve uses of 'static inline' and 'inline'

### DIFF
--- a/teensy/HardwareSerial.h
+++ b/teensy/HardwareSerial.h
@@ -7,7 +7,7 @@
 class HardwareSerial : public Stream
 {
 public:
-	inline void begin(uint32_t baud, uint8_t txen_pin=255) {
+	void begin(uint32_t baud, uint8_t txen_pin=255) {
 		_begin(((F_CPU / 8) + (baud / 2)) / baud, txen_pin);
 	}
 	void _begin(uint16_t baud_count, uint8_t pin);

--- a/teensy/Print.h
+++ b/teensy/Print.h
@@ -111,7 +111,7 @@ class Print
 	size_t printNumberHex(unsigned long n);
 	size_t printNumberBin(unsigned long n);
 	size_t printNumberAny(unsigned long n, uint8_t base);
-	inline size_t printNumber(unsigned long n, uint8_t sign, uint8_t base) __attribute__((always_inline)) {
+	size_t printNumber(unsigned long n, uint8_t sign, uint8_t base) __attribute__((always_inline)) {
 		// when "base" is a constant (pretty much always), the
 		// compiler optimizes this to a single function call.
 		if (base == 0) return write((uint8_t)n);

--- a/teensy/WString.h
+++ b/teensy/WString.h
@@ -69,7 +69,7 @@ public:
 
 	// memory management
 	unsigned char reserve(unsigned int size);
-	inline unsigned int length(void) const {return len;}
+	unsigned int length(void) const {return len;}
 
 	// copy and move
 	String & copy(const char *cstr, unsigned int length);

--- a/teensy/core_pins.h
+++ b/teensy/core_pins.h
@@ -815,6 +815,11 @@
 
 #ifdef __cplusplus
 extern "C"{
+// C++ compilers shouldn't use 'static inline' because then there may be more
+// than one copy of the function; 'static' implies internal linkage
+#define STATIC_INLINE inline
+#else
+#define STATIC_INLINE static inline
 #endif
 
 
@@ -822,8 +827,8 @@ extern void _digitalWrite(void);
 extern void _digitalWrite_HIGH(void);
 extern void _digitalWrite_LOW(void);
 
-static inline void digitalWrite(uint8_t, uint8_t) __attribute__((always_inline, unused));
-static inline void digitalWrite(uint8_t pin, uint8_t val)
+STATIC_INLINE void digitalWrite(uint8_t, uint8_t) __attribute__((always_inline, unused));
+STATIC_INLINE void digitalWrite(uint8_t pin, uint8_t val)
 {
 	if (__builtin_constant_p(pin)) {
 		if (val) {
@@ -1136,8 +1141,8 @@ static inline void digitalWrite(uint8_t pin, uint8_t val)
 	}
 }
 
-static inline void digitalWriteFast(uint8_t, uint8_t) __attribute__((always_inline, unused));
-static inline void digitalWriteFast(uint8_t pin, uint8_t val)
+STATIC_INLINE void digitalWriteFast(uint8_t, uint8_t) __attribute__((always_inline, unused));
+STATIC_INLINE void digitalWriteFast(uint8_t pin, uint8_t val)
 {
 	if (__builtin_constant_p(pin)) {
 		if (val) {
@@ -1349,8 +1354,8 @@ static inline void digitalWriteFast(uint8_t pin, uint8_t val)
 
 extern void _digitalRead(void) __attribute__((noinline));
 
-static inline uint8_t digitalRead(uint8_t) __attribute__((always_inline, unused));
-static inline uint8_t digitalRead(uint8_t pin)
+STATIC_INLINE uint8_t digitalRead(uint8_t) __attribute__((always_inline, unused));
+STATIC_INLINE uint8_t digitalRead(uint8_t pin)
 {
 	if (__builtin_constant_p(pin)) {
 		if (pin == 0) {
@@ -1465,8 +1470,8 @@ static inline uint8_t digitalRead(uint8_t pin)
 	}
 }
 
-static inline uint8_t digitalReadFast(uint8_t) __attribute__((always_inline, unused));
-static inline uint8_t digitalReadFast(uint8_t pin)
+STATIC_INLINE uint8_t digitalReadFast(uint8_t) __attribute__((always_inline, unused));
+STATIC_INLINE uint8_t digitalReadFast(uint8_t pin)
 {
 	return digitalRead(pin);
 }
@@ -1476,8 +1481,8 @@ extern void _pinMode_output(uint8_t pin) __attribute__((noinline));
 extern void _pinMode_input(uint8_t pin) __attribute__((noinline));
 extern void _pinMode_input_pullup(uint8_t pin) __attribute__((noinline));
 
-static inline void pinMode(uint8_t, uint8_t) __attribute__((always_inline, unused));
-static inline void pinMode(uint8_t pin, uint8_t mode)
+STATIC_INLINE void pinMode(uint8_t, uint8_t) __attribute__((always_inline, unused));
+STATIC_INLINE void pinMode(uint8_t pin, uint8_t mode)
 {
 	if (__builtin_constant_p(pin) && __builtin_constant_p(mode)) {
 		if (mode == OUTPUT) {
@@ -1935,8 +1940,8 @@ static inline void pinMode(uint8_t pin, uint8_t mode)
 	}
 }
 
-static inline void digitalToggle(uint8_t) __attribute__((always_inline, unused));
-static inline void digitalToggle(uint8_t pin)
+STATIC_INLINE void digitalToggle(uint8_t) __attribute__((always_inline, unused));
+STATIC_INLINE void digitalToggle(uint8_t pin)
 {
 	if (__builtin_constant_p(pin)) {
 		if (pin == 0) {
@@ -2074,8 +2079,8 @@ static inline void digitalToggle(uint8_t pin)
 	}
 }
 
-static inline void digitalToggleFast(uint8_t) __attribute__((always_inline, unused));
-static inline void digitalToggleFast(uint8_t pin)
+STATIC_INLINE void digitalToggleFast(uint8_t) __attribute__((always_inline, unused));
+STATIC_INLINE void digitalToggleFast(uint8_t pin)
 {
 	if (__builtin_constant_p(pin)) {
 		if (pin == 0) {
@@ -2187,8 +2192,8 @@ extern int analogRead(uint8_t);
 
 extern void _analogWrite(uint8_t pin, int val) __attribute__((noinline));
 
-static inline void analogWrite(uint8_t, int) __attribute__((always_inline, unused));
-static inline void analogWrite(uint8_t pin, int val)
+STATIC_INLINE void analogWrite(uint8_t, int) __attribute__((always_inline, unused));
+STATIC_INLINE void analogWrite(uint8_t pin, int val)
 {
 	if (__builtin_constant_p(pin)) {
 		if (pin == CORE_OC0B_PIN) {	// TIMER0B
@@ -2266,12 +2271,12 @@ static inline void analogWrite(uint8_t pin, int val)
 	}
 }
 
-static inline void shiftOut(uint8_t, uint8_t, uint8_t, uint8_t) __attribute__((always_inline, unused));
+STATIC_INLINE void shiftOut(uint8_t, uint8_t, uint8_t, uint8_t) __attribute__((always_inline, unused));
 extern void _shiftOut(uint8_t dataPin, uint8_t clockPin, uint8_t bitOrder, uint8_t value) __attribute__((noinline));
 extern void shiftOut_lsbFirst(uint8_t dataPin, uint8_t clockPin, uint8_t value) __attribute__((noinline));
 extern void shiftOut_msbFirst(uint8_t dataPin, uint8_t clockPin, uint8_t value) __attribute__((noinline));
 
-static inline void shiftOut(uint8_t dataPin, uint8_t clockPin, uint8_t bitOrder, uint8_t value)
+STATIC_INLINE void shiftOut(uint8_t dataPin, uint8_t clockPin, uint8_t bitOrder, uint8_t value)
 {
 	if (__builtin_constant_p(bitOrder)) {
 		if (bitOrder == LSBFIRST) {
@@ -2284,12 +2289,12 @@ static inline void shiftOut(uint8_t dataPin, uint8_t clockPin, uint8_t bitOrder,
 	}
 }
 
-static inline uint8_t shiftIn(uint8_t, uint8_t, uint8_t) __attribute__((always_inline, unused));
+STATIC_INLINE uint8_t shiftIn(uint8_t, uint8_t, uint8_t) __attribute__((always_inline, unused));
 extern uint8_t _shiftIn(uint8_t dataPin, uint8_t clockPin, uint8_t bitOrder) __attribute__((noinline));
 extern uint8_t shiftIn_lsbFirst(uint8_t dataPin, uint8_t clockPin) __attribute__((noinline));
 extern uint8_t shiftIn_msbFirst(uint8_t dataPin, uint8_t clockPin) __attribute__((noinline));
 
-static inline uint8_t shiftIn(uint8_t dataPin, uint8_t clockPin, uint8_t bitOrder)
+STATIC_INLINE uint8_t shiftIn(uint8_t dataPin, uint8_t clockPin, uint8_t bitOrder)
 {
 	if (__builtin_constant_p(bitOrder)) {
 		if (bitOrder == LSBFIRST) {
@@ -2310,7 +2315,7 @@ void _restart_Teensyduino_(void) __attribute__((noreturn));
 #define analogReference(mode)
 #else
 extern uint8_t w_analog_reference;
-static inline void analogReference(uint8_t mode)
+STATIC_INLINE void analogReference(uint8_t mode)
 {
 	w_analog_reference = (mode << 6);
 }
@@ -2322,8 +2327,8 @@ extern void delay(uint32_t);
 
 extern volatile uint32_t timer0_millis_count;
 
-static inline uint32_t millis(void) __attribute__((always_inline, unused));
-static inline uint32_t millis(void)
+STATIC_INLINE uint32_t millis(void) __attribute__((always_inline, unused));
+STATIC_INLINE uint32_t millis(void)
 {
 	uint32_t out;
 	asm volatile(
@@ -2341,8 +2346,8 @@ static inline uint32_t millis(void)
 
 extern uint32_t _micros(void) __attribute__((noinline));
 
-static inline uint32_t micros(void) __attribute__((always_inline, unused));
-static inline uint32_t micros(void)
+STATIC_INLINE uint32_t micros(void) __attribute__((always_inline, unused));
+STATIC_INLINE uint32_t micros(void)
 {
 	register uint32_t out asm("r22");
 	asm volatile("call _micros" : "=d" (out) : : "r0");
@@ -2350,8 +2355,8 @@ static inline uint32_t micros(void)
 }
 
 
-static inline void delayMicroseconds(uint16_t) __attribute__((always_inline, unused));
-static inline void delayMicroseconds(uint16_t usec)
+STATIC_INLINE void delayMicroseconds(uint16_t) __attribute__((always_inline, unused));
+STATIC_INLINE void delayMicroseconds(uint16_t usec)
 {
 	if (__builtin_constant_p(usec)) {
 		#if F_CPU == 16000000L
@@ -2445,8 +2450,8 @@ static inline void delayMicroseconds(uint16_t usec)
 }
 
 
-static inline void delayNanoseconds(uint16_t) __attribute__((always_inline, unused));
-static inline void delayNanoseconds(uint16_t nsec)
+STATIC_INLINE void delayNanoseconds(uint16_t) __attribute__((always_inline, unused));
+STATIC_INLINE void delayNanoseconds(uint16_t nsec)
 {
 	if (__builtin_constant_p(nsec)) {
 		// use NOPs for the common usage of a constexpr input and short delay
@@ -2550,4 +2555,7 @@ void breakTime(uint32_t time, DateTimeFields &tm);  // break 32 bit time into Da
 uint32_t makeTime(const DateTimeFields &tm); // convert DateTimeFields to 32 bit time
 
 #endif // __cplusplus
+
+#undef STATIC_INLINE
+
 #endif

--- a/teensy3/DMAChannel.h
+++ b/teensy3/DMAChannel.h
@@ -379,7 +379,7 @@ protected:
 	// require the inheriting class to initialize the TCD pointer.
 	DMABaseClass() {}
 
-	static inline void copy_tcd(TCD_t *dst, const TCD_t *src) {
+	static void copy_tcd(TCD_t *dst, const TCD_t *src) {
 		dst->CSR = 0;
 		const uint32_t *p = (const uint32_t *)src;
 		uint32_t *q = (uint32_t *)dst;
@@ -860,14 +860,14 @@ protected:
 	// require the inheriting class to initialize the TCD pointer.
 	DMABaseClass() {}
 
-	static inline void copy_cfg(CFG_t *dst, const CFG_t *src) {
+	static void copy_cfg(CFG_t *dst, const CFG_t *src) {
 		dst->SAR = src->SAR;
 		dst->DAR = src->DAR;
 		dst->DSR_BCR = src->DSR_BCR;
 		dst->DCR = src->DCR;
 	}
 private:
-	static inline uint32_t len2mod(uint32_t len) {
+	static uint32_t len2mod(uint32_t len) {
 		if (len < 16) return 0;
 		if (len < 32) return 1;
 		if (len < 64) return 2;

--- a/teensy3/HardwareSerial.h
+++ b/teensy3/HardwareSerial.h
@@ -314,7 +314,7 @@ public:
 	virtual size_t write9bit(uint32_t c)	{ serial_putchar(c); return 1; }
 	operator bool()			{ return true; }
 
-	static inline void processSerialEventsList() {
+	static void processSerialEventsList() {
 		for (uint8_t i = 0; i < s_count_serials_with_serial_events; i++) {
 			s_serials_with_serial_events[i]->doYieldCode();
 		}
@@ -324,7 +324,7 @@ protected:
 	static uint8_t 			s_count_serials_with_serial_events;
 	void 		(* const _serialEvent)(); 
 	void addToSerialEventsList(); 
-	inline void doYieldCode()  {
+	void doYieldCode()  {
 		if (available()) (*_serialEvent)();
 	}
 

--- a/teensy3/Print.h
+++ b/teensy3/Print.h
@@ -126,7 +126,7 @@ class Print
 	size_t printNumberHex(unsigned long n);
 	size_t printNumberBin(unsigned long n);
 	size_t printNumberAny(unsigned long n, uint8_t base);
-	inline size_t printNumber(unsigned long n, uint8_t base, uint8_t sign) __attribute__((always_inline)) {
+	size_t printNumber(unsigned long n, uint8_t base, uint8_t sign) __attribute__((always_inline)) {
 		// when "base" is a constant (pretty much always), the
 		// compiler optimizes this to a single function call.
 		if (base == 0) return write((uint8_t)n);

--- a/teensy3/SPIFIFO.h
+++ b/teensy3/SPIFIFO.h
@@ -237,7 +237,7 @@ for $i (2, 3, 5, 7) {
 class SPIFIFOclass
 {
 public:
-	inline void begin(uint8_t pin, uint32_t speed, uint32_t mode=SPI_MODE0) __attribute__((always_inline, deprecated)) {
+	void begin(uint8_t pin, uint32_t speed, uint32_t mode=SPI_MODE0) __attribute__((always_inline, deprecated)) {
 		uint32_t p, ctar = speed;
 		SIM_SCGC6 |= SIM_SCGC6_SPI0;
 
@@ -293,7 +293,7 @@ public:
 		clear();
 		SPCR.enable_pins();
 	}
-	inline void write(uint32_t b, uint32_t cont=0) __attribute__((always_inline)) {
+	void write(uint32_t b, uint32_t cont=0) __attribute__((always_inline)) {
 		uint32_t pcsbits = pcs << 16;
 		if (pcsbits) {
 			KINETISK_SPI0.PUSHR = (b & 0xFF) | pcsbits | (cont ? SPI_PUSHR_CONT : 0);
@@ -310,7 +310,7 @@ public:
 			}
 		}
 	}
-	inline void write16(uint32_t b, uint32_t cont=0) __attribute__((always_inline)) {
+	void write16(uint32_t b, uint32_t cont=0) __attribute__((always_inline)) {
 		uint32_t pcsbits = pcs << 16;
 		if (pcsbits) {
 			KINETISK_SPI0.PUSHR = (b & 0xFFFF) | (pcs << 16) |
@@ -328,11 +328,11 @@ public:
 			}
 		}
 	}
-	inline uint32_t read(void) __attribute__((always_inline)) {
+	uint32_t read(void) __attribute__((always_inline)) {
 		while ((KINETISK_SPI0.SR & (15 << 4)) == 0) ;  // TODO, could wait forever
 		return KINETISK_SPI0.POPR;
 	}
-	inline void clear(void) __attribute__((always_inline)) {
+	void clear(void) __attribute__((always_inline)) {
 		KINETISK_SPI0.MCR = SPI_MCR_MSTR | SPI_MCR_PCSIS(0x1F) | SPI_MCR_CLR_TXF | SPI_MCR_CLR_RXF;
 	}
 private:

--- a/teensy3/WString.h
+++ b/teensy3/WString.h
@@ -75,7 +75,7 @@ public:
 
 	// memory management
 	unsigned char reserve(unsigned int size);
-	inline unsigned int length(void) const {return len;}
+	unsigned int length(void) const {return len;}
 
 	// copy and move
 	String & copy(const char *cstr, unsigned int length);

--- a/teensy3/avr_emulation.h
+++ b/teensy3/avr_emulation.h
@@ -55,7 +55,7 @@
 class PORTDemulation
 {
 public:
-	inline PORTDemulation & operator = (int val) __attribute__((always_inline)) {
+	PORTDemulation & operator = (int val) __attribute__((always_inline)) {
 		digitalWriteFast(0, (val & (1<<0)));
 		if (!(CORE_PIN0_DDRREG & CORE_PIN0_BIT))
 			CORE_PIN0_CONFIG = ((val & (1<<0)) ? CONFIG_PULLUP : CONFIG_NOPULLUP);
@@ -82,7 +82,7 @@ public:
 			CORE_PIN7_CONFIG = ((val & (1<<7)) ? CONFIG_PULLUP : CONFIG_NOPULLUP);
 		return *this;
 	}
-	inline PORTDemulation & operator |= (int val) __attribute__((always_inline)) {
+	PORTDemulation & operator |= (int val) __attribute__((always_inline)) {
 		if (val & (1<<0)) {
 			digitalWriteFast(0, HIGH);
 			if (!(CORE_PIN0_DDRREG & CORE_PIN0_BIT)) CORE_PIN0_CONFIG = CONFIG_PULLUP;
@@ -117,7 +117,7 @@ public:
 		}
 		return *this;
 	}
-	inline PORTDemulation & operator &= (int val) __attribute__((always_inline)) {
+	PORTDemulation & operator &= (int val) __attribute__((always_inline)) {
 		if (!(val & (1<<0))) {
 			digitalWriteFast(0, LOW);
 			if (!(CORE_PIN0_DDRREG & CORE_PIN0_BIT)) CORE_PIN0_CONFIG = CONFIG_NOPULLUP;
@@ -158,7 +158,7 @@ extern PORTDemulation PORTD;
 class PINDemulation
 {
 public:
-	inline int operator & (int val) const __attribute__((always_inline)) {
+	int operator & (int val) const __attribute__((always_inline)) {
 		int ret = 0;
 		if ((val & (1<<0)) && digitalReadFast(0)) ret |= (1<<0);
 		if ((val & (1<<1)) && digitalReadFast(1)) ret |= (1<<1);
@@ -188,7 +188,7 @@ extern PINDemulation PIND;
 class DDRDemulation
 {
 public:
-	inline DDRDemulation & operator = (int val) __attribute__((always_inline)) {
+	DDRDemulation & operator = (int val) __attribute__((always_inline)) {
 		if (val & (1<<0)) set0(); else clr0();
 		if (val & (1<<1)) set1(); else clr1();
 		if (val & (1<<2)) set2(); else clr2();
@@ -199,7 +199,7 @@ public:
 		if (val & (1<<7)) set7(); else clr7();
 		return *this;
 	}
-	inline DDRDemulation & operator |= (int val) __attribute__((always_inline)) {
+	DDRDemulation & operator |= (int val) __attribute__((always_inline)) {
 		if (val & (1<<0)) set0();
 		if (val & (1<<1)) set1();
 		if (val & (1<<2)) set2();
@@ -210,7 +210,7 @@ public:
 		if (val & (1<<7)) set7();
 		return *this;
 	}
-	inline DDRDemulation & operator &= (int val) __attribute__((always_inline)) {
+	DDRDemulation & operator &= (int val) __attribute__((always_inline)) {
 		if (!(val & (1<<0))) clr0();
 		if (!(val & (1<<1))) clr1();
 		if (!(val & (1<<2))) clr2();
@@ -222,74 +222,74 @@ public:
 		return *this;
 	}
 private:
-	inline void set0() __attribute__((always_inline)) {
+	void set0() __attribute__((always_inline)) {
 		GPIO_SETBIT_ATOMIC(CORE_PIN0_DDRREG, CORE_PIN0_BIT);
 		CORE_PIN0_CONFIG = CONFIG_PULLUP;
 	}
-	inline void set1() __attribute__((always_inline)) {
+	void set1() __attribute__((always_inline)) {
 		GPIO_SETBIT_ATOMIC(CORE_PIN1_DDRREG, CORE_PIN1_BIT);
 		CORE_PIN1_CONFIG = CONFIG_PULLUP;
 	}
-	inline void set2() __attribute__((always_inline)) {
+	void set2() __attribute__((always_inline)) {
 		GPIO_SETBIT_ATOMIC(CORE_PIN2_DDRREG, CORE_PIN2_BIT);
 		CORE_PIN2_CONFIG = CONFIG_PULLUP;
 	}
-	inline void set3() __attribute__((always_inline)) {
+	void set3() __attribute__((always_inline)) {
 		GPIO_SETBIT_ATOMIC(CORE_PIN3_DDRREG, CORE_PIN3_BIT);
 		CORE_PIN3_CONFIG = CONFIG_PULLUP;
 	}
-	inline void set4() __attribute__((always_inline)) {
+	void set4() __attribute__((always_inline)) {
 		GPIO_SETBIT_ATOMIC(CORE_PIN4_DDRREG, CORE_PIN4_BIT);
 		CORE_PIN4_CONFIG = CONFIG_PULLUP;
 	}
-	inline void set5() __attribute__((always_inline)) {
+	void set5() __attribute__((always_inline)) {
 		GPIO_SETBIT_ATOMIC(CORE_PIN5_DDRREG, CORE_PIN5_BIT);
 		CORE_PIN5_CONFIG = CONFIG_PULLUP;
 	}
-	inline void set6() __attribute__((always_inline)) {
+	void set6() __attribute__((always_inline)) {
 		GPIO_SETBIT_ATOMIC(CORE_PIN6_DDRREG, CORE_PIN6_BIT);
 		CORE_PIN6_CONFIG = CONFIG_PULLUP;
 	}
-	inline void set7() __attribute__((always_inline)) {
+	void set7() __attribute__((always_inline)) {
 		GPIO_SETBIT_ATOMIC(CORE_PIN7_DDRREG, CORE_PIN7_BIT);
 		CORE_PIN7_CONFIG = CONFIG_PULLUP;
 	}
-	inline void clr0() __attribute__((always_inline)) {
+	void clr0() __attribute__((always_inline)) {
 		CORE_PIN0_CONFIG = ((CORE_PIN0_PORTREG & CORE_PIN0_BITMASK)
 		  ? CONFIG_PULLUP : CONFIG_NOPULLUP);
 		GPIO_CLRBIT_ATOMIC(CORE_PIN0_DDRREG, CORE_PIN0_BIT);
 	}
-	inline void clr1() __attribute__((always_inline)) {
+	void clr1() __attribute__((always_inline)) {
 		CORE_PIN1_CONFIG = ((CORE_PIN1_PORTREG & CORE_PIN1_BITMASK)
 		  ? CONFIG_PULLUP : CONFIG_NOPULLUP);
 		GPIO_CLRBIT_ATOMIC(CORE_PIN1_DDRREG, CORE_PIN1_BIT);
 	}
-	inline void clr2() __attribute__((always_inline)) {
+	void clr2() __attribute__((always_inline)) {
 		CORE_PIN2_CONFIG = ((CORE_PIN2_PORTREG & CORE_PIN2_BITMASK)
 		  ? CONFIG_PULLUP : CONFIG_NOPULLUP);
 		GPIO_CLRBIT_ATOMIC(CORE_PIN2_DDRREG, CORE_PIN2_BIT);
 	}
-	inline void clr3() __attribute__((always_inline)) {
+	void clr3() __attribute__((always_inline)) {
 		CORE_PIN3_CONFIG = ((CORE_PIN3_PORTREG & CORE_PIN3_BITMASK)
 		  ? CONFIG_PULLUP : CONFIG_NOPULLUP);
 		GPIO_CLRBIT_ATOMIC(CORE_PIN3_DDRREG, CORE_PIN3_BIT);
 	}
-	inline void clr4() __attribute__((always_inline)) {
+	void clr4() __attribute__((always_inline)) {
 		CORE_PIN4_CONFIG = ((CORE_PIN4_PORTREG & CORE_PIN4_BITMASK)
 		  ? CONFIG_PULLUP : CONFIG_NOPULLUP);
 		GPIO_CLRBIT_ATOMIC(CORE_PIN4_DDRREG, CORE_PIN4_BIT);
 	}
-	inline void clr5() __attribute__((always_inline)) {
+	void clr5() __attribute__((always_inline)) {
 		CORE_PIN5_CONFIG = ((CORE_PIN5_PORTREG & CORE_PIN5_BITMASK)
 		  ? CONFIG_PULLUP : CONFIG_NOPULLUP);
 		GPIO_CLRBIT_ATOMIC(CORE_PIN5_DDRREG, CORE_PIN5_BIT);
 	}
-	inline void clr6() __attribute__((always_inline)) {
+	void clr6() __attribute__((always_inline)) {
 		CORE_PIN6_CONFIG = ((CORE_PIN6_PORTREG & CORE_PIN6_BITMASK)
 		  ? CONFIG_PULLUP : CONFIG_NOPULLUP);
 		GPIO_CLRBIT_ATOMIC(CORE_PIN6_DDRREG, CORE_PIN6_BIT);
 	}
-	inline void clr7() __attribute__((always_inline)) {
+	void clr7() __attribute__((always_inline)) {
 		CORE_PIN7_CONFIG = ((CORE_PIN7_PORTREG & CORE_PIN7_BITMASK)
 		  ? CONFIG_PULLUP : CONFIG_NOPULLUP);
 		GPIO_CLRBIT_ATOMIC(CORE_PIN7_DDRREG, CORE_PIN7_BIT);
@@ -306,7 +306,7 @@ extern DDRDemulation DDRD;
 class PORTBemulation
 {
 public:
-	inline PORTBemulation & operator = (int val) __attribute__((always_inline)) {
+	PORTBemulation & operator = (int val) __attribute__((always_inline)) {
 		digitalWriteFast(8, (val & (1<<0)));
 		if (!(CORE_PIN8_DDRREG & CORE_PIN8_BIT))
 			CORE_PIN8_CONFIG = ((val & (1<<0)) ? CONFIG_PULLUP : CONFIG_NOPULLUP);
@@ -327,7 +327,7 @@ public:
 			CORE_PIN13_CONFIG = ((val & (1<<5)) ? CONFIG_PULLUP : CONFIG_NOPULLUP);
 		return *this;
 	}
-	inline PORTBemulation & operator |= (int val) __attribute__((always_inline)) {
+	PORTBemulation & operator |= (int val) __attribute__((always_inline)) {
 		if (val & (1<<0)) {
 			digitalWriteFast(8, HIGH);
 			if (!(CORE_PIN7_DDRREG & CORE_PIN7_BIT)) CORE_PIN8_CONFIG = CONFIG_PULLUP;
@@ -354,7 +354,7 @@ public:
 		}
 		return *this;
 	}
-	inline PORTBemulation & operator &= (int val) __attribute__((always_inline)) {
+	PORTBemulation & operator &= (int val) __attribute__((always_inline)) {
 		if (!(val & (1<<0))) {
 			digitalWriteFast(8, LOW);
 			if (!(CORE_PIN8_DDRREG & CORE_PIN8_BIT)) CORE_PIN8_CONFIG = CONFIG_NOPULLUP;
@@ -387,7 +387,7 @@ extern PORTBemulation PORTB;
 class PINBemulation
 {
 public:
-	inline int operator & (int val) const __attribute__((always_inline)) {
+	int operator & (int val) const __attribute__((always_inline)) {
 		int ret = 0;
 		if ((val & (1<<0)) && digitalReadFast(8)) ret |= (1<<0);
 		if ((val & (1<<1)) && digitalReadFast(9)) ret |= (1<<1);
@@ -413,7 +413,7 @@ extern PINBemulation PINB;
 class DDRBemulation
 {
 public:
-	inline DDRBemulation & operator = (int val) __attribute__((always_inline)) {
+	DDRBemulation & operator = (int val) __attribute__((always_inline)) {
 		if (val & (1<<0)) set0(); else clr0();
 		if (val & (1<<1)) set1(); else clr1();
 		if (val & (1<<2)) set2(); else clr2();
@@ -422,7 +422,7 @@ public:
 		if (val & (1<<5)) set5(); else clr5();
 		return *this;
 	}
-	inline DDRBemulation & operator |= (int val) __attribute__((always_inline)) {
+	DDRBemulation & operator |= (int val) __attribute__((always_inline)) {
 		if (val & (1<<0)) set0();
 		if (val & (1<<1)) set1();
 		if (val & (1<<2)) set2();
@@ -431,7 +431,7 @@ public:
 		if (val & (1<<5)) set5();
 		return *this;
 	}
-	inline DDRBemulation & operator &= (int val) __attribute__((always_inline)) {
+	DDRBemulation & operator &= (int val) __attribute__((always_inline)) {
 		if (!(val & (1<<0))) clr0();
 		if (!(val & (1<<1))) clr1();
 		if (!(val & (1<<2))) clr2();
@@ -441,56 +441,56 @@ public:
 		return *this;
 	}
 private:
-	inline void set0() __attribute__((always_inline)) {
+	void set0() __attribute__((always_inline)) {
 		GPIO_SETBIT_ATOMIC(CORE_PIN8_DDRREG, CORE_PIN8_BIT);
 		CORE_PIN8_CONFIG = CONFIG_PULLUP;
 	}
-	inline void set1() __attribute__((always_inline)) {
+	void set1() __attribute__((always_inline)) {
 		GPIO_SETBIT_ATOMIC(CORE_PIN9_DDRREG, CORE_PIN9_BIT);
 		CORE_PIN9_CONFIG = CONFIG_PULLUP;
 	}
-	inline void set2() __attribute__((always_inline)) {
+	void set2() __attribute__((always_inline)) {
 		GPIO_SETBIT_ATOMIC(CORE_PIN10_DDRREG, CORE_PIN10_BIT);
 		CORE_PIN10_CONFIG = CONFIG_PULLUP;
 	}
-	inline void set3() __attribute__((always_inline)) {
+	void set3() __attribute__((always_inline)) {
 		GPIO_SETBIT_ATOMIC(CORE_PIN11_DDRREG, CORE_PIN11_BIT);
 		CORE_PIN11_CONFIG = CONFIG_PULLUP;
 	}
-	inline void set4() __attribute__((always_inline)) {
+	void set4() __attribute__((always_inline)) {
 		GPIO_SETBIT_ATOMIC(CORE_PIN12_DDRREG, CORE_PIN12_BIT);
 		CORE_PIN12_CONFIG = CONFIG_PULLUP;
 	}
-	inline void set5() __attribute__((always_inline)) {
+	void set5() __attribute__((always_inline)) {
 		GPIO_SETBIT_ATOMIC(CORE_PIN13_DDRREG, CORE_PIN13_BIT);
 		CORE_PIN13_CONFIG = CONFIG_PULLUP;
 	}
-	inline void clr0() __attribute__((always_inline)) {
+	void clr0() __attribute__((always_inline)) {
 		CORE_PIN8_CONFIG = ((CORE_PIN8_PORTREG & CORE_PIN8_BITMASK)
 		  ? CONFIG_PULLUP : CONFIG_NOPULLUP);
 		GPIO_CLRBIT_ATOMIC(CORE_PIN8_DDRREG, CORE_PIN8_BIT);
 	}
-	inline void clr1() __attribute__((always_inline)) {
+	void clr1() __attribute__((always_inline)) {
 		CORE_PIN9_CONFIG = ((CORE_PIN9_PORTREG & CORE_PIN9_BITMASK)
 		  ? CONFIG_PULLUP : CONFIG_NOPULLUP);
 		GPIO_CLRBIT_ATOMIC(CORE_PIN9_DDRREG, CORE_PIN9_BIT);
 	}
-	inline void clr2() __attribute__((always_inline)) {
+	void clr2() __attribute__((always_inline)) {
 		CORE_PIN10_CONFIG = ((CORE_PIN10_PORTREG & CORE_PIN10_BITMASK)
 		  ? CONFIG_PULLUP : CONFIG_NOPULLUP);
 		GPIO_CLRBIT_ATOMIC(CORE_PIN10_DDRREG, CORE_PIN10_BIT);
 	}
-	inline void clr3() __attribute__((always_inline)) {
+	void clr3() __attribute__((always_inline)) {
 		CORE_PIN11_CONFIG = ((CORE_PIN11_PORTREG & CORE_PIN11_BITMASK)
 		  ? CONFIG_PULLUP : CONFIG_NOPULLUP);
 		GPIO_CLRBIT_ATOMIC(CORE_PIN11_DDRREG, CORE_PIN11_BIT);
 	}
-	inline void clr4() __attribute__((always_inline)) {
+	void clr4() __attribute__((always_inline)) {
 		CORE_PIN12_CONFIG = ((CORE_PIN12_PORTREG & CORE_PIN12_BITMASK)
 		  ? CONFIG_PULLUP : CONFIG_NOPULLUP);
 		GPIO_CLRBIT_ATOMIC(CORE_PIN12_DDRREG, CORE_PIN12_BIT);
 	}
-	inline void clr5() __attribute__((always_inline)) {
+	void clr5() __attribute__((always_inline)) {
 		CORE_PIN13_CONFIG = ((CORE_PIN13_PORTREG & CORE_PIN13_BITMASK)
 		  ? CONFIG_PULLUP : CONFIG_NOPULLUP);
 		GPIO_CLRBIT_ATOMIC(CORE_PIN13_DDRREG, CORE_PIN13_BIT);
@@ -507,7 +507,7 @@ extern DDRBemulation DDRB;
 class PORTCemulation
 {
 public:
-	inline PORTCemulation & operator = (int val) __attribute__((always_inline)) {
+	PORTCemulation & operator = (int val) __attribute__((always_inline)) {
 		digitalWriteFast(14, (val & (1<<0)));
 		if (!(CORE_PIN14_DDRREG & CORE_PIN14_BIT))
 			CORE_PIN14_CONFIG = ((val & (1<<0)) ? CONFIG_PULLUP : CONFIG_NOPULLUP);
@@ -528,7 +528,7 @@ public:
 			CORE_PIN19_CONFIG = ((val & (1<<5)) ? CONFIG_PULLUP : CONFIG_NOPULLUP);
 		return *this;
 	}
-	inline PORTCemulation & operator |= (int val) __attribute__((always_inline)) {
+	PORTCemulation & operator |= (int val) __attribute__((always_inline)) {
 		if (val & (1<<0)) {
 			digitalWriteFast(14, HIGH);
 			if (!(CORE_PIN14_DDRREG & CORE_PIN14_BIT)) CORE_PIN14_CONFIG = CONFIG_PULLUP;
@@ -555,7 +555,7 @@ public:
 		}
 		return *this;
 	}
-	inline PORTCemulation & operator &= (int val) __attribute__((always_inline)) {
+	PORTCemulation & operator &= (int val) __attribute__((always_inline)) {
 		if (!(val & (1<<0))) {
 			digitalWriteFast(14, LOW);
 			if (!(CORE_PIN14_DDRREG & CORE_PIN14_BIT)) CORE_PIN14_CONFIG = CONFIG_NOPULLUP;
@@ -588,7 +588,7 @@ extern PORTCemulation PORTC;
 class PINCemulation
 {
 public:
-	inline int operator & (int val) const __attribute__((always_inline)) {
+	int operator & (int val) const __attribute__((always_inline)) {
 		int ret = 0;
 		if ((val & (1<<0)) && digitalReadFast(14)) ret |= (1<<0);
 		if ((val & (1<<1)) && digitalReadFast(15)) ret |= (1<<1);
@@ -614,7 +614,7 @@ extern PINCemulation PINC;
 class DDRCemulation
 {
 public:
-	inline DDRCemulation & operator = (int val) __attribute__((always_inline)) {
+	DDRCemulation & operator = (int val) __attribute__((always_inline)) {
 		if (val & (1<<0)) set0(); else clr0();
 		if (val & (1<<1)) set1(); else clr1();
 		if (val & (1<<2)) set2(); else clr2();
@@ -623,7 +623,7 @@ public:
 		if (val & (1<<5)) set5(); else clr5();
 		return *this;
 	}
-	inline DDRCemulation & operator |= (int val) __attribute__((always_inline)) {
+	DDRCemulation & operator |= (int val) __attribute__((always_inline)) {
 		if (val & (1<<0)) set0();
 		if (val & (1<<1)) set1();
 		if (val & (1<<2)) set2();
@@ -632,7 +632,7 @@ public:
 		if (val & (1<<5)) set5();
 		return *this;
 	}
-	inline DDRCemulation & operator &= (int val) __attribute__((always_inline)) {
+	DDRCemulation & operator &= (int val) __attribute__((always_inline)) {
 		if (!(val & (1<<0))) clr0();
 		if (!(val & (1<<1))) clr1();
 		if (!(val & (1<<2))) clr2();
@@ -642,56 +642,56 @@ public:
 		return *this;
 	}
 private:
-	inline void set0() __attribute__((always_inline)) {
+	void set0() __attribute__((always_inline)) {
 		GPIO_SETBIT_ATOMIC(CORE_PIN14_DDRREG, CORE_PIN14_BIT);
 		CORE_PIN14_CONFIG = CONFIG_PULLUP;
 	}
-	inline void set1() __attribute__((always_inline)) {
+	void set1() __attribute__((always_inline)) {
 		GPIO_SETBIT_ATOMIC(CORE_PIN15_DDRREG, CORE_PIN15_BIT);
 		CORE_PIN15_CONFIG = CONFIG_PULLUP;
 	}
-	inline void set2() __attribute__((always_inline)) {
+	void set2() __attribute__((always_inline)) {
 		GPIO_SETBIT_ATOMIC(CORE_PIN16_DDRREG, CORE_PIN16_BIT);
 		CORE_PIN16_CONFIG = CONFIG_PULLUP;
 	}
-	inline void set3() __attribute__((always_inline)) {
+	void set3() __attribute__((always_inline)) {
 		GPIO_SETBIT_ATOMIC(CORE_PIN17_DDRREG, CORE_PIN17_BIT);
 		CORE_PIN17_CONFIG = CONFIG_PULLUP;
 	}
-	inline void set4() __attribute__((always_inline)) {
+	void set4() __attribute__((always_inline)) {
 		GPIO_SETBIT_ATOMIC(CORE_PIN18_DDRREG, CORE_PIN18_BIT);
 		CORE_PIN18_CONFIG = CONFIG_PULLUP;
 	}
-	inline void set5() __attribute__((always_inline)) {
+	void set5() __attribute__((always_inline)) {
 		GPIO_SETBIT_ATOMIC(CORE_PIN19_DDRREG, CORE_PIN19_BIT);
 		CORE_PIN19_CONFIG = CONFIG_PULLUP;
 	}
-	inline void clr0() __attribute__((always_inline)) {
+	void clr0() __attribute__((always_inline)) {
 		CORE_PIN14_CONFIG = ((CORE_PIN14_PORTREG & CORE_PIN14_BITMASK)
 		  ? CONFIG_PULLUP : CONFIG_NOPULLUP);
 		GPIO_CLRBIT_ATOMIC(CORE_PIN14_DDRREG, CORE_PIN14_BIT);
 	}
-	inline void clr1() __attribute__((always_inline)) {
+	void clr1() __attribute__((always_inline)) {
 		CORE_PIN15_CONFIG = ((CORE_PIN15_PORTREG & CORE_PIN15_BITMASK)
 		  ? CONFIG_PULLUP : CONFIG_NOPULLUP);
 		GPIO_CLRBIT_ATOMIC(CORE_PIN15_DDRREG, CORE_PIN15_BIT);
 	}
-	inline void clr2() __attribute__((always_inline)) {
+	void clr2() __attribute__((always_inline)) {
 		CORE_PIN16_CONFIG = ((CORE_PIN16_PORTREG & CORE_PIN16_BITMASK)
 		  ? CONFIG_PULLUP : CONFIG_NOPULLUP);
 		GPIO_CLRBIT_ATOMIC(CORE_PIN16_DDRREG, CORE_PIN16_BIT);
 	}
-	inline void clr3() __attribute__((always_inline)) {
+	void clr3() __attribute__((always_inline)) {
 		CORE_PIN17_CONFIG = ((CORE_PIN17_PORTREG & CORE_PIN17_BITMASK)
 		  ? CONFIG_PULLUP : CONFIG_NOPULLUP);
 		GPIO_CLRBIT_ATOMIC(CORE_PIN17_DDRREG, CORE_PIN17_BIT);
 	}
-	inline void clr4() __attribute__((always_inline)) {
+	void clr4() __attribute__((always_inline)) {
 		CORE_PIN18_CONFIG = ((CORE_PIN18_PORTREG & CORE_PIN18_BITMASK)
 		  ? CONFIG_PULLUP : CONFIG_NOPULLUP);
 		GPIO_CLRBIT_ATOMIC(CORE_PIN18_DDRREG, CORE_PIN18_BIT);
 	}
-	inline void clr5() __attribute__((always_inline)) {
+	void clr5() __attribute__((always_inline)) {
 		CORE_PIN19_CONFIG = ((CORE_PIN19_PORTREG & CORE_PIN19_BITMASK)
 		  ? CONFIG_PULLUP : CONFIG_NOPULLUP);
 		GPIO_CLRBIT_ATOMIC(CORE_PIN19_DDRREG, CORE_PIN19_BIT);
@@ -810,7 +810,7 @@ class SPDRemulation;
 class SPCRemulation
 {
 public:
-	inline SPCRemulation & operator = (int val) __attribute__((always_inline)) {
+	SPCRemulation & operator = (int val) __attribute__((always_inline)) {
 		uint32_t ctar, mcr, sim6;
 		//serial_print("SPCR=");
 		//serial_phex(val);
@@ -869,7 +869,7 @@ public:
 		//serial_print("\n");
 		return *this;
 	}
-	inline SPCRemulation & operator |= (int val) __attribute__((always_inline)) {
+	SPCRemulation & operator |= (int val) __attribute__((always_inline)) {
 		uint32_t sim6;
 		//serial_print("SPCR |= ");
 		//serial_phex(val);
@@ -924,7 +924,7 @@ public:
 		//serial_print("\n");
 		return *this;
 	}
-	inline SPCRemulation & operator &= (int val) __attribute__((always_inline)) {
+	SPCRemulation & operator &= (int val) __attribute__((always_inline)) {
 		//serial_print("SPCR &= ");
 		//serial_phex(val);
 		//serial_print("\n");
@@ -968,7 +968,7 @@ public:
 		if (!(val & (1<<MSTR))) SPI0_MCR &= ~SPI_MCR_MSTR;
 		return *this;
 	}
-	inline int operator & (int val) const __attribute__((always_inline)) {
+	int operator & (int val) const __attribute__((always_inline)) {
 		int ret = 0;
 		//serial_print("SPCR & ");
 		//serial_phex(val);
@@ -1020,7 +1020,7 @@ public:
 		}
 		return ret;
 	}
-	inline void setMOSI(uint8_t pin) __attribute__((always_inline)) {
+	void setMOSI(uint8_t pin) __attribute__((always_inline)) {
 #if defined(__MK64FX512__) || defined(__MK66FX1M0__)
 		uint8_t newpinout = pinout;
 		// More than two options so now 2 bits
@@ -1057,7 +1057,7 @@ public:
 		pinout = newpinout;
 #endif
 	}
-	inline void setMOSI_soft(uint8_t pin) __attribute__((always_inline)) {
+	void setMOSI_soft(uint8_t pin) __attribute__((always_inline)) {
 #if defined(__MK64FX512__) || defined(__MK66FX1M0__)
 		if (pin == 11) pinout &= ~3;
 		if (pin == 7)  pinout = (pinout & ~0x3) | 1;
@@ -1067,7 +1067,7 @@ public:
 		if (pin == 7)  pinout |= 1;
 #endif
 	}
-	inline void setMISO(uint8_t pin) __attribute__((always_inline)) {
+	void setMISO(uint8_t pin) __attribute__((always_inline)) {
 #if defined(__MK64FX512__) || defined(__MK66FX1M0__)
 		uint8_t newpinout = pinout;
 		// More than two options so now 2 bits
@@ -1104,7 +1104,7 @@ public:
 		pinout = newpinout;
 #endif
 	}
-	inline void setMISO_soft(uint8_t pin) __attribute__((always_inline)) {
+	void setMISO_soft(uint8_t pin) __attribute__((always_inline)) {
 #if defined(__MK64FX512__) || defined(__MK66FX1M0__)
 		if (pin == 12) pinout &= ~0xc;
 		if (pin == 8)  pinout = (pinout & ~0xc) | 4;
@@ -1114,7 +1114,7 @@ public:
 		if (pin == 8)  pinout |= 2;
 #endif
 	}
-	inline void setSCK(uint8_t pin) __attribute__((always_inline)) {
+	void setSCK(uint8_t pin) __attribute__((always_inline)) {
 #if defined(__MK64FX512__) || defined(__MK66FX1M0__)
 		uint8_t newpinout = pinout;
 		// More than two options so now 2 bits
@@ -1151,7 +1151,7 @@ public:
 		pinout = newpinout;
 #endif
 	}
-	inline void setSCK_soft(uint8_t pin) __attribute__((always_inline)) {
+	void setSCK_soft(uint8_t pin) __attribute__((always_inline)) {
 #if defined(__MK64FX512__) || defined(__MK66FX1M0__)
 		if (pin == 13) pinout &= ~0x30;
 		if (pin == 14) pinout = (pinout & ~0x30) | 0x10;
@@ -1164,7 +1164,7 @@ public:
 	friend class SPSRemulation;
 	friend class SPIFIFOclass;
 private:
-	static inline void update_ctar(uint32_t ctar) __attribute__((always_inline)) {
+	static void update_ctar(uint32_t ctar) __attribute__((always_inline)) {
 		if (SPI0_CTAR0 == ctar) return;
 		uint32_t mcr = SPI0_MCR;
 		if (mcr & SPI_MCR_MDIS) {
@@ -1177,7 +1177,7 @@ private:
 	}
 	static uint8_t pinout;
 public:
-	inline void enable_pins(void) __attribute__((always_inline)) {
+	void enable_pins(void) __attribute__((always_inline)) {
 		//serial_print("enable_pins\n");
 #if defined(__MK64FX512__) || defined(__MK66FX1M0__)
 		switch (pinout & 3) {
@@ -1213,7 +1213,7 @@ public:
 		}
 #endif
 	}
-	inline void disable_pins(void) __attribute__((always_inline)) {
+	void disable_pins(void) __attribute__((always_inline)) {
 #if defined(__MK64FX512__) || defined(__MK66FX1M0__)
 		switch (pinout & 3) {
 			case 0: CORE_PIN11_CONFIG = PORT_PCR_SRE | PORT_PCR_DSE | PORT_PCR_MUX(1); break;
@@ -1257,7 +1257,7 @@ extern SPCRemulation SPCR;
 class SPCR1emulation
 {
 public:
-	inline SPCR1emulation & operator = (int val) __attribute__((always_inline)) {
+	SPCR1emulation & operator = (int val) __attribute__((always_inline)) {
 		uint32_t ctar, mcr, sim6;
 		//serial_print("SPCR=");
 		//serial_phex(val);
@@ -1316,7 +1316,7 @@ public:
 		//serial_print("\n");
 		return *this;
 	}
-	inline SPCR1emulation & operator |= (int val) __attribute__((always_inline)) {
+	SPCR1emulation & operator |= (int val) __attribute__((always_inline)) {
 		uint32_t sim6;
 		//serial_print("SPCR |= ");
 		//serial_phex(val);
@@ -1356,7 +1356,7 @@ public:
 		//serial_print("\n");
 		return *this;
 	}
-	inline SPCR1emulation & operator &= (int val) __attribute__((always_inline)) {
+	SPCR1emulation & operator &= (int val) __attribute__((always_inline)) {
 		//serial_print("SPCR &= ");
 		//serial_phex(val);
 		//serial_print("\n");
@@ -1385,7 +1385,7 @@ public:
 		if (!(val & (1<<MSTR))) SPI1_MCR &= ~SPI_MCR_MSTR;
 		return *this;
 	}
-	inline int operator & (int val) const __attribute__((always_inline)) {
+	int operator & (int val) const __attribute__((always_inline)) {
 		int ret = 0;
 		//serial_print("SPCR & ");
 		//serial_phex(val);
@@ -1422,7 +1422,7 @@ public:
 		//serial_print("\n");
 		return ret;
 	}
-	inline void setMOSI(uint8_t pin) __attribute__((always_inline)) {
+	void setMOSI(uint8_t pin) __attribute__((always_inline)) {
 		// More options, so 2 bits
 		pinout &= ~3;
 		switch (pin) {
@@ -1432,7 +1432,7 @@ public:
 			case 59: pinout |= 3; break;
 		}
 	}
-	inline void setMISO(uint8_t pin) __attribute__((always_inline)) {
+	void setMISO(uint8_t pin) __attribute__((always_inline)) {
 		// More options, so 2 bits
 		pinout &= ~0xc;
 		switch (pin) {
@@ -1442,7 +1442,7 @@ public:
 			case 59: pinout |= 0xc; break;
 		}
 	}
-	inline void setSCK(uint8_t pin) __attribute__((always_inline)) {
+	void setSCK(uint8_t pin) __attribute__((always_inline)) {
 		// More options, so 2 bits
 		pinout &= ~0x30;
 		switch (pin) {
@@ -1451,7 +1451,7 @@ public:
 			case 60: pinout |= 0x20; break;
 		}
 	}
-	inline void enable_pins(void) __attribute__((always_inline)) {
+	void enable_pins(void) __attribute__((always_inline)) {
 		//serial_print("enable_pins\n");
 		// MOSI (SOUT)
 		switch (pinout & 0x3) {
@@ -1474,7 +1474,7 @@ public:
 			case 0x20: CORE_PIN60_CONFIG = PORT_PCR_MUX(2); break;
 		}
 	}
-	inline void disable_pins(void) __attribute__((always_inline)) {
+	void disable_pins(void) __attribute__((always_inline)) {
 		switch (pinout & 0x3) {
 			case 0: CORE_PIN0_CONFIG = PORT_PCR_SRE | PORT_PCR_MUX(1); break;
 			case 1: CORE_PIN21_CONFIG = PORT_PCR_SRE | PORT_PCR_MUX(1); break;
@@ -1496,7 +1496,7 @@ public:
 	friend class SPIFIFO1class;
 private:
 	static uint8_t pinout;
-	static inline void update_ctar(uint32_t ctar) __attribute__((always_inline)) {
+	static void update_ctar(uint32_t ctar) __attribute__((always_inline)) {
 		if (SPI1_CTAR0 == ctar) return;
 		uint32_t mcr = SPI1_MCR;
 		if (mcr & SPI_MCR_MDIS) {
@@ -1515,7 +1515,7 @@ extern SPCR1emulation SPCR1;
 class SPCR2emulation
 {
 public:
-	inline SPCR2emulation & operator = (int val) __attribute__((always_inline)) {
+	SPCR2emulation & operator = (int val) __attribute__((always_inline)) {
 		uint32_t ctar, mcr, sim3;
 		//serial_print("SPCR=");
 		//serial_phex(val);
@@ -1574,7 +1574,7 @@ public:
 		//serial_print("\n");
 		return *this;
 	}
-	inline SPCR2emulation & operator |= (int val) __attribute__((always_inline)) {
+	SPCR2emulation & operator |= (int val) __attribute__((always_inline)) {
 		uint32_t sim3;
 		//serial_print("SPCR |= ");
 		//serial_phex(val);
@@ -1614,7 +1614,7 @@ public:
 		//serial_print("\n");
 		return *this;
 	}
-	inline SPCR2emulation & operator &= (int val) __attribute__((always_inline)) {
+	SPCR2emulation & operator &= (int val) __attribute__((always_inline)) {
 		//serial_print("SPCR &= ");
 		//serial_phex(val);
 		//serial_print("\n");
@@ -1643,7 +1643,7 @@ public:
 		if (!(val & (1<<MSTR))) SPI2_MCR &= ~SPI_MCR_MSTR;
 		return *this;
 	}
-	inline int operator & (int val) const __attribute__((always_inline)) {
+	int operator & (int val) const __attribute__((always_inline)) {
 		int ret = 0;
 		//serial_print("SPCR & ");
 		//serial_phex(val);
@@ -1680,19 +1680,19 @@ public:
 		//serial_print("\n");
 		return ret;
 	}
-	inline void setMOSI(uint8_t pin) __attribute__((always_inline)) {
+	void setMOSI(uint8_t pin) __attribute__((always_inline)) {
 		if (pin == 44) pinout &= ~1; 
 		if (pin == 52) pinout |= 1; 
 	}
-	inline void setMISO(uint8_t pin) __attribute__((always_inline)) {
+	void setMISO(uint8_t pin) __attribute__((always_inline)) {
 		if (pin == 45) pinout &= ~2; 
 		if (pin == 51) pinout |= 2; 
 	}
-	inline void setSCK(uint8_t pin) __attribute__((always_inline)) {
+	void setSCK(uint8_t pin) __attribute__((always_inline)) {
 		if (pin == 46) pinout &= ~4; 
 		if (pin == 53) pinout |= 4; 
 	}
-	inline void enable_pins(void) __attribute__((always_inline)) {
+	void enable_pins(void) __attribute__((always_inline)) {
 		//serial_print("enable_pins\n");
 		if ((pinout & 1) == 0) {
 			CORE_PIN44_CONFIG = PORT_PCR_MUX(2);
@@ -1710,7 +1710,7 @@ public:
 			CORE_PIN53_CONFIG = PORT_PCR_MUX(2); 
 		}
 	}
-	inline void disable_pins(void) __attribute__((always_inline)) {
+	void disable_pins(void) __attribute__((always_inline)) {
 		//serial_print("disable_pins\n");
 		if ((pinout & 1) == 0) {
 			CORE_PIN44_CONFIG = PORT_PCR_SRE | PORT_PCR_MUX(1);
@@ -1731,7 +1731,7 @@ public:
 	friend class SPIFIFO1class;
 private:
 	static uint8_t pinout;
-	static inline void update_ctar(uint32_t ctar) __attribute__((always_inline)) {
+	static void update_ctar(uint32_t ctar) __attribute__((always_inline)) {
 		if (SPI2_CTAR0 == ctar) return;
 		uint32_t mcr = SPI2_MCR;
 		if (mcr & SPI_MCR_MDIS) {
@@ -1752,7 +1752,7 @@ extern SPCR2emulation SPCR2;
 class SPSRemulation
 {
 public:
-	inline SPSRemulation & operator = (int val) __attribute__((always_inline)) {
+	SPSRemulation & operator = (int val) __attribute__((always_inline)) {
 		//serial_print("SPSR=");
 		//serial_phex(val);
 		//serial_print("\n");
@@ -1770,21 +1770,21 @@ public:
 		//serial_print("\n");
 		return *this;
 	}
-	inline SPSRemulation & operator |= (int val) __attribute__((always_inline)) {
+	SPSRemulation & operator |= (int val) __attribute__((always_inline)) {
 		//serial_print("SPSR |= ");
 		//serial_phex(val);
 		//serial_print("\n");
 		if (val & (1<<SPI2X)) SPCRemulation::update_ctar(SPI0_CTAR0 |= SPI_CTAR_DBR);
 		return *this;
 	}
-	inline SPSRemulation & operator &= (int val) __attribute__((always_inline)) {
+	SPSRemulation & operator &= (int val) __attribute__((always_inline)) {
 		//serial_print("SPSR &= ");
 		//serial_phex(val);
 		//serial_print("\n");
 		if (!(val & (1<<SPI2X))) SPCRemulation::update_ctar(SPI0_CTAR0 &= ~SPI_CTAR_DBR);
 		return *this;
 	}
-	inline int operator & (int val) const __attribute__((always_inline)) {
+	int operator & (int val) const __attribute__((always_inline)) {
 		int ret = 0;
 		//serial_print("SPSR & ");
 		//serial_phex(val);
@@ -1815,7 +1815,7 @@ extern SPSRemulation SPSR;
 class SPDRemulation
 {
 public:
-	inline SPDRemulation & operator = (int val) __attribute__((always_inline)) {
+	SPDRemulation & operator = (int val) __attribute__((always_inline)) {
 		//serial_print("SPDR = ");
 		//serial_phex(val);
 		//serial_print("\n");
@@ -1862,7 +1862,7 @@ extern SPDRemulation SPDR;
 class SPCRemulation
 {
 public:
-	inline SPCRemulation & operator = (int val) __attribute__((always_inline)) {
+	SPCRemulation & operator = (int val) __attribute__((always_inline)) {
 		uint32_t sim4 = SIM_SCGC4;
 		if (!(sim4 & SIM_SCGC4_SPI0)) {
 			SIM_SCGC4 = sim4 | SIM_SCGC4_SPI0;
@@ -1887,7 +1887,7 @@ public:
 		else disable_pins();
 		return *this;
 	}
-	inline SPCRemulation & operator |= (int val) __attribute__((always_inline)) {
+	SPCRemulation & operator |= (int val) __attribute__((always_inline)) {
 		uint32_t sim4 = SIM_SCGC4;
 		if (!(sim4 & SIM_SCGC4_SPI0)) {
 			SIM_SCGC4 = sim4 | SIM_SCGC4_SPI0;
@@ -1918,7 +1918,7 @@ public:
 		}
 		return *this;
 	}
-	inline SPCRemulation & operator &= (int val) __attribute__((always_inline)) {
+	SPCRemulation & operator &= (int val) __attribute__((always_inline)) {
 		uint32_t sim4 = SIM_SCGC4;
 		if (!(sim4 & SIM_SCGC4_SPI0)) {
 			SIM_SCGC4 = sim4 | SIM_SCGC4_SPI0;
@@ -1949,7 +1949,7 @@ public:
 		}
 		return *this;
 	}
-	inline int operator & (int val) const __attribute__((always_inline)) {
+	int operator & (int val) const __attribute__((always_inline)) {
 		int ret = 0;
 		uint32_t sim4 = SIM_SCGC4;
 		if (!(sim4 & SIM_SCGC4_SPI0)) {
@@ -1983,7 +1983,7 @@ public:
 		ret |= baud2avr(SPI0_BR);
 		return ret;
 	}
-	inline void setMOSI(uint8_t pin) __attribute__((always_inline)) {
+	void setMOSI(uint8_t pin) __attribute__((always_inline)) {
 		uint8_t newpinout = pinout;
 		if (pin == 11) newpinout &= ~1;
 		if (pin == 7) newpinout |= 1;
@@ -1998,7 +1998,7 @@ public:
 		}
 		pinout = newpinout;
 	}
-	inline void setMISO(uint8_t pin) __attribute__((always_inline)) {
+	void setMISO(uint8_t pin) __attribute__((always_inline)) {
 		uint8_t newpinout = pinout;
 		if (pin == 12) newpinout &= ~2;
 		if (pin == 8) newpinout |= 2;
@@ -2013,7 +2013,7 @@ public:
 		}
 		pinout = newpinout;
 	}
-	inline void setSCK(uint8_t pin) __attribute__((always_inline)) {
+	void setSCK(uint8_t pin) __attribute__((always_inline)) {
 		uint8_t newpinout = pinout;
 		if (pin == 13) newpinout &= ~4;
 		if (pin == 14) newpinout |= 4;
@@ -2031,7 +2031,7 @@ public:
 	friend class SPSRemulation;
 	friend class SPIFIFOclass;
 private:
-	static inline uint32_t baud2avr(uint32_t br) __attribute__((always_inline)) {
+	static uint32_t baud2avr(uint32_t br) __attribute__((always_inline)) {
 		br &= 15;
 		if (br == 0) return 0;
 		if (br <= 2) return 1;
@@ -2040,7 +2040,7 @@ private:
 	}
 	static uint8_t pinout;
 public:
-	inline void enable_pins(void) __attribute__((always_inline)) {
+	void enable_pins(void) __attribute__((always_inline)) {
 		//serial_print("enable_pins\n");
 		if ((pinout & 1) == 0) {
 			CORE_PIN11_CONFIG = PORT_PCR_DSE | PORT_PCR_MUX(2); // MOSI0 = 11 (PTC6)
@@ -2058,7 +2058,7 @@ public:
 			CORE_PIN14_CONFIG = PORT_PCR_MUX(2); // SCK0 = 14 (PTD1)
 		}
 	}
-	inline void disable_pins(void) __attribute__((always_inline)) {
+	void disable_pins(void) __attribute__((always_inline)) {
 		//serial_print("disable_pins\n");
 		if ((pinout & 1) == 0) {
 			CORE_PIN11_CONFIG = PORT_PCR_SRE | PORT_PCR_MUX(1);
@@ -2083,18 +2083,18 @@ extern SPCRemulation SPCR;
 class SPCR1emulation
 {
 public:
-	inline void setMOSI(uint8_t pin) __attribute__((always_inline)) {
+	void setMOSI(uint8_t pin) __attribute__((always_inline)) {
 		if (pin == 0) pinout &= ~1; // MOSI1 = 0  (PTB16)
 		if (pin == 21) pinout |= 1; // MOSI1 = 21 (PTD6)
 	}
-	inline void setMISO(uint8_t pin) __attribute__((always_inline)) {
+	void setMISO(uint8_t pin) __attribute__((always_inline)) {
 		if (pin == 1) pinout &= ~2; // MISO1 = 1  (PTB17)
 		if (pin == 5) pinout |= 2;  // MISO1 = 5  (PTD7)
 	}
-	inline void setSCK(uint8_t pin) __attribute__((always_inline)) {
+	void setSCK(uint8_t pin) __attribute__((always_inline)) {
 		// SCK1 = 20 (PTD5) - no alternative pin
 	}
-	inline void enable_pins(void) __attribute__((always_inline)) {
+	void enable_pins(void) __attribute__((always_inline)) {
 		//serial_print("enable_pins\n");
 		if ((pinout & 1) == 0) {
 			CORE_PIN0_CONFIG = PORT_PCR_MUX(2);  // MOSI1 = 0  (PTB16)
@@ -2108,7 +2108,7 @@ public:
 		}
 		CORE_PIN20_CONFIG = PORT_PCR_MUX(2); // SCK1 = 20 (PTD5)
 	}
-	inline void disable_pins(void) __attribute__((always_inline)) {
+	void disable_pins(void) __attribute__((always_inline)) {
 		//serial_print("disable_pins\n");
 		if ((pinout & 1) == 0) {
 			CORE_PIN0_CONFIG = PORT_PCR_SRE | PORT_PCR_MUX(1);
@@ -2132,7 +2132,7 @@ extern SPCR1emulation SPCR1;
 class SPSRemulation
 {
 public:
-	inline SPSRemulation & operator = (int val) __attribute__((always_inline)) {
+	SPSRemulation & operator = (int val) __attribute__((always_inline)) {
 		if (val & (1<<SPI2X)) {
 			SPI0_BR &= ~0x10;
 		} else {
@@ -2140,15 +2140,15 @@ public:
 		}
 		return *this;
 	}
-	inline SPSRemulation & operator |= (int val) __attribute__((always_inline)) {
+	SPSRemulation & operator |= (int val) __attribute__((always_inline)) {
 		if (val & (1<<SPI2X)) SPI0_BR &= ~0x10;
 		return *this;
 	}
-	inline SPSRemulation & operator &= (int val) __attribute__((always_inline)) {
+	SPSRemulation & operator &= (int val) __attribute__((always_inline)) {
 		if (!(val & (1<<SPI2X))) SPI0_BR |= 0x10;
 		return *this;
 	}
-	inline int operator & (int val) const __attribute__((always_inline)) {
+	int operator & (int val) const __attribute__((always_inline)) {
 		int ret = 0;
 		if ((val & (1<<SPIF)) && (SPI0_S & SPI_S_SPRF)) ret = (1<<SPIF);
 		if ((val & (1<<SPI2X)) && (!(SPI0_BR & 0x10))) ret |= (1<<SPI2X);
@@ -2167,7 +2167,7 @@ extern SPSRemulation SPSR;
 class SPDRemulation
 {
 public:
-	inline SPDRemulation & operator = (int val) __attribute__((always_inline)) {
+	SPDRemulation & operator = (int val) __attribute__((always_inline)) {
 		if ((SPI0_S & SPI_S_SPTEF)) {
 			uint32_t tmp __attribute__((unused)) = SPI0_DL;
 		}
@@ -2199,7 +2199,7 @@ public:
 		if (primask) return 0;
 		return (1<<7);
 	}
-	inline SREGemulation & operator = (int val) __attribute__((always_inline)) {
+	SREGemulation & operator = (int val) __attribute__((always_inline)) {
 		if (val & (1<<7)) {
 			__enable_irq();
 		} else {
@@ -2244,7 +2244,7 @@ public:
 		if (icer[IRQ_PORTE >> 5] & (1 << (IRQ_PORTE & 31))) mask |= EIMSK_pE;
 		return mask;
 	}
-	inline EIMSKemulation & operator |= (int val) __attribute__((always_inline)) {
+	EIMSKemulation & operator |= (int val) __attribute__((always_inline)) {
 		if (val & EIMSK_pA) NVIC_ENABLE_IRQ(IRQ_PORTA);
 		if (val & EIMSK_pB) NVIC_ENABLE_IRQ(IRQ_PORTB);
 		if (val & EIMSK_pC) NVIC_ENABLE_IRQ(IRQ_PORTC);
@@ -2252,7 +2252,7 @@ public:
 		if (val & EIMSK_pE) NVIC_ENABLE_IRQ(IRQ_PORTE);
 		return *this;
 	}
-	inline EIMSKemulation & operator &= (int val) __attribute__((always_inline)) {
+	EIMSKemulation & operator &= (int val) __attribute__((always_inline)) {
 		uint32_t n = val;
 		if ((n | ~EIMSK_pA) != 0xFFFFFFFF) NVIC_DISABLE_IRQ(IRQ_PORTA);
 		if ((n | ~EIMSK_pB) != 0xFFFFFFFF) NVIC_DISABLE_IRQ(IRQ_PORTB);
@@ -2280,12 +2280,12 @@ public:
 		if (icer[IRQ_PORTCD >> 5] & (1 << (IRQ_PORTCD & 31))) mask |= (EIMSK_pC | EIMSK_pD);
 		return mask;
 	}
-	inline EIMSKemulation & operator |= (int val) __attribute__((always_inline)) {
+	EIMSKemulation & operator |= (int val) __attribute__((always_inline)) {
 		if (val & EIMSK_pA) NVIC_ENABLE_IRQ(IRQ_PORTA);
 		if (val & (EIMSK_pC | EIMSK_pD)) NVIC_ENABLE_IRQ(IRQ_PORTCD);
 		return *this;
 	}
-	inline EIMSKemulation & operator &= (int val) __attribute__((always_inline)) {
+	EIMSKemulation & operator &= (int val) __attribute__((always_inline)) {
 		uint32_t n = val;
 		if ((n | ~EIMSK_pA) != 0xFFFFFFFF) NVIC_DISABLE_IRQ(IRQ_PORTA);
 		if ((n | ~(EIMSK_pC | EIMSK_pD)) != 0xFFFFFFFF) NVIC_DISABLE_IRQ(IRQ_PORTCD);

--- a/teensy3/avr_functions.h
+++ b/teensy3/avr_functions.h
@@ -35,6 +35,11 @@
 
 #ifdef __cplusplus
 extern "C" {
+// C++ compilers shouldn't use 'static inline' because then there may be more
+// than one copy of the function; 'static' implies internal linkage
+#define STATIC_INLINE inline
+#else
+#define STATIC_INLINE static inline
 #endif
 
 void eeprom_initialize(void);
@@ -49,44 +54,44 @@ void eeprom_write_block(const void *buf, void *addr, uint32_t len);
 int eeprom_is_ready(void);
 #define eeprom_busy_wait() do {} while (!eeprom_is_ready())
 
-static inline float eeprom_read_float(const float *addr) __attribute__((pure, always_inline, unused));
-static inline float eeprom_read_float(const float *addr)
+STATIC_INLINE float eeprom_read_float(const float *addr) __attribute__((pure, always_inline, unused));
+STATIC_INLINE float eeprom_read_float(const float *addr)
 {
 	union {float f; uint32_t u32;} u;
 	u.u32 = eeprom_read_dword((const uint32_t *)addr);
 	return u.f;
 }
-static inline void eeprom_write_float(float *addr, float value) __attribute__((always_inline, unused));
-static inline void eeprom_write_float(float *addr, float value)
+STATIC_INLINE void eeprom_write_float(float *addr, float value) __attribute__((always_inline, unused));
+STATIC_INLINE void eeprom_write_float(float *addr, float value)
 {
 	union {float f; uint32_t u32;} u;
 	u.f = value;
 	eeprom_write_dword((uint32_t *)addr, u.u32);
 }
-static inline void eeprom_update_byte(uint8_t *addr, uint8_t value) __attribute__((always_inline, unused));
-static inline void eeprom_update_byte(uint8_t *addr, uint8_t value)
+STATIC_INLINE void eeprom_update_byte(uint8_t *addr, uint8_t value) __attribute__((always_inline, unused));
+STATIC_INLINE void eeprom_update_byte(uint8_t *addr, uint8_t value)
 {
 	eeprom_write_byte(addr, value);
 }
-static inline void eeprom_update_word(uint16_t *addr, uint16_t value) __attribute__((always_inline, unused));
-static inline void eeprom_update_word(uint16_t *addr, uint16_t value)
+STATIC_INLINE void eeprom_update_word(uint16_t *addr, uint16_t value) __attribute__((always_inline, unused));
+STATIC_INLINE void eeprom_update_word(uint16_t *addr, uint16_t value)
 {
 	eeprom_write_word(addr, value);
 }
-static inline void eeprom_update_dword(uint32_t *addr, uint32_t value) __attribute__((always_inline, unused));
-static inline void eeprom_update_dword(uint32_t *addr, uint32_t value)
+STATIC_INLINE void eeprom_update_dword(uint32_t *addr, uint32_t value) __attribute__((always_inline, unused));
+STATIC_INLINE void eeprom_update_dword(uint32_t *addr, uint32_t value)
 {
 	eeprom_write_dword(addr, value);
 }
-static inline void eeprom_update_float(float *addr, float value) __attribute__((always_inline, unused));
-static inline void eeprom_update_float(float *addr, float value)
+STATIC_INLINE void eeprom_update_float(float *addr, float value) __attribute__((always_inline, unused));
+STATIC_INLINE void eeprom_update_float(float *addr, float value)
 {
 	union {float f; uint32_t u32;} u;
 	u.f = value;
 	eeprom_write_dword((uint32_t *)addr, u.u32);
 }
-static inline void eeprom_update_block(const void *buf, void *addr, uint32_t len) __attribute__((always_inline, unused));
-static inline void eeprom_update_block(const void *buf, void *addr, uint32_t len)
+STATIC_INLINE void eeprom_update_block(const void *buf, void *addr, uint32_t len) __attribute__((always_inline, unused));
+STATIC_INLINE void eeprom_update_block(const void *buf, void *addr, uint32_t len)
 {
 	eeprom_write_block(buf, addr, len);
 }
@@ -98,10 +103,10 @@ char * ulltoa(unsigned long long val, char *buf, int radix);
 char * lltoa(long long val, char *buf, int radix);
 
 /* #if defined(__STRICT_ANSI__) || (defined(_NEWLIB_VERSION) && (__NEWLIB__ < 2 || __NEWLIB__ == 2 && __NEWLIB_MINOR__ < 2))
-static inline char * utoa(unsigned int val, char *buf, int radix) __attribute__((always_inline, unused));
-static inline char * utoa(unsigned int val, char *buf, int radix) { return ultoa(val, buf, radix); }
-static inline char * itoa(int val, char *buf, int radix) __attribute__((always_inline, unused));
-static inline char * itoa(int val, char *buf, int radix) { return ltoa(val, buf, radix); }
+STATIC_INLINE char * utoa(unsigned int val, char *buf, int radix) __attribute__((always_inline, unused));
+STATIC_INLINE char * utoa(unsigned int val, char *buf, int radix) { return ultoa(val, buf, radix); }
+STATIC_INLINE char * itoa(int val, char *buf, int radix) __attribute__((always_inline, unused));
+STATIC_INLINE char * itoa(int val, char *buf, int radix) { return ltoa(val, buf, radix); }
 #endif */
 
 char * dtostrf(float val, int width, unsigned int precision, char *buf);
@@ -110,4 +115,7 @@ char * dtostrf(float val, int width, unsigned int precision, char *buf);
 #ifdef __cplusplus
 }
 #endif
+
+#undef STATIC_INLINE
+
 #endif

--- a/teensy3/core_pins.h
+++ b/teensy3/core_pins.h
@@ -1598,14 +1598,18 @@
 #define CORE_TPM1_CH1_PIN	17
 #endif
 
-
 #ifdef __cplusplus
 extern "C" {
+// C++ compilers shouldn't use 'static inline' because then there may be more
+// than one copy of the function; 'static' implies internal linkage
+#define STATIC_INLINE inline
+#else
+#define STATIC_INLINE static inline
 #endif
 
 void digitalWrite(uint8_t pin, uint8_t val);
-static inline void digitalWriteFast(uint8_t pin, uint8_t val) __attribute__((always_inline, unused));
-static inline void digitalWriteFast(uint8_t pin, uint8_t val)
+STATIC_INLINE void digitalWriteFast(uint8_t pin, uint8_t val) __attribute__((always_inline, unused));
+STATIC_INLINE void digitalWriteFast(uint8_t pin, uint8_t val)
 {
 	if (__builtin_constant_p(pin)) {
 		if (val) {
@@ -1891,8 +1895,8 @@ static inline void digitalWriteFast(uint8_t pin, uint8_t val)
 }
 
 void digitalToggle(uint8_t pin);
-static inline void digitalToggleFast(uint8_t pin) __attribute__((always_inline, unused));
-static inline void digitalToggleFast(uint8_t pin)
+STATIC_INLINE void digitalToggleFast(uint8_t pin) __attribute__((always_inline, unused));
+STATIC_INLINE void digitalToggleFast(uint8_t pin)
 {
 	if (__builtin_constant_p(pin)) {
 		if (pin == 0) {
@@ -2098,8 +2102,8 @@ static inline void digitalToggleFast(uint8_t pin)
 }
 
 uint8_t digitalRead(uint8_t pin);
-static inline uint8_t digitalReadFast(uint8_t pin) __attribute__((always_inline, unused));
-static inline uint8_t digitalReadFast(uint8_t pin)
+STATIC_INLINE uint8_t digitalReadFast(uint8_t pin) __attribute__((always_inline, unused));
+STATIC_INLINE uint8_t digitalReadFast(uint8_t pin)
 {
 	if (__builtin_constant_p(pin)) {
 		if (pin == 0) {
@@ -2254,7 +2258,7 @@ void pinMode(uint8_t pin, uint8_t mode);
 void init_pins(void);
 void analogWrite(uint8_t pin, int val);
 uint32_t analogWriteRes(uint32_t bits);
-static inline uint32_t analogWriteResolution(uint32_t bits) { return analogWriteRes(bits); }
+STATIC_INLINE uint32_t analogWriteResolution(uint32_t bits) { return analogWriteRes(bits); }
 void analogWriteFrequency(uint8_t pin, float frequency);
 void analogWriteDAC0(int val);
 void analogWriteDAC1(int val);
@@ -2270,7 +2274,7 @@ void _init_Teensyduino_internal_(void);
 int analogRead(uint8_t pin);
 void analogReference(uint8_t type);
 void analogReadRes(unsigned int bits);
-static inline void analogReadResolution(unsigned int bits) { analogReadRes(bits); }
+STATIC_INLINE void analogReadResolution(unsigned int bits) { analogReadRes(bits); }
 void analogReadAveraging(unsigned int num);
 void analog_init(void);
 
@@ -2292,12 +2296,12 @@ void analog_init(void);
 int touchRead(uint8_t pin);
 
 
-static inline void shiftOut(uint8_t, uint8_t, uint8_t, uint8_t) __attribute__((always_inline, unused));
+STATIC_INLINE void shiftOut(uint8_t, uint8_t, uint8_t, uint8_t) __attribute__((always_inline, unused));
 extern void _shiftOut(uint8_t dataPin, uint8_t clockPin, uint8_t bitOrder, uint8_t value) __attribute__((noinline));
 extern void shiftOut_lsbFirst(uint8_t dataPin, uint8_t clockPin, uint8_t value) __attribute__((noinline));
 extern void shiftOut_msbFirst(uint8_t dataPin, uint8_t clockPin, uint8_t value) __attribute__((noinline));
 
-static inline void shiftOut(uint8_t dataPin, uint8_t clockPin, uint8_t bitOrder, uint8_t value)
+STATIC_INLINE void shiftOut(uint8_t dataPin, uint8_t clockPin, uint8_t bitOrder, uint8_t value)
 {
         if (__builtin_constant_p(bitOrder)) {
                 if (bitOrder == LSBFIRST) {
@@ -2310,12 +2314,12 @@ static inline void shiftOut(uint8_t dataPin, uint8_t clockPin, uint8_t bitOrder,
         }
 }
 
-static inline uint8_t shiftIn(uint8_t, uint8_t, uint8_t) __attribute__((always_inline, unused));
+STATIC_INLINE uint8_t shiftIn(uint8_t, uint8_t, uint8_t) __attribute__((always_inline, unused));
 extern uint8_t _shiftIn(uint8_t dataPin, uint8_t clockPin, uint8_t bitOrder) __attribute__((noinline));
 extern uint8_t shiftIn_lsbFirst(uint8_t dataPin, uint8_t clockPin) __attribute__((noinline));
 extern uint8_t shiftIn_msbFirst(uint8_t dataPin, uint8_t clockPin) __attribute__((noinline));
 
-static inline uint8_t shiftIn(uint8_t dataPin, uint8_t clockPin, uint8_t bitOrder)
+STATIC_INLINE uint8_t shiftIn(uint8_t dataPin, uint8_t clockPin, uint8_t bitOrder)
 {
         if (__builtin_constant_p(bitOrder)) {
                 if (bitOrder == LSBFIRST) {
@@ -2347,8 +2351,8 @@ void delay(uint32_t msec);
 
 extern volatile uint32_t systick_millis_count;
 
-static inline uint32_t millis(void) __attribute__((always_inline, unused));
-static inline uint32_t millis(void)
+STATIC_INLINE uint32_t millis(void) __attribute__((always_inline, unused));
+STATIC_INLINE uint32_t millis(void)
 {
 	// Reading a volatile variable to another volatile
 	// seems redundant, but isn't for some cases.
@@ -2365,8 +2369,8 @@ static inline uint32_t millis(void)
 
 uint32_t micros(void);
 
-static inline void delayMicroseconds(uint32_t) __attribute__((always_inline, unused));
-static inline void delayMicroseconds(uint32_t usec)
+STATIC_INLINE void delayMicroseconds(uint32_t) __attribute__((always_inline, unused));
+STATIC_INLINE void delayMicroseconds(uint32_t usec)
 {
 #if F_CPU == 256000000
 	uint32_t n = usec * 85;
@@ -2424,8 +2428,8 @@ static inline void delayMicroseconds(uint32_t usec)
 }
 #endif
 
-static inline void delayNanoseconds(uint32_t) __attribute__((always_inline, unused));
-static inline void delayNanoseconds(uint32_t nsec)
+STATIC_INLINE void delayNanoseconds(uint32_t) __attribute__((always_inline, unused));
+STATIC_INLINE void delayNanoseconds(uint32_t nsec)
 {
 	if (__builtin_constant_p(nsec)) {
 		// use NOPs for the common usage of a constexpr input and short delay
@@ -2557,7 +2561,6 @@ public:
 extern teensy3_clock_class Teensy3Clock;
 #endif
 
-
-
+#undef STATIC_INLINE
 
 #endif

--- a/teensy3/kinetis.h
+++ b/teensy3/kinetis.h
@@ -5761,6 +5761,11 @@ typedef struct __attribute__((packed)) {
 
 #ifdef __cplusplus
 extern "C" {
+// C++ compilers shouldn't use 'static inline' because then there may be more
+// than one copy of the function; 'static' implies internal linkage
+#define STATIC_INLINE inline
+#else
+#define STATIC_INLINE static inline
 #endif
 extern int nvic_execution_priority(void);
 
@@ -5768,8 +5773,8 @@ extern int nvic_execution_priority(void);
 extern int kinetis_hsrun_disable(void);
 extern int kinetis_hsrun_enable(void);
 #else
-__attribute__((always_inline)) static inline int kinetis_hsrun_disable(void) { return 0; }
-__attribute__((always_inline)) static inline int kinetis_hsrun_enable(void)  { return 0; }
+__attribute__((always_inline)) STATIC_INLINE int kinetis_hsrun_disable(void) { return 0; }
+__attribute__((always_inline)) STATIC_INLINE int kinetis_hsrun_enable(void)  { return 0; }
 #endif
 
 extern void nmi_isr(void);
@@ -5890,11 +5895,11 @@ extern void (* const _VectorsFlash[NVIC_NUM_INTERRUPTS+16])(void);
 
 // Cache management functions for compatibility with Teensy 4.0
 __attribute__((always_inline, unused))
-static inline void arm_dcache_flush(void *addr, uint32_t size) { }
+STATIC_INLINE void arm_dcache_flush(void *addr, uint32_t size) { }
 __attribute__((always_inline, unused))
-static inline void arm_dcache_delete(void *addr, uint32_t size) { }
+STATIC_INLINE void arm_dcache_delete(void *addr, uint32_t size) { }
 __attribute__((always_inline, unused))
-static inline void arm_dcache_flush_delete(void *addr, uint32_t size) { }
+STATIC_INLINE void arm_dcache_flush_delete(void *addr, uint32_t size) { }
 
 #ifdef __cplusplus
 }
@@ -5902,4 +5907,6 @@ static inline void arm_dcache_flush_delete(void *addr, uint32_t size) { }
 
 #undef BEGIN_ENUM
 #undef END_ENUM
+#undef STATIC_INLINE
+
 #endif

--- a/teensy3/usb_dev.h
+++ b/teensy3/usb_dev.h
@@ -45,6 +45,11 @@
 
 #ifdef __cplusplus
 extern "C" {
+// C++ compilers shouldn't use 'static inline' because then there may be more
+// than one copy of the function; 'static' implies internal linkage
+#define STATIC_INLINE inline
+#else
+#define STATIC_INLINE static inline
 #endif
 
 void usb_init(void);
@@ -59,8 +64,8 @@ void usb_tx_isochronous(uint32_t endpoint, void *data, uint32_t len);
 extern volatile uint8_t usb_configuration;
 
 extern uint16_t usb_rx_byte_count_data[NUM_ENDPOINTS];
-static inline uint32_t usb_rx_byte_count(uint32_t endpoint) __attribute__((always_inline));
-static inline uint32_t usb_rx_byte_count(uint32_t endpoint)
+STATIC_INLINE uint32_t usb_rx_byte_count(uint32_t endpoint) __attribute__((always_inline));
+STATIC_INLINE uint32_t usb_rx_byte_count(uint32_t endpoint)
 {
         endpoint--;
         if (endpoint >= NUM_ENDPOINTS) return 0;
@@ -137,5 +142,7 @@ void usb_init(void);
 
 
 #endif // F_CPU
+
+#undef STATIC_INLINE
 
 #endif

--- a/teensy3/usb_joystick.h
+++ b/teensy3/usb_joystick.h
@@ -105,7 +105,7 @@ class usb_joystick_class
 			| (val << 12) | (val << 22);
 		if (!manual_mode) usb_joystick_send();
 	}
-        inline void hat(int dir) {
+        void hat(int dir) {
                 uint32_t val = 0;
                 if (dir < 0) val = 15;
                 else if (dir < 23) val = 0;
@@ -138,7 +138,7 @@ class usb_joystick_class
 		if (--num >= 17) return;
 		analog16(num + 6, position);
 	}
-        inline void hat(unsigned int num, int angle) {
+        void hat(unsigned int num, int angle) {
 		uint32_t val=15;
 		if (angle > 0 && angle < 23) val = 0;
 		else if (angle < 68) val = 1;

--- a/teensy4/DMAChannel.h
+++ b/teensy4/DMAChannel.h
@@ -373,7 +373,7 @@ protected:
 	// require the inheriting class to initialize the TCD pointer.
 	DMABaseClass() {}
 
-	static inline void copy_tcd(TCD_t *dst, const TCD_t *src) {
+	static void copy_tcd(TCD_t *dst, const TCD_t *src) {
 		dst->CSR &= ~DMA_TCD_CSR_DONE;
 		const uint32_t *p = (const uint32_t *)src;
 		volatile uint32_t *q = (uint32_t *)dst;

--- a/teensy4/HardwareSerial.h
+++ b/teensy4/HardwareSerial.h
@@ -294,7 +294,7 @@ public:
 
 	operator bool()			{ return true; }
 
-	static inline void processSerialEventsList() {
+	static void processSerialEventsList() {
 		for (uint8_t i = 0; i < s_count_serials_with_serial_events; i++) {
 			s_serials_with_serial_events[i]->doYieldCode();
 		}
@@ -328,8 +328,8 @@ private:
 	volatile uint32_t 	*rts_pin_baseReg_ = 0;
 	uint32_t 			rts_pin_bitmask_ = 0;
 
-  	inline void rts_assert();
-  	inline void rts_deassert();
+  	void rts_assert();
+  	void rts_deassert();
 
 	void IRQHandler();
 	friend void IRQHandler_Serial1();
@@ -347,7 +347,7 @@ private:
 	#endif
 	static uint8_t 			s_count_serials_with_serial_events;
 	void addToSerialEventsList(); 
-	inline void doYieldCode()  {
+	void doYieldCode()  {
 		if (available()) (*hardware->_serialEvent)();
 	}
 

--- a/teensy4/MTP_Storage.h
+++ b/teensy4/MTP_Storage.h
@@ -130,8 +130,8 @@ public:
 	}
 	enum {NO_ERROR=0, SOURCE_OPEN_FAIL, DEST_OPEN_FAIL, READ_ERROR, WRITE_ERROR, 
 				RENAME_FAIL, MKDIR_FAIL, REMOVE_FAIL, RMDIR_FAIL};
-	inline uint8_t getLastError() {return last_error_;}
-	inline void setLastError(uint8_t error) {last_error_ = error;}
+	uint8_t getLastError() {return last_error_;}
+	void setLastError(uint8_t error) {last_error_ = error;}
 	const char *getStoreName(uint32_t store) {
 		if (store < (uint32_t)fsCount) return name[store];
 		return nullptr;

--- a/teensy4/MTP_Teensy.h
+++ b/teensy4/MTP_Teensy.h
@@ -81,7 +81,7 @@ public:
 
 #if 1
   // returns the count of file systems that have been added to the storage list
-  //inline uint32_t getFilesystemCount(void) { return storage_.get_FSCount(); }
+  //uint32_t getFilesystemCount(void) { return storage_.get_FSCount(); }
 
   FS* getFilesystemByIndex(uint32_t store) {
     if (store >= storage_.get_FSCount()) return nullptr;
@@ -108,16 +108,16 @@ public:
     return false;
   }
 
-  //inline bool useFileSystemIndexFileStore(uint32_t store = 0) { return storage_.setIndexStore(store); }
+  //bool useFileSystemIndexFileStore(uint32_t store = 0) { return storage_.setIndexStore(store); }
 
   // maps a file system name (The diskname parameter in addFilesystem)
   // and returns the file system index.
-  //inline uint32_t getFilesystemIndexFromName(const char *fsname) { return storage_.getStoreID(fsname); }
+  //uint32_t getFilesystemIndexFromName(const char *fsname) { return storage_.getStoreID(fsname); }
 
   // Reurns a pointer to stream object that is being used within MTP_Teensy
   // code to output debug and informational messages.  By default it
   // is a pointer to the Serial object.
-  static inline Stream *PrintStream(void) { return printStream_; }
+  static Stream *PrintStream(void) { return printStream_; }
 
   // Set what stream object should be used to output debug and information 
   // messages.  By default the system uses the Serial object.
@@ -265,10 +265,10 @@ private:
   // location, such as a removable memory card or an internal memory bank. The
   // least-significant 16 bits identify a logical partition of that physical
   // storage."
-  inline uint32_t Store2Storage(uint32_t store) {
+  uint32_t Store2Storage(uint32_t store) {
     return ((store + 1) << 16) | 0x0001;
   }
-  static inline uint32_t Storage2Store(uint32_t storage) {
+  static uint32_t Storage2Store(uint32_t storage) {
     return (storage >> 16) - 1;
   }
 

--- a/teensy4/WString.h
+++ b/teensy4/WString.h
@@ -75,7 +75,7 @@ public:
 
 	// memory management
 	unsigned char reserve(unsigned int size);
-	inline unsigned int length(void) const {return len;}
+	unsigned int length(void) const {return len;}
 
 	// copy and move
 	String & copy(const char *cstr, unsigned int length);

--- a/teensy4/avr_emulation.h
+++ b/teensy4/avr_emulation.h
@@ -39,13 +39,13 @@
 
 
 // bitband addressing for atomic access to data direction register
-static inline void GPIO_SETBIT_ATOMIC(volatile uint32_t *reg, uint32_t mask) {
+inline void GPIO_SETBIT_ATOMIC(volatile uint32_t *reg, uint32_t mask) {
 	__disable_irq();
 	*reg |= mask;
 	__enable_irq();
 }
 
-static inline void GPIO_CLRBIT_ATOMIC(volatile uint32_t *reg, uint32_t mask) {
+inline void GPIO_CLRBIT_ATOMIC(volatile uint32_t *reg, uint32_t mask) {
 	__disable_irq();
 	*reg &= ~mask;
 	__enable_irq();

--- a/teensy4/avr_emulation.h
+++ b/teensy4/avr_emulation.h
@@ -78,7 +78,7 @@ class SPDRemulation;
 class SPCRemulation
 {
 public:
-	inline SPCRemulation & operator = (int val __attribute__((unused))) __attribute__((always_inline)) {
+	SPCRemulation & operator = (int val __attribute__((unused))) __attribute__((always_inline)) {
 /*
 		uint32_t ctar, mcr, sim6;
 		//serial_print("SPCR=");
@@ -139,7 +139,7 @@ public:
 */
 		return *this;
 	}
-	inline SPCRemulation & operator |= (int val __attribute__((unused))) __attribute__((always_inline)) {
+	SPCRemulation & operator |= (int val __attribute__((unused))) __attribute__((always_inline)) {
 /*
 		uint32_t sim6;
 		//serial_print("SPCR |= ");
@@ -196,7 +196,7 @@ public:
 */
 		return *this;
 	}
-	inline SPCRemulation & operator &= (int val __attribute__((unused))) __attribute__((always_inline)) {
+	SPCRemulation & operator &= (int val __attribute__((unused))) __attribute__((always_inline)) {
 /*
 		//serial_print("SPCR &= ");
 		//serial_phex(val);
@@ -242,7 +242,7 @@ public:
 */
 		return *this;
 	}
-	inline int operator & (int val __attribute__((unused))) const __attribute__((always_inline)) {
+	int operator & (int val __attribute__((unused))) const __attribute__((always_inline)) {
 		int ret = 0;
 /*		
 		//serial_print("SPCR & ");
@@ -298,23 +298,23 @@ public:
 */
 		return ret;
 	}
-	inline void setMOSI(uint8_t pin __attribute__((unused))) __attribute__((always_inline)) {
+	void setMOSI(uint8_t pin __attribute__((unused))) __attribute__((always_inline)) {
 	}
-	inline void setMOSI_soft(uint8_t pin __attribute__((unused))) __attribute__((always_inline)) {
+	void setMOSI_soft(uint8_t pin __attribute__((unused))) __attribute__((always_inline)) {
 	}
-	inline void setMISO(uint8_t pin __attribute__((unused))) __attribute__((always_inline)) {
+	void setMISO(uint8_t pin __attribute__((unused))) __attribute__((always_inline)) {
 	}
-	inline void setSCK(uint8_t pin __attribute__((unused))) __attribute__((always_inline)) {
+	void setSCK(uint8_t pin __attribute__((unused))) __attribute__((always_inline)) {
 	}
 	friend class SPSRemulation;
 	friend class SPIFIFOclass;
 private:
 	static uint8_t pinout;
 public:
-	inline void enable_pins(void) __attribute__((always_inline)) {
+	void enable_pins(void) __attribute__((always_inline)) {
 		//serial_print("enable_pins\n");
 	}
-	inline void disable_pins(void) __attribute__((always_inline)) {
+	void disable_pins(void) __attribute__((always_inline)) {
 	}
 };
 extern SPCRemulation SPCR;
@@ -323,7 +323,7 @@ extern SPCRemulation SPCR;
 class SPSRemulation
 {
 public:
-	inline SPSRemulation & operator = (int val __attribute__((unused))) __attribute__((always_inline)) {
+	SPSRemulation & operator = (int val __attribute__((unused))) __attribute__((always_inline)) {
 		//serial_print("SPSR=");
 		//serial_phex(val);
 		//serial_print("\n");
@@ -343,7 +343,7 @@ public:
 */		
 		return *this;
 	}
-	inline SPSRemulation & operator |= (int val __attribute__((unused))) __attribute__((always_inline)) {
+	SPSRemulation & operator |= (int val __attribute__((unused))) __attribute__((always_inline)) {
 /*
 		//serial_print("SPSR |= ");
 		//serial_phex(val);
@@ -352,7 +352,7 @@ public:
 */
 		return *this;
 	}
-	inline SPSRemulation & operator &= (int val __attribute__((unused))) __attribute__((always_inline)) {
+	SPSRemulation & operator &= (int val __attribute__((unused))) __attribute__((always_inline)) {
 /*
 		//serial_print("SPSR &= ");
 		//serial_phex(val);
@@ -361,7 +361,7 @@ public:
 */
 		return *this;
 	}
-	inline int operator & (int val) const __attribute__((always_inline)) {
+	int operator & (int val) const __attribute__((always_inline)) {
 		int ret = 0;
 		//serial_print("SPSR & ");
 		//serial_phex(val);
@@ -392,7 +392,7 @@ extern SPSRemulation SPSR;
 class SPDRemulation
 {
 public:
-	inline SPDRemulation & operator = (int val) __attribute__((always_inline)) {
+	SPDRemulation & operator = (int val) __attribute__((always_inline)) {
 		//serial_print("SPDR = ");
 		//serial_phex(val);
 		//serial_print("\n");
@@ -411,7 +411,7 @@ extern SPDRemulation SPDR;
 class PORTDemulation
 {
 public:
-	inline PORTDemulation & operator = (int val) __attribute__((always_inline)) {
+	PORTDemulation & operator = (int val) __attribute__((always_inline)) {
 		digitalWriteFast(0, (val & (1<<0)));
 		if (!(CORE_PIN0_DDRREG & CORE_PIN0_BITMASK))
 			CORE_PIN0_PADCONFIG = ((val & (1<<0)) ? CONFIG_PULLUP : CONFIG_NOPULLUP);
@@ -438,7 +438,7 @@ public:
 			CORE_PIN7_PADCONFIG = ((val & (1<<7)) ? CONFIG_PULLUP : CONFIG_NOPULLUP);
 		return *this;
 	}
-	inline PORTDemulation & operator |= (int val) __attribute__((always_inline)) {
+	PORTDemulation & operator |= (int val) __attribute__((always_inline)) {
 		if (val & (1<<0)) {
 			digitalWriteFast(0, HIGH);
 			if (!(CORE_PIN0_DDRREG & CORE_PIN0_BITMASK)) CORE_PIN0_CONFIG = CONFIG_PULLUP;
@@ -473,7 +473,7 @@ public:
 		}
 		return *this;
 	}
-	inline PORTDemulation & operator &= (int val) __attribute__((always_inline)) {
+	PORTDemulation & operator &= (int val) __attribute__((always_inline)) {
 		if (!(val & (1<<0))) {
 			digitalWriteFast(0, LOW);
 			if (!(CORE_PIN0_DDRREG & CORE_PIN0_BITMASK)) CORE_PIN0_CONFIG = CONFIG_NOPULLUP;
@@ -514,7 +514,7 @@ extern PORTDemulation PORTD;
 class PINDemulation
 {
 public:
-	inline int operator & (int val) const __attribute__((always_inline)) {
+	int operator & (int val) const __attribute__((always_inline)) {
 		int ret = 0;
 		if ((val & (1<<0)) && digitalReadFast(0)) ret |= (1<<0);
 		if ((val & (1<<1)) && digitalReadFast(1)) ret |= (1<<1);
@@ -544,7 +544,7 @@ extern PINDemulation PIND;
 class DDRDemulation
 {
 public:
-	inline DDRDemulation & operator = (int val) __attribute__((always_inline)) {
+	DDRDemulation & operator = (int val) __attribute__((always_inline)) {
 		if (val & (1<<0)) set0(); else clr0();
 		if (val & (1<<1)) set1(); else clr1();
 		if (val & (1<<2)) set2(); else clr2();
@@ -555,7 +555,7 @@ public:
 		if (val & (1<<7)) set7(); else clr7();
 		return *this;
 	}
-	inline DDRDemulation & operator |= (int val) __attribute__((always_inline)) {
+	DDRDemulation & operator |= (int val) __attribute__((always_inline)) {
 		if (val & (1<<0)) set0();
 		if (val & (1<<1)) set1();
 		if (val & (1<<2)) set2();
@@ -566,7 +566,7 @@ public:
 		if (val & (1<<7)) set7();
 		return *this;
 	}
-	inline DDRDemulation & operator &= (int val) __attribute__((always_inline)) {
+	DDRDemulation & operator &= (int val) __attribute__((always_inline)) {
 		if (!(val & (1<<0))) clr0();
 		if (!(val & (1<<1))) clr1();
 		if (!(val & (1<<2))) clr2();
@@ -578,89 +578,89 @@ public:
 		return *this;
 	}
 private:
-	inline void set0() __attribute__((always_inline)) {
+	void set0() __attribute__((always_inline)) {
 		GPIO_SETBIT_ATOMIC(&CORE_PIN0_DDRREG, CORE_PIN0_BITMASK);
 		CORE_PIN0_CONFIG = 5 | 0x10;
 		CORE_PIN0_PADCONFIG = CONFIG_PULLUP;
 	}
-	inline void set1() __attribute__((always_inline)) {
+	void set1() __attribute__((always_inline)) {
 		GPIO_SETBIT_ATOMIC(&CORE_PIN1_DDRREG, CORE_PIN1_BITMASK);
 		CORE_PIN1_CONFIG = 5 | 0x10;
 		CORE_PIN1_PADCONFIG = CONFIG_PULLUP;
 	}
-	inline void set2() __attribute__((always_inline)) {
+	void set2() __attribute__((always_inline)) {
 		GPIO_SETBIT_ATOMIC(&CORE_PIN2_DDRREG, CORE_PIN2_BITMASK);
 		CORE_PIN2_CONFIG = 5 | 0x10;
 		CORE_PIN2_PADCONFIG = CONFIG_PULLUP;
 	}
-	inline void set3() __attribute__((always_inline)) {
+	void set3() __attribute__((always_inline)) {
 		GPIO_SETBIT_ATOMIC(&CORE_PIN3_DDRREG, CORE_PIN3_BITMASK);
 		CORE_PIN3_CONFIG = 5 | 0x10;
 		CORE_PIN3_PADCONFIG = CONFIG_PULLUP;
 	}
-	inline void set4() __attribute__((always_inline)) {
+	void set4() __attribute__((always_inline)) {
 		GPIO_SETBIT_ATOMIC(&CORE_PIN4_DDRREG, CORE_PIN4_BITMASK);
 		CORE_PIN4_CONFIG = 5 | 0x10;
 		CORE_PIN4_PADCONFIG = CONFIG_PULLUP;
 	}
-	inline void set5() __attribute__((always_inline)) {
+	void set5() __attribute__((always_inline)) {
 		GPIO_SETBIT_ATOMIC(&CORE_PIN5_DDRREG, CORE_PIN5_BITMASK);
 		CORE_PIN5_CONFIG = 5 | 0x10;
 		CORE_PIN5_PADCONFIG = CONFIG_PULLUP;
 	}
-	inline void set6() __attribute__((always_inline)) {
+	void set6() __attribute__((always_inline)) {
 		GPIO_SETBIT_ATOMIC(&CORE_PIN6_DDRREG, CORE_PIN6_BITMASK);
 		CORE_PIN6_CONFIG = 5 | 0x10;
 		CORE_PIN6_PADCONFIG = CONFIG_PULLUP;
 	}
-	inline void set7() __attribute__((always_inline)) {
+	void set7() __attribute__((always_inline)) {
 		GPIO_SETBIT_ATOMIC(&CORE_PIN7_DDRREG, CORE_PIN7_BITMASK);
 		CORE_PIN7_CONFIG = 5 | 0x10;
 		CORE_PIN7_PADCONFIG = CONFIG_PULLUP;
 	}
-	inline void clr0() __attribute__((always_inline)) {
+	void clr0() __attribute__((always_inline)) {
 		CORE_PIN0_CONFIG = 5 | 0x10;
 		CORE_PIN0_PADCONFIG = ((CORE_PIN0_PORTREG & CORE_PIN0_BITMASK)
 		  ? CONFIG_PULLUP : CONFIG_NOPULLUP);
 		GPIO_CLRBIT_ATOMIC(&CORE_PIN0_DDRREG, CORE_PIN0_BITMASK);
 	}
-	inline void clr1() __attribute__((always_inline)) {
+	void clr1() __attribute__((always_inline)) {
 		CORE_PIN1_CONFIG = 5 | 0x10;
 		CORE_PIN1_PADCONFIG = ((CORE_PIN1_PORTREG & CORE_PIN1_BITMASK)
 		  ? CONFIG_PULLUP : CONFIG_NOPULLUP);
 		GPIO_CLRBIT_ATOMIC(&CORE_PIN1_DDRREG, CORE_PIN1_BITMASK);
 	}
-	inline void clr2() __attribute__((always_inline)) {
+	void clr2() __attribute__((always_inline)) {
 		CORE_PIN2_CONFIG = 5 | 0x10;
 		CORE_PIN2_PADCONFIG = ((CORE_PIN2_PORTREG & CORE_PIN2_BITMASK)
 		  ? CONFIG_PULLUP : CONFIG_NOPULLUP);
 		GPIO_CLRBIT_ATOMIC(&CORE_PIN2_DDRREG, CORE_PIN2_BITMASK);
 	}
-	inline void clr3() __attribute__((always_inline)) {
+	void clr3() __attribute__((always_inline)) {
 		CORE_PIN3_CONFIG = 5 | 0x10;
 		CORE_PIN3_PADCONFIG = ((CORE_PIN3_PORTREG & CORE_PIN3_BITMASK)
 		  ? CONFIG_PULLUP : CONFIG_NOPULLUP);
 		GPIO_CLRBIT_ATOMIC(&CORE_PIN3_DDRREG, CORE_PIN3_BITMASK);
 	}
-	inline void clr4() __attribute__((always_inline)) {
+	void clr4() __attribute__((always_inline)) {
 		CORE_PIN4_CONFIG = 5 | 0x10;
 		CORE_PIN4_PADCONFIG = ((CORE_PIN4_PORTREG & CORE_PIN4_BITMASK)
 		  ? CONFIG_PULLUP : CONFIG_NOPULLUP);
 		GPIO_CLRBIT_ATOMIC(&CORE_PIN4_DDRREG, CORE_PIN4_BITMASK);
 	}
-	inline void clr5() __attribute__((always_inline)) {
+	void clr5() __attribute__((always_inline)) {
 		CORE_PIN5_CONFIG = 5 | 0x10;
 		CORE_PIN5_PADCONFIG = ((CORE_PIN5_PORTREG & CORE_PIN5_BITMASK)
 		  ? CONFIG_PULLUP : CONFIG_NOPULLUP);
 		GPIO_CLRBIT_ATOMIC(&CORE_PIN5_DDRREG, CORE_PIN5_BITMASK);
 	}
-	inline void clr6() __attribute__((always_inline)) {
+	void clr6() __attribute__((always_inline)) {
 		CORE_PIN6_CONFIG = 5 | 0x10;
 		CORE_PIN6_PADCONFIG = ((CORE_PIN6_PORTREG & CORE_PIN6_BITMASK)
 		  ? CONFIG_PULLUP : CONFIG_NOPULLUP);
 		GPIO_CLRBIT_ATOMIC(&CORE_PIN6_DDRREG, CORE_PIN6_BITMASK);
 	}
-	inline void clr7() __attribute__((always_inline)) {
+	void clr7() __attribute__((always_inline)) {
 		CORE_PIN7_CONFIG = 5 | 0x10;
 		CORE_PIN7_PADCONFIG = ((CORE_PIN7_PORTREG & CORE_PIN7_BITMASK)
 		  ? CONFIG_PULLUP : CONFIG_NOPULLUP);
@@ -678,7 +678,7 @@ extern DDRDemulation DDRD;
 class PORTBemulation
 {
 public:
-	inline PORTBemulation & operator = (int val) __attribute__((always_inline)) {
+	PORTBemulation & operator = (int val) __attribute__((always_inline)) {
 		digitalWriteFast(8, (val & (1<<0)));
 		if (!(CORE_PIN8_DDRREG & CORE_PIN8_BITMASK))
 			CORE_PIN8_PADCONFIG = ((val & (1<<0)) ? CONFIG_PULLUP : CONFIG_NOPULLUP);
@@ -699,7 +699,7 @@ public:
 			CORE_PIN13_PADCONFIG = ((val & (1<<5)) ? CONFIG_PULLUP : CONFIG_NOPULLUP);
 		return *this;
 	}
-	inline PORTBemulation & operator |= (int val) __attribute__((always_inline)) {
+	PORTBemulation & operator |= (int val) __attribute__((always_inline)) {
 		if (val & (1<<0)) {
 			digitalWriteFast(8, HIGH);
 			if (!(CORE_PIN7_DDRREG & CORE_PIN7_BITMASK)) CORE_PIN8_CONFIG = CONFIG_PULLUP;
@@ -726,7 +726,7 @@ public:
 		}
 		return *this;
 	}
-	inline PORTBemulation & operator &= (int val) __attribute__((always_inline)) {
+	PORTBemulation & operator &= (int val) __attribute__((always_inline)) {
 		if (!(val & (1<<0))) {
 			digitalWriteFast(8, LOW);
 			if (!(CORE_PIN8_DDRREG & CORE_PIN8_BITMASK)) CORE_PIN8_CONFIG = CONFIG_NOPULLUP;
@@ -759,7 +759,7 @@ extern PORTBemulation PORTB;
 class PINBemulation
 {
 public:
-	inline int operator & (int val) const __attribute__((always_inline)) {
+	int operator & (int val) const __attribute__((always_inline)) {
 		int ret = 0;
 		if ((val & (1<<0)) && digitalReadFast(8)) ret |= (1<<0);
 		if ((val & (1<<1)) && digitalReadFast(9)) ret |= (1<<1);
@@ -785,7 +785,7 @@ extern PINBemulation PINB;
 class DDRBemulation
 {
 public:
-	inline DDRBemulation & operator = (int val) __attribute__((always_inline)) {
+	DDRBemulation & operator = (int val) __attribute__((always_inline)) {
 		if (val & (1<<0)) set0(); else clr0();
 		if (val & (1<<1)) set1(); else clr1();
 		if (val & (1<<2)) set2(); else clr2();
@@ -794,7 +794,7 @@ public:
 		if (val & (1<<5)) set5(); else clr5();
 		return *this;
 	}
-	inline DDRBemulation & operator |= (int val) __attribute__((always_inline)) {
+	DDRBemulation & operator |= (int val) __attribute__((always_inline)) {
 		if (val & (1<<0)) set0();
 		if (val & (1<<1)) set1();
 		if (val & (1<<2)) set2();
@@ -803,7 +803,7 @@ public:
 		if (val & (1<<5)) set5();
 		return *this;
 	}
-	inline DDRBemulation & operator &= (int val) __attribute__((always_inline)) {
+	DDRBemulation & operator &= (int val) __attribute__((always_inline)) {
 		if (!(val & (1<<0))) clr0();
 		if (!(val & (1<<1))) clr1();
 		if (!(val & (1<<2))) clr2();
@@ -813,67 +813,67 @@ public:
 		return *this;
 	}
 private:
-	inline void set0() __attribute__((always_inline)) {
+	void set0() __attribute__((always_inline)) {
 		GPIO_SETBIT_ATOMIC(&CORE_PIN8_DDRREG, CORE_PIN8_BITMASK);
 		CORE_PIN8_CONFIG = 5 | 0x10;
 		CORE_PIN8_PADCONFIG = CONFIG_PULLUP;
 	}
-	inline void set1() __attribute__((always_inline)) {
+	void set1() __attribute__((always_inline)) {
 		GPIO_SETBIT_ATOMIC(&CORE_PIN9_DDRREG, CORE_PIN9_BITMASK);
 		CORE_PIN9_CONFIG = 5 | 0x10;
 		CORE_PIN9_PADCONFIG = CONFIG_PULLUP;
 	}
-	inline void set2() __attribute__((always_inline)) {
+	void set2() __attribute__((always_inline)) {
 		GPIO_SETBIT_ATOMIC(&CORE_PIN10_DDRREG, CORE_PIN10_BITMASK);
 		CORE_PIN10_CONFIG = 5 | 0x10;
 		CORE_PIN10_PADCONFIG = CONFIG_PULLUP;
 	}
-	inline void set3() __attribute__((always_inline)) {
+	void set3() __attribute__((always_inline)) {
 		GPIO_SETBIT_ATOMIC(&CORE_PIN11_DDRREG, CORE_PIN11_BITMASK);
 		CORE_PIN11_CONFIG = 5 | 0x10;
 		CORE_PIN11_PADCONFIG = CONFIG_PULLUP;
 	}
-	inline void set4() __attribute__((always_inline)) {
+	void set4() __attribute__((always_inline)) {
 		GPIO_SETBIT_ATOMIC(&CORE_PIN12_DDRREG, CORE_PIN12_BITMASK);
 		CORE_PIN12_CONFIG = 5 | 0x10;
 		CORE_PIN12_PADCONFIG = CONFIG_PULLUP;
 	}
-	inline void set5() __attribute__((always_inline)) {
+	void set5() __attribute__((always_inline)) {
 		GPIO_SETBIT_ATOMIC(&CORE_PIN13_DDRREG, CORE_PIN13_BITMASK);
 		CORE_PIN13_CONFIG = 5 | 0x10;
 		CORE_PIN13_PADCONFIG = CONFIG_PULLUP;
 	}
-	inline void clr0() __attribute__((always_inline)) {
+	void clr0() __attribute__((always_inline)) {
 		CORE_PIN8_CONFIG = 5 | 0x10;
 		CORE_PIN8_PADCONFIG = ((CORE_PIN8_PORTREG & CORE_PIN8_BITMASK)
 		  ? CONFIG_PULLUP : CONFIG_NOPULLUP);
 		GPIO_CLRBIT_ATOMIC(&CORE_PIN8_DDRREG, CORE_PIN8_BITMASK);
 	}
-	inline void clr1() __attribute__((always_inline)) {
+	void clr1() __attribute__((always_inline)) {
 		CORE_PIN9_CONFIG = 5 | 0x10;
 		CORE_PIN9_PADCONFIG = ((CORE_PIN9_PORTREG & CORE_PIN9_BITMASK)
 		  ? CONFIG_PULLUP : CONFIG_NOPULLUP);
 		GPIO_CLRBIT_ATOMIC(&CORE_PIN9_DDRREG, CORE_PIN9_BITMASK);
 	}
-	inline void clr2() __attribute__((always_inline)) {
+	void clr2() __attribute__((always_inline)) {
 		CORE_PIN10_CONFIG = 5 | 0x10;
 		CORE_PIN10_PADCONFIG = ((CORE_PIN10_PORTREG & CORE_PIN10_BITMASK)
 		  ? CONFIG_PULLUP : CONFIG_NOPULLUP);
 		GPIO_CLRBIT_ATOMIC(&CORE_PIN10_DDRREG, CORE_PIN10_BITMASK);
 	}
-	inline void clr3() __attribute__((always_inline)) {
+	void clr3() __attribute__((always_inline)) {
 		CORE_PIN11_CONFIG = 5 | 0x10;
 		CORE_PIN11_PADCONFIG = ((CORE_PIN11_PORTREG & CORE_PIN11_BITMASK)
 		  ? CONFIG_PULLUP : CONFIG_NOPULLUP);
 		GPIO_CLRBIT_ATOMIC(&CORE_PIN11_DDRREG, CORE_PIN11_BITMASK);
 	}
-	inline void clr4() __attribute__((always_inline)) {
+	void clr4() __attribute__((always_inline)) {
 		CORE_PIN12_CONFIG = 5 | 0x10;
 		CORE_PIN12_PADCONFIG = ((CORE_PIN12_PORTREG & CORE_PIN12_BITMASK)
 		  ? CONFIG_PULLUP : CONFIG_NOPULLUP);
 		GPIO_CLRBIT_ATOMIC(&CORE_PIN12_DDRREG, CORE_PIN12_BITMASK);
 	}
-	inline void clr5() __attribute__((always_inline)) {
+	void clr5() __attribute__((always_inline)) {
 		CORE_PIN13_CONFIG = 5 | 0x10;
 		CORE_PIN13_PADCONFIG = ((CORE_PIN13_PORTREG & CORE_PIN13_BITMASK)
 		  ? CONFIG_PULLUP : CONFIG_NOPULLUP);
@@ -891,7 +891,7 @@ extern DDRBemulation DDRB;
 class PORTCemulation
 {
 public:
-	inline PORTCemulation & operator = (int val) __attribute__((always_inline)) {
+	PORTCemulation & operator = (int val) __attribute__((always_inline)) {
 		digitalWriteFast(14, (val & (1<<0)));
 		if (!(CORE_PIN14_DDRREG & CORE_PIN14_BITMASK))
 			CORE_PIN14_PADCONFIG = ((val & (1<<0)) ? CONFIG_PULLUP : CONFIG_NOPULLUP);
@@ -912,7 +912,7 @@ public:
 			CORE_PIN19_PADCONFIG = ((val & (1<<5)) ? CONFIG_PULLUP : CONFIG_NOPULLUP);
 		return *this;
 	}
-	inline PORTCemulation & operator |= (int val) __attribute__((always_inline)) {
+	PORTCemulation & operator |= (int val) __attribute__((always_inline)) {
 		if (val & (1<<0)) {
 			digitalWriteFast(14, HIGH);
 			if (!(CORE_PIN14_DDRREG & CORE_PIN14_BITMASK)) CORE_PIN14_CONFIG = CONFIG_PULLUP;
@@ -939,7 +939,7 @@ public:
 		}
 		return *this;
 	}
-	inline PORTCemulation & operator &= (int val) __attribute__((always_inline)) {
+	PORTCemulation & operator &= (int val) __attribute__((always_inline)) {
 		if (!(val & (1<<0))) {
 			digitalWriteFast(14, LOW);
 			if (!(CORE_PIN14_DDRREG & CORE_PIN14_BITMASK)) CORE_PIN14_CONFIG = CONFIG_NOPULLUP;
@@ -972,7 +972,7 @@ extern PORTCemulation PORTC;
 class PINCemulation
 {
 public:
-	inline int operator & (int val) const __attribute__((always_inline)) {
+	int operator & (int val) const __attribute__((always_inline)) {
 		int ret = 0;
 		if ((val & (1<<0)) && digitalReadFast(14)) ret |= (1<<0);
 		if ((val & (1<<1)) && digitalReadFast(15)) ret |= (1<<1);
@@ -998,7 +998,7 @@ extern PINCemulation PINC;
 class DDRCemulation
 {
 public:
-	inline DDRCemulation & operator = (int val) __attribute__((always_inline)) {
+	DDRCemulation & operator = (int val) __attribute__((always_inline)) {
 		if (val & (1<<0)) set0(); else clr0();
 		if (val & (1<<1)) set1(); else clr1();
 		if (val & (1<<2)) set2(); else clr2();
@@ -1007,7 +1007,7 @@ public:
 		if (val & (1<<5)) set5(); else clr5();
 		return *this;
 	}
-	inline DDRCemulation & operator |= (int val) __attribute__((always_inline)) {
+	DDRCemulation & operator |= (int val) __attribute__((always_inline)) {
 		if (val & (1<<0)) set0();
 		if (val & (1<<1)) set1();
 		if (val & (1<<2)) set2();
@@ -1016,7 +1016,7 @@ public:
 		if (val & (1<<5)) set5();
 		return *this;
 	}
-	inline DDRCemulation & operator &= (int val) __attribute__((always_inline)) {
+	DDRCemulation & operator &= (int val) __attribute__((always_inline)) {
 		if (!(val & (1<<0))) clr0();
 		if (!(val & (1<<1))) clr1();
 		if (!(val & (1<<2))) clr2();
@@ -1026,67 +1026,67 @@ public:
 		return *this;
 	}
 private:
-	inline void set0() __attribute__((always_inline)) {
+	void set0() __attribute__((always_inline)) {
 		GPIO_SETBIT_ATOMIC(&CORE_PIN14_DDRREG, CORE_PIN14_BITMASK);
 		CORE_PIN14_CONFIG = 5 | 0x10;
 		CORE_PIN14_PADCONFIG = CONFIG_PULLUP;
 	}
-	inline void set1() __attribute__((always_inline)) {
+	void set1() __attribute__((always_inline)) {
 		GPIO_SETBIT_ATOMIC(&CORE_PIN15_DDRREG, CORE_PIN15_BITMASK);
 		CORE_PIN15_CONFIG = 5 | 0x10;
 		CORE_PIN15_PADCONFIG = CONFIG_PULLUP;
 	}
-	inline void set2() __attribute__((always_inline)) {
+	void set2() __attribute__((always_inline)) {
 		GPIO_SETBIT_ATOMIC(&CORE_PIN16_DDRREG, CORE_PIN16_BITMASK);
 		CORE_PIN16_CONFIG = 5 | 0x10;
 		CORE_PIN16_PADCONFIG = CONFIG_PULLUP;
 	}
-	inline void set3() __attribute__((always_inline)) {
+	void set3() __attribute__((always_inline)) {
 		GPIO_SETBIT_ATOMIC(&CORE_PIN17_DDRREG, CORE_PIN17_BITMASK);
 		CORE_PIN17_CONFIG = 5 | 0x10;
 		CORE_PIN17_PADCONFIG = CONFIG_PULLUP;
 	}
-	inline void set4() __attribute__((always_inline)) {
+	void set4() __attribute__((always_inline)) {
 		GPIO_SETBIT_ATOMIC(&CORE_PIN18_DDRREG, CORE_PIN18_BITMASK);
 		CORE_PIN18_CONFIG = 5 | 0x10;
 		CORE_PIN18_PADCONFIG = CONFIG_PULLUP;
 	}
-	inline void set5() __attribute__((always_inline)) {
+	void set5() __attribute__((always_inline)) {
 		GPIO_SETBIT_ATOMIC(&CORE_PIN19_DDRREG, CORE_PIN19_BITMASK);
 		CORE_PIN19_CONFIG = 5 | 0x10;
 		CORE_PIN19_PADCONFIG = CONFIG_PULLUP;
 	}
-	inline void clr0() __attribute__((always_inline)) {
+	void clr0() __attribute__((always_inline)) {
 		CORE_PIN14_CONFIG = 5 | 0x10;
 		CORE_PIN14_PADCONFIG = ((CORE_PIN14_PORTREG & CORE_PIN14_BITMASK)
 		  ? CONFIG_PULLUP : CONFIG_NOPULLUP);
 		GPIO_CLRBIT_ATOMIC(&CORE_PIN14_DDRREG, CORE_PIN14_BITMASK);
 	}
-	inline void clr1() __attribute__((always_inline)) {
+	void clr1() __attribute__((always_inline)) {
 		CORE_PIN15_CONFIG = 5 | 0x10;
 		CORE_PIN15_PADCONFIG = ((CORE_PIN15_PORTREG & CORE_PIN15_BITMASK)
 		  ? CONFIG_PULLUP : CONFIG_NOPULLUP);
 		GPIO_CLRBIT_ATOMIC(&CORE_PIN15_DDRREG, CORE_PIN15_BITMASK);
 	}
-	inline void clr2() __attribute__((always_inline)) {
+	void clr2() __attribute__((always_inline)) {
 		CORE_PIN16_CONFIG = 5 | 0x10;
 		CORE_PIN16_PADCONFIG = ((CORE_PIN16_PORTREG & CORE_PIN16_BITMASK)
 		  ? CONFIG_PULLUP : CONFIG_NOPULLUP);
 		GPIO_CLRBIT_ATOMIC(&CORE_PIN16_DDRREG, CORE_PIN16_BITMASK);
 	}
-	inline void clr3() __attribute__((always_inline)) {
+	void clr3() __attribute__((always_inline)) {
 		CORE_PIN17_CONFIG = 5 | 0x10;
 		CORE_PIN17_PADCONFIG = ((CORE_PIN17_PORTREG & CORE_PIN17_BITMASK)
 		  ? CONFIG_PULLUP : CONFIG_NOPULLUP);
 		GPIO_CLRBIT_ATOMIC(&CORE_PIN17_DDRREG, CORE_PIN17_BITMASK);
 	}
-	inline void clr4() __attribute__((always_inline)) {
+	void clr4() __attribute__((always_inline)) {
 		CORE_PIN18_CONFIG = 5 | 0x10;
 		CORE_PIN18_PADCONFIG = ((CORE_PIN18_PORTREG & CORE_PIN18_BITMASK)
 		  ? CONFIG_PULLUP : CONFIG_NOPULLUP);
 		GPIO_CLRBIT_ATOMIC(&CORE_PIN18_DDRREG, CORE_PIN18_BITMASK);
 	}
-	inline void clr5() __attribute__((always_inline)) {
+	void clr5() __attribute__((always_inline)) {
 		CORE_PIN19_CONFIG = 5 | 0x10;
 		CORE_PIN19_PADCONFIG = ((CORE_PIN19_PORTREG & CORE_PIN19_BITMASK)
 		  ? CONFIG_PULLUP : CONFIG_NOPULLUP);

--- a/teensy4/avr_functions.h
+++ b/teensy4/avr_functions.h
@@ -35,6 +35,11 @@
 
 #ifdef __cplusplus
 extern "C" {
+// C++ compilers shouldn't use 'static inline' because then there may be more
+// than one copy of the function; 'static' implies internal linkage
+#define STATIC_INLINE inline
+#else
+#define STATIC_INLINE static inline
 #endif
 
 void eeprom_initialize(void);
@@ -50,44 +55,44 @@ int eeprom_is_ready(void);
 #define eeprom_busy_wait() do {} while (!eeprom_is_ready())
 
 /*
-static inline float eeprom_read_float(const float *addr) __attribute__((pure, always_inline, unused));
-static inline float eeprom_read_float(const float *addr)
+STATIC_INLINE float eeprom_read_float(const float *addr) __attribute__((pure, always_inline, unused));
+STATIC_INLINE float eeprom_read_float(const float *addr)
 {
 	union {float f; uint32_t u32;} u;
 	u.u32 = eeprom_read_dword((const uint32_t *)addr);
 	return u.f;
 }
-static inline void eeprom_write_float(float *addr, float value) __attribute__((always_inline, unused));
-static inline void eeprom_write_float(float *addr, float value)
+STATIC_INLINE void eeprom_write_float(float *addr, float value) __attribute__((always_inline, unused));
+STATIC_INLINE void eeprom_write_float(float *addr, float value)
 {
 	union {float f; uint32_t u32;} u;
 	u.f = value;
 	eeprom_write_dword((uint32_t *)addr, u.u32);
 }
-static inline void eeprom_update_byte(uint8_t *addr, uint8_t value) __attribute__((always_inline, unused));
-static inline void eeprom_update_byte(uint8_t *addr, uint8_t value)
+STATIC_INLINE void eeprom_update_byte(uint8_t *addr, uint8_t value) __attribute__((always_inline, unused));
+STATIC_INLINE void eeprom_update_byte(uint8_t *addr, uint8_t value)
 {
 	eeprom_write_byte(addr, value);
 }
-static inline void eeprom_update_word(uint16_t *addr, uint16_t value) __attribute__((always_inline, unused));
-static inline void eeprom_update_word(uint16_t *addr, uint16_t value)
+STATIC_INLINE void eeprom_update_word(uint16_t *addr, uint16_t value) __attribute__((always_inline, unused));
+STATIC_INLINE void eeprom_update_word(uint16_t *addr, uint16_t value)
 {
 	eeprom_write_word(addr, value);
 }
-static inline void eeprom_update_dword(uint32_t *addr, uint32_t value) __attribute__((always_inline, unused));
-static inline void eeprom_update_dword(uint32_t *addr, uint32_t value)
+STATIC_INLINE void eeprom_update_dword(uint32_t *addr, uint32_t value) __attribute__((always_inline, unused));
+STATIC_INLINE void eeprom_update_dword(uint32_t *addr, uint32_t value)
 {
 	eeprom_write_dword(addr, value);
 }
-static inline void eeprom_update_float(float *addr, float value) __attribute__((always_inline, unused));
-static inline void eeprom_update_float(float *addr, float value)
+STATIC_INLINE void eeprom_update_float(float *addr, float value) __attribute__((always_inline, unused));
+STATIC_INLINE void eeprom_update_float(float *addr, float value)
 {
 	union {float f; uint32_t u32;} u;
 	u.f = value;
 	eeprom_write_dword((uint32_t *)addr, u.u32);
 }
-static inline void eeprom_update_block(const void *buf, void *addr, uint32_t len) __attribute__((always_inline, unused));
-static inline void eeprom_update_block(const void *buf, void *addr, uint32_t len)
+STATIC_INLINE void eeprom_update_block(const void *buf, void *addr, uint32_t len) __attribute__((always_inline, unused));
+STATIC_INLINE void eeprom_update_block(const void *buf, void *addr, uint32_t len)
 {
 	eeprom_write_block(buf, addr, len);
 }
@@ -100,10 +105,10 @@ char * ulltoa(unsigned long long val, char *buf, int radix);
 char * lltoa(long long val, char *buf, int radix);
 
 /* #if defined(__STRICT_ANSI__) || (defined(_NEWLIB_VERSION) && (__NEWLIB__ < 2 || __NEWLIB__ == 2 && __NEWLIB_MINOR__ < 2))
-static inline char * utoa(unsigned int val, char *buf, int radix) __attribute__((always_inline, unused));
-static inline char * utoa(unsigned int val, char *buf, int radix) { return ultoa(val, buf, radix); }
-static inline char * itoa(int val, char *buf, int radix) __attribute__((always_inline, unused));
-static inline char * itoa(int val, char *buf, int radix) { return ltoa(val, buf, radix); }
+STATIC_INLINE char * utoa(unsigned int val, char *buf, int radix) __attribute__((always_inline, unused));
+STATIC_INLINE char * utoa(unsigned int val, char *buf, int radix) { return ultoa(val, buf, radix); }
+STATIC_INLINE char * itoa(int val, char *buf, int radix) __attribute__((always_inline, unused));
+STATIC_INLINE char * itoa(int val, char *buf, int radix) { return ltoa(val, buf, radix); }
 #endif */
 
 char * dtostrf(float val, int width, unsigned int precision, char *buf);
@@ -112,4 +117,7 @@ char * dtostrf(float val, int width, unsigned int precision, char *buf);
 #ifdef __cplusplus
 }
 #endif
+
+#undef STATIC_INLINE
+
 #endif

--- a/teensy4/core_pins.h
+++ b/teensy4/core_pins.h
@@ -1776,6 +1776,11 @@
 
 #ifdef __cplusplus
 extern "C" {
+// C++ compilers shouldn't use 'static inline' because then there may be more
+// than one copy of the function; 'static' implies internal linkage
+#define STATIC_INLINE inline
+#else
+#define STATIC_INLINE static inline
 #endif
 
 //TODO:
@@ -1787,13 +1792,13 @@ extern "C" {
 // have been configured with pinMode() as either OUTPUT or
 // OUTPUT_OPENDRAIN mode.
 void digitalWrite(uint8_t pin, uint8_t val);
-static inline void digitalWriteFast(uint8_t pin, uint8_t val) __attribute__((always_inline, unused));
+STATIC_INLINE void digitalWriteFast(uint8_t pin, uint8_t val) __attribute__((always_inline, unused));
 // Cause a digital pin to output either HIGH or LOW.  The pin must
 // have been configured with pinMode().  This fast version of
 // digitalWrite has minimal overhead when the pin number is a
 // constant.  Successive digitalWriteFast without delays can be
 // too quick in many applications!
-static inline void digitalWriteFast(uint8_t pin, uint8_t val)
+STATIC_INLINE void digitalWriteFast(uint8_t pin, uint8_t val)
 {
 	if (__builtin_constant_p(pin)) {
 		if (val) {
@@ -2039,12 +2044,12 @@ static inline void digitalWriteFast(uint8_t pin, uint8_t val)
 // configured with pinMode() as INPUT, INPUT_PULLUP, or INPUT_PULLDOWN.
 // The return value is either HIGH or LOW.
 uint8_t digitalRead(uint8_t pin);
-static inline uint8_t digitalReadFast(uint8_t pin) __attribute__((always_inline, unused));
+STATIC_INLINE uint8_t digitalReadFast(uint8_t pin) __attribute__((always_inline, unused));
 // Read the signal at a digital pin.  The pin must have previously been
 // configured with pinMode() as INPUT, INPUT_PULLUP, or INPUT_PULLDOWN.  The
 // return value is either HIGH or LOW.  This fast version of digitalRead()
 // has minimal overhead when the pin number is a constant.
-static inline uint8_t digitalReadFast(uint8_t pin)
+STATIC_INLINE uint8_t digitalReadFast(uint8_t pin)
 {
 	if (__builtin_constant_p(pin)) {
 		if (pin == 0) {
@@ -2175,12 +2180,12 @@ static inline uint8_t digitalReadFast(uint8_t pin)
 // the pin outputs LOW, and if it was LOW the pin outputs HIGH.  The
 // pin must have been configured to OUTPUT mode with pinMode().
 void digitalToggle(uint8_t pin);
-static inline void digitalToggleFast(uint8_t pin) __attribute__((always_inline, unused));
+STATIC_INLINE void digitalToggleFast(uint8_t pin) __attribute__((always_inline, unused));
 // Cause a digital pin's output to change state.  This fast version
 // of digitalToggle() has minimal overhead when the pin number is a
 // constant.  Without additional delay, successive digitalToggleFast()
 // can cause the pin to oscillate too quickly for many applications.
-static inline void digitalToggleFast(uint8_t pin)
+STATIC_INLINE void digitalToggleFast(uint8_t pin)
 {
 	if (__builtin_constant_p(pin)) {
 		if (pin == 0) {
@@ -2321,7 +2326,7 @@ uint32_t analogWriteRes(uint32_t bits);
 // resolution, allowing you to temporarily change resolution, call analogWrite()
 // and then restore the resolution, so other code or libraries using analogWrite()
 // are not impacted.
-static inline uint32_t analogWriteResolution(uint32_t bits) { return analogWriteRes(bits); }
+STATIC_INLINE uint32_t analogWriteResolution(uint32_t bits) { return analogWriteRes(bits); }
 // Configure the PWM carrier frequency used by a specific PWM pin.  The frequency
 // is a floating point number, so you are not limited to integer frequency.  You can
 // have 261.63 Hz (musical note C4), if you like.  analogWriteFrequency() should
@@ -2349,7 +2354,7 @@ int analogRead(uint8_t pin);
 void analogReference(uint8_t type);
 void analogReadRes(unsigned int bits);
 // Configure the number of bits resolution returned by analogRead().
-static inline void analogReadResolution(unsigned int bits) { analogReadRes(bits); }
+STATIC_INLINE void analogReadResolution(unsigned int bits) { analogReadRes(bits); }
 // Configure the number readings used (and averaged) internally when reading analog
 // voltage with analogRead().  Possible configurations are 1, 4, 8, 16, 32.  More
 // readings averaged gives better results, but takes longer.
@@ -2372,12 +2377,12 @@ void IMXRTfuseReload();
 
 // Transmit 8 bits to a shift register connected to 2 digital pins.  bitOrder
 // may be MSBFIRST or LSBFIRST.
-static inline void shiftOut(uint8_t, uint8_t, uint8_t, uint8_t) __attribute__((always_inline, unused));
+STATIC_INLINE void shiftOut(uint8_t, uint8_t, uint8_t, uint8_t) __attribute__((always_inline, unused));
 extern void _shiftOut(uint8_t dataPin, uint8_t clockPin, uint8_t bitOrder, uint8_t value) __attribute__((noinline));
 extern void shiftOut_lsbFirst(uint8_t dataPin, uint8_t clockPin, uint8_t value) __attribute__((noinline));
 extern void shiftOut_msbFirst(uint8_t dataPin, uint8_t clockPin, uint8_t value) __attribute__((noinline));
 
-static inline void shiftOut(uint8_t dataPin, uint8_t clockPin, uint8_t bitOrder, uint8_t value)
+STATIC_INLINE void shiftOut(uint8_t dataPin, uint8_t clockPin, uint8_t bitOrder, uint8_t value)
 {
         if (__builtin_constant_p(bitOrder)) {
                 if (bitOrder == LSBFIRST) {
@@ -2392,12 +2397,12 @@ static inline void shiftOut(uint8_t dataPin, uint8_t clockPin, uint8_t bitOrder,
 
 // Receive 8 bits from a shift register connected to 2 digital pins.  bitOrder
 // may be MSBFIRST or LSBFIRST.
-static inline uint8_t shiftIn(uint8_t, uint8_t, uint8_t) __attribute__((always_inline, unused));
+STATIC_INLINE uint8_t shiftIn(uint8_t, uint8_t, uint8_t) __attribute__((always_inline, unused));
 extern uint8_t _shiftIn(uint8_t dataPin, uint8_t clockPin, uint8_t bitOrder) __attribute__((noinline));
 extern uint8_t shiftIn_lsbFirst(uint8_t dataPin, uint8_t clockPin) __attribute__((noinline));
 extern uint8_t shiftIn_msbFirst(uint8_t dataPin, uint8_t clockPin) __attribute__((noinline));
 
-static inline uint8_t shiftIn(uint8_t dataPin, uint8_t clockPin, uint8_t bitOrder)
+STATIC_INLINE uint8_t shiftIn(uint8_t dataPin, uint8_t clockPin, uint8_t bitOrder)
 {
         if (__builtin_constant_p(bitOrder)) {
                 if (bitOrder == LSBFIRST) {
@@ -2433,22 +2438,22 @@ extern volatile uint32_t F_BUS_ACTUAL;
 extern volatile uint32_t scale_cpu_cycles_to_microseconds;
 extern volatile uint32_t systick_millis_count;
 
-static inline uint32_t millis(void) __attribute__((always_inline, unused));
+STATIC_INLINE uint32_t millis(void) __attribute__((always_inline, unused));
 // Returns the number of milliseconds since your program started running.
 // This 32 bit number will roll back to zero after about 49.7 days.  For a
 // simpler way to build delays or timeouts, consider using elapsedMillis.
-static inline uint32_t millis(void)
+STATIC_INLINE uint32_t millis(void)
 {
 	return systick_millis_count;
 }
 
 uint32_t micros(void);
 
-static inline void delayMicroseconds(uint32_t) __attribute__((always_inline, unused));
+STATIC_INLINE void delayMicroseconds(uint32_t) __attribute__((always_inline, unused));
 // Wait for a number of microseconds.  During this time, interrupts remain
 // active, but the rest of your program becomes effectively stalled.  For shorter
 // delay, use delayNanoseconds().
-static inline void delayMicroseconds(uint32_t usec)
+STATIC_INLINE void delayMicroseconds(uint32_t usec)
 {
 	uint32_t begin = ARM_DWT_CYCCNT;
 	uint32_t cycles = F_CPU_ACTUAL / 1000000 * usec;
@@ -2456,10 +2461,10 @@ static inline void delayMicroseconds(uint32_t usec)
 	while (ARM_DWT_CYCCNT - begin < cycles) ; // wait
 }
 
-static inline void delayNanoseconds(uint32_t) __attribute__((always_inline, unused));
+STATIC_INLINE void delayNanoseconds(uint32_t) __attribute__((always_inline, unused));
 // Wait for a number of nanoseconds.  During this time, interrupts remain
 // active, but the rest of your program becomes effectively stalled.
-static inline void delayNanoseconds(uint32_t nsec)
+STATIC_INLINE void delayNanoseconds(uint32_t nsec)
 {
 	uint32_t begin = ARM_DWT_CYCCNT;
 	uint32_t cycles =   ((F_CPU_ACTUAL>>16) * nsec) / (1000000000UL>>16);
@@ -2509,6 +2514,4 @@ extern teensy3_clock_class Teensy3Clock;
 
 #endif // __cplusplus
 
-
-
-
+#undef STATIC_INLINE

--- a/teensy4/imxrt.h
+++ b/teensy4/imxrt.h
@@ -462,8 +462,8 @@ enum IRQ_NUMBER_t {
 
 #ifdef __cplusplus
 extern "C" void (* volatile _VectorsRam[NVIC_NUM_INTERRUPTS+16])(void);
-static inline void attachInterruptVector(IRQ_NUMBER_t irq, void (*function)(void)) __attribute__((always_inline, unused));
-static inline void attachInterruptVector(IRQ_NUMBER_t irq, void (*function)(void)) { _VectorsRam[irq + 16] = function; asm volatile("": : :"memory"); }
+inline void attachInterruptVector(IRQ_NUMBER_t irq, void (*function)(void)) __attribute__((always_inline, unused));
+inline void attachInterruptVector(IRQ_NUMBER_t irq, void (*function)(void)) { _VectorsRam[irq + 16] = function; asm volatile("": : :"memory"); }
 #else
 extern void (* volatile _VectorsRam[NVIC_NUM_INTERRUPTS+16])(void);
 static inline void attachInterruptVector(enum IRQ_NUMBER_t irq, void (*function)(void)) __attribute__((always_inline, unused));

--- a/teensy4/usb_joystick.h
+++ b/teensy4/usb_joystick.h
@@ -107,7 +107,7 @@ class usb_joystick_class
 			| (val << 12) | (val << 22);
 		if (!manual_mode) usb_joystick_send();
 	}
-        inline void hat(int dir) {
+        void hat(int dir) {
                 uint32_t val = 0;
                 if (dir < 0) val = 15;
                 else if (dir < 23) val = 0;
@@ -140,7 +140,7 @@ class usb_joystick_class
 		if (--num >= 17) return;
 		analog16(num + 6, position);
 	}
-        inline void hat(unsigned int num, int angle) {
+        void hat(unsigned int num, int angle) {
 		uint32_t val=15;
 		if (angle > 0 && angle < 23) val = 0;
 		else if (angle < 68) val = 1;

--- a/usb_disk/usb_api.h
+++ b/usb_disk/usb_api.h
@@ -91,25 +91,25 @@ void media_unlock(void);
 class usb_disk_class
 {
 	public:
-	inline void pause(void) {
+	void pause(void) {
 		while (!media_lock()) /* wait */ ;
 	}
-	inline void resume(void) {
+	void resume(void) {
 		media_unlock();
 	}
-	inline void claim(void) {
+	void claim(void) {
 		media_claim();
 	}
-	inline uint8_t readSector(uint32_t addr, uint8_t *buffer) {
+	uint8_t readSector(uint32_t addr, uint8_t *buffer) {
 		return media_read_sector(addr, buffer);
 	}
-	inline uint8_t writeSector(uint32_t addr, const uint8_t *buffer) {
+	uint8_t writeSector(uint32_t addr, const uint8_t *buffer) {
 		return media_write_sector(addr, buffer);
 	}
-	inline void release(void) {
+	void release(void) {
 		media_release(0);
 	}
-	inline void releaseReadOnly(void) {
+	void releaseReadOnly(void) {
 		media_release(1);
 	}
 };

--- a/usb_hid/usb_api.h
+++ b/usb_hid/usb_api.h
@@ -86,7 +86,7 @@ class usb_joystick_class
 {
 	public:
 	usb_joystick_class() { manual_mode = 0; }
-	inline void button(uint8_t button, bool val) {
+	void button(uint8_t button, bool val) {
 		button--;
 		uint8_t mask = (1 << (button & 7));
 		if (val) {
@@ -103,19 +103,19 @@ class usb_joystick_class
 		}
 		if (!manual_mode) send_now();
 	}
-	inline void X(uint16_t val) {
+	void X(uint16_t val) {
 		if (val > 1023) val = 1023;
 		joystick_report_data[4] = (joystick_report_data[4] & 0x0F) | (val << 4);
 		joystick_report_data[5] = (joystick_report_data[5] & 0xC0) | (val >> 4);
 		if (!manual_mode) send_now();
 	}
-	inline void Y(uint16_t val) {
+	void Y(uint16_t val) {
 		if (val > 1023) val = 1023;
 		joystick_report_data[5] = (joystick_report_data[5] & 0x3F) | (val << 6);
 		joystick_report_data[6] = (val >> 2);
 		if (!manual_mode) send_now();
 	}
-	inline void position(uint16_t x, uint16_t y) {
+	void position(uint16_t x, uint16_t y) {
 		if (x > 1023) x = 1023;
 		if (y > 1023) y = 1023;
 		joystick_report_data[4] = (joystick_report_data[4] & 0x0F) | (x << 4);
@@ -123,38 +123,38 @@ class usb_joystick_class
 		joystick_report_data[6] = (y >> 2);
 		if (!manual_mode) send_now();
 	}
-	inline void Z(uint16_t val) {
+	void Z(uint16_t val) {
 		if (val > 1023) val = 1023;
 		joystick_report_data[7] = val;
 		joystick_report_data[8] = (joystick_report_data[8] & 0xFC) | (val >> 8);
 		if (!manual_mode) send_now();
 	}
-	inline void Zrotate(uint16_t val) {
+	void Zrotate(uint16_t val) {
 		if (val > 1023) val = 1023;
 		joystick_report_data[8] = (joystick_report_data[8] & 0x03) | (val << 2);
 		joystick_report_data[9] = (joystick_report_data[9] & 0xF0) | (val >> 6);
 		if (!manual_mode) send_now();
 	}
-	inline void sliderLeft(uint16_t val) {
+	void sliderLeft(uint16_t val) {
 		if (val > 1023) val = 1023;
 		joystick_report_data[9] = (joystick_report_data[9] & 0x0F) | (val << 4);
 		joystick_report_data[10] = (joystick_report_data[10] & 0xC0) | (val >> 4);
 		if (!manual_mode) send_now();
 	}
-	inline void sliderRight(uint16_t val) {
+	void sliderRight(uint16_t val) {
 		if (val > 1023) val = 1023;
 		joystick_report_data[10] = (joystick_report_data[10] & 0x3F) | (val << 6);
 		joystick_report_data[11] = (val >> 2);
 		if (!manual_mode) send_now();
 	}
-	inline void slider(uint16_t val) {
+	void slider(uint16_t val) {
 		if (val > 1023) val = 1023;
 		joystick_report_data[9] = (joystick_report_data[9] & 0x0F) | (val << 4);
 		joystick_report_data[10] = (val >> 4) | (val << 6);
 		joystick_report_data[11] = (val >> 2);
 		if (!manual_mode) send_now();
 	}
-	inline void hat(int16_t dir) {
+	void hat(int16_t dir) {
 		uint8_t val;
 		if (dir < 0) val = 15;
 		else if (dir < 23) val = 0;
@@ -168,7 +168,7 @@ class usb_joystick_class
 		joystick_report_data[4] = (joystick_report_data[4] & 0xF0) | val;
 		if (!manual_mode) send_now();
 	}
-	inline void useManualSend(bool mode) {
+	void useManualSend(bool mode) {
 		manual_mode = mode;
 	}
 	void send_now(void);

--- a/usb_midi/usb_api.h
+++ b/usb_midi/usb_api.h
@@ -173,7 +173,7 @@ public:
 	void send_now(void);
 	uint8_t analog2velocity(uint16_t val, uint8_t range);
 	bool read(uint8_t channel=0);
-	inline uint8_t getType(void) {
+	uint8_t getType(void) {
 		return msg_type;
 	}
 	uint8_t getCable(void) {

--- a/usb_serial_hid/usb_api.h
+++ b/usb_serial_hid/usb_api.h
@@ -114,7 +114,7 @@ class usb_joystick_class
 {
         public:
         usb_joystick_class() { manual_mode = 0; }
-        inline void button(uint8_t button, bool val) {
+        void button(uint8_t button, bool val) {
                 button--;
                 uint8_t mask = (1 << (button & 7));
                 if (val) {
@@ -131,19 +131,19 @@ class usb_joystick_class
                 }
                 if (!manual_mode) send_now();
         }
-        inline void X(uint16_t val) {
+        void X(uint16_t val) {
                 if (val > 1023) val = 1023;
                 joystick_report_data[4] = (joystick_report_data[4] & 0x0F) | (val << 4);
                 joystick_report_data[5] = (joystick_report_data[5] & 0xC0) | (val >> 4);
                 if (!manual_mode) send_now();
         }
-        inline void Y(uint16_t val) {
+        void Y(uint16_t val) {
                 if (val > 1023) val = 1023;
                 joystick_report_data[5] = (joystick_report_data[5] & 0x3F) | (val << 6);
                 joystick_report_data[6] = (val >> 2);
                 if (!manual_mode) send_now();
         }
-        inline void position(uint16_t x, uint16_t y) {
+        void position(uint16_t x, uint16_t y) {
                 if (x > 1023) x = 1023;
                 if (y > 1023) y = 1023;
                 joystick_report_data[4] = (joystick_report_data[4] & 0x0F) | (x << 4);
@@ -151,38 +151,38 @@ class usb_joystick_class
                 joystick_report_data[6] = (y >> 2);
                 if (!manual_mode) send_now();
         }
-        inline void Z(uint16_t val) {
+        void Z(uint16_t val) {
                 if (val > 1023) val = 1023;
                 joystick_report_data[7] = val;
                 joystick_report_data[8] = (joystick_report_data[8] & 0xFC) | (val >> 8);
                 if (!manual_mode) send_now();
         }
-        inline void Zrotate(uint16_t val) {
+        void Zrotate(uint16_t val) {
                 if (val > 1023) val = 1023;
                 joystick_report_data[8] = (joystick_report_data[8] & 0x03) | (val << 2);
                 joystick_report_data[9] = (joystick_report_data[9] & 0xF0) | (val >> 6);
                 if (!manual_mode) send_now();
         }
-        inline void sliderLeft(uint16_t val) {
+        void sliderLeft(uint16_t val) {
                 if (val > 1023) val = 1023;
                 joystick_report_data[9] = (joystick_report_data[9] & 0x0F) | (val << 4);
                 joystick_report_data[10] = (joystick_report_data[10] & 0xC0) | (val >> 4);
                 if (!manual_mode) send_now();
         }
-        inline void sliderRight(uint16_t val) {
+        void sliderRight(uint16_t val) {
                 if (val > 1023) val = 1023;
                 joystick_report_data[10] = (joystick_report_data[10] & 0x3F) | (val << 6);
                 joystick_report_data[11] = (val >> 2);
                 if (!manual_mode) send_now();
         }
-        inline void slider(uint16_t val) {
+        void slider(uint16_t val) {
                 if (val > 1023) val = 1023;
                 joystick_report_data[9] = (joystick_report_data[9] & 0x0F) | (val << 4);
                 joystick_report_data[10] = (val >> 4) | (val << 6);
                 joystick_report_data[11] = (val >> 2);
                 if (!manual_mode) send_now();
         }
-        inline void hat(int16_t dir) {
+        void hat(int16_t dir) {
                 uint8_t val;
                 if (dir < 0) val = 15;
                 else if (dir < 23) val = 0;
@@ -196,7 +196,7 @@ class usb_joystick_class
                 joystick_report_data[4] = (joystick_report_data[4] & 0xF0) | val;
                 if (!manual_mode) send_now();
         }
-        inline void useManualSend(bool mode) {
+        void useManualSend(bool mode) {
                 manual_mode = mode;
         }
         void send_now(void);


### PR DESCRIPTION
1. When C++, use just `inline` instead of `static inline` for external
   functions, to ensure there's only a single copy of those functions.
   In other words, make these definitions have external linkage. This
   improvement also lets functions that are intended to have external
   linkage, such as `millis()`, be used as template arguments without
   complaints about anonymous namespaces or internal linkage.
2. Keep `static inline` for C-only functions and when there wasn't a
   check for `__cppreference` in the file.
3. Remove `inline` for functions declared or defined within a class
   declaration. Those are implicitly "inline".

The problem this solves is that it ensures there's only one linked
version of a function instead of multiple copies of that function.
This will save a little space.
    
Note that this change only affects the headers. It's possible for
a header to be included in more than one translation unit, meaning
that if a function has its definition in a header, there will be
duplicate copies of that function. Here's where `static` and `inline`
come in.
    
The `static` part means "internal linkage", where the function may be
included in several compiled object files and linked without conflict.
'inline' in modern C++ came to mean "multiple definitions are allowed"
(as long as they're the same), which can happen if functions are
defined in a header that's included in more than one translation unit.
If just `inline` without `static` is used, then a potentially-
conflicting multiply-defined function is okay and the linker will
choose one of them.
    
One example is the `millis()` function. It's declared `static inline`
and therefore will likely have multiple copies in the final binary.
Note that optimization settings may change this, but regardless, by
being declared `static`, the function has "internal linkage", so there
is effectively one copy per object file.

More information can be found here:
https://en.cppreference.com/w/cpp/language/inline.html

For the functions also accessed from C, it's still appropriate to keep
the `static inline`. More information can be found here:
https://en.cppreference.com/w/c/language/inline.html