### PR TITLE
Update feedback_accumulator calculation for audio to use AUDIO_SAMPLE_RATE_EXACT

### DIFF
--- a/teensy4/usb_audio.cpp
+++ b/teensy4/usb_audio.cpp
@@ -94,7 +94,7 @@ void usb_audio_configure(void)
 	printf("usb_audio_configure\n");
 	usb_audio_underrun_count = 0;
 	usb_audio_overrun_count = 0;
-	feedback_accumulator = 739875226; // 44.1 * 2^24
+	feedback_accumulator = (uint32_t)((AUDIO_SAMPLE_RATE_EXACT / 1000.0f) * 16777216.0f); // 44.1 * 2^24
 	if (usb_high_speed) {
 		usb_audio_sync_nbytes = 4;
 		usb_audio_sync_rshift = 8;


### PR DESCRIPTION
I found this formula was mentioning 44.1 kHz which could be improved by referencing the exact variable. With this change, `feedback_accumulator` value is more dynamic and respects changes to AUDIO_SAMPLE_RATE_EXACT.

Note I only am updating Teensy 4 version. I don't know the formula used for Teensy 3 version; I am not sure of the formula for this and how 185042824 was determined.