### PR TITLE
Fix USB MIDI sendStop() to send 0xFC instead of 0xFB

### DIFF
--- a/teensy3/usb_midi.h
+++ b/teensy3/usb_midi.h
@@ -199,7 +199,7 @@ class usb_midi_class
 		sendRealTime(0xFA, cable);
 	}
 	void sendStop(uint8_t cable=0) {
-		sendRealTime(0xFB, cable);
+		sendRealTime(0xFC, cable);
 	}
 	void sendTick(uint8_t cable=0) {
 		sendRealTime(0xF9, cable);

--- a/teensy4/usb_midi.h
+++ b/teensy4/usb_midi.h
@@ -197,7 +197,7 @@ class usb_midi_class
 		sendRealTime(0xFA, cable);
 	}
 	void sendStop(uint8_t cable=0) {
-		sendRealTime(0xFB, cable);
+		sendRealTime(0xFC, cable);
 	}
 	void sendTick(uint8_t cable=0) {
 		sendRealTime(0xF9, cable);

--- a/usb_midi/usb_api.h
+++ b/usb_midi/usb_api.h
@@ -94,7 +94,7 @@ public:
 		sendRealTime(0xFA, cable);
 	}
 	void sendStop(uint8_t cable=0) {
-		sendRealTime(0xFB, cable);
+		sendRealTime(0xFC, cable);
 	}
 	void sendTick(uint8_t cable=0) {
 		sendRealTime(0xF9, cable);


### PR DESCRIPTION
This fixes a typo in the USB MIDI implementation.

`sendStop()` currently calls `sendRealTime(0xFB, cable)`, but `0xFB` is MIDI Continue. 
MIDI Stop should be `0xFC`.

This patch updates `sendStop()` to send `0xFC`, which also matches the existing real-time enum/switch definitions elsewhere in the implementation.

Files changed:
- teensy3/usb_midi.h
- teensy4/usb_midi.h
- usb_midi/usb_api.h