### PR TITLE
teensy4: add capture-side USB Audio Feature Unit (mute/volume) for recording devices

### DIFF
--- a/teensy4/usb_audio.cpp
+++ b/teensy4/usb_audio.cpp
@@ -44,6 +44,11 @@ uint16_t AudioInputUSB::incoming_count;
 uint8_t AudioInputUSB::receive_flag;
 
 struct usb_audio_features_struct AudioInputUSB::features = {0,0,FEATURE_MAX_VOLUME/2};
+struct usb_audio_features_struct AudioOutputUSB::features = {0,0,FEATURE_MAX_VOLUME/2};
+
+// Feature Unit IDs in usb_desc.c. Keep in sync with the AudioControl topology.
+#define USB_AUDIO_CAPTURE_FEATURE_UNIT_ID  0x30  // device -> host (Windows recording slider)
+#define USB_AUDIO_PLAYBACK_FEATURE_UNIT_ID 0x31  // host -> device (Windows speakers slider)
 
 extern volatile uint8_t usb_high_speed;
 static void rx_event(transfer_t *t);
@@ -461,19 +466,33 @@ struct setup_struct {
   };
 };
 
+// Pick the right feature struct based on which Feature Unit the host is
+// addressing. The high byte of wIndex carries the Entity ID; the low byte
+// is the AudioControl interface number.
+//   FU 0x31 -> playback path  (host -> device, AudioInputUSB pulls audio in)
+//   FU 0x30 -> capture path   (device -> host, AudioOutputUSB sends audio out)
+static struct usb_audio_features_struct *usb_audio_features_for_entity(uint8_t entity_id)
+{
+	if (entity_id == USB_AUDIO_PLAYBACK_FEATURE_UNIT_ID) return &AudioInputUSB::features;
+	if (entity_id == USB_AUDIO_CAPTURE_FEATURE_UNIT_ID)  return &AudioOutputUSB::features;
+	return 0;
+}
+
 int usb_audio_get_feature(void *stp, uint8_t *data, uint32_t *datalen)
 {
 	struct setup_struct setup = *((struct setup_struct *)stp);
 	if (setup.bmRequestType==0xA1) { // should check bRequest, bChannel, and UnitID
+			struct usb_audio_features_struct *f = usb_audio_features_for_entity(setup.bEntityId);
+			if (f == 0) return 0;
 			if (setup.bCS==0x01) { // mute
-				data[0] = AudioInputUSB::features.mute;  // 1=mute, 0=unmute
+				data[0] = f->mute;  // 1=mute, 0=unmute
 				*datalen = 1;
 				return 1;
 			}
 			else if (setup.bCS==0x02) { // volume
 				if (setup.bRequest==0x81) { // GET_CURR
-					data[0] = AudioInputUSB::features.volume & 0xFF;
-					data[1] = (AudioInputUSB::features.volume>>8) & 0xFF;
+					data[0] = f->volume & 0xFF;
+					data[1] = (f->volume>>8) & 0xFF;
 				}
 				else if (setup.bRequest==0x82) { // GET_MIN
 					//serial_print("vol get_min\n");
@@ -498,21 +517,23 @@ int usb_audio_get_feature(void *stp, uint8_t *data, uint32_t *datalen)
 	return 0;
 }
 
-int usb_audio_set_feature(void *stp, uint8_t *buf) 
+int usb_audio_set_feature(void *stp, uint8_t *buf)
 {
 	struct setup_struct setup = *((struct setup_struct *)stp);
 	if (setup.bmRequestType==0x21) { // should check bRequest, bChannel and UnitID
+			struct usb_audio_features_struct *f = usb_audio_features_for_entity(setup.bEntityId);
+			if (f == 0) return 0;
 			if (setup.bCS==0x01) { // mute
 				if (setup.bRequest==0x01) { // SET_CUR
-					AudioInputUSB::features.mute = buf[0]; // 1=mute,0=unmute
-					AudioInputUSB::features.change = 1;
+					f->mute = buf[0]; // 1=mute,0=unmute
+					f->change = 1;
 					return 1;
 				}
 			}
 			else if (setup.bCS==0x02) { // volume
 				if (setup.bRequest==0x01) { // SET_CUR
-					AudioInputUSB::features.volume = buf[0];
-					AudioInputUSB::features.change = 1;
+					f->volume = buf[0];
+					f->change = 1;
 					return 1;
 				}
 			}

--- a/teensy4/usb_audio.h
+++ b/teensy4/usb_audio.h
@@ -76,6 +76,7 @@ public:
 		if (features.mute) return 0.0;
 		return (float)(features.volume) * (1.0 / (float)FEATURE_MAX_VOLUME);
 	}
+	bool mute(void) { return features.mute != 0; }
 private:
 	static bool update_responsibility;
 	static audio_block_t *incoming_left;
@@ -93,6 +94,19 @@ public:
 	virtual void update(void);
 	void begin(void);
 	friend unsigned int usb_audio_transmit_callback(void);
+	friend int usb_audio_set_feature(void *stp, uint8_t *buf);
+	friend int usb_audio_get_feature(void *stp, uint8_t *data, uint32_t *datalen);
+	// Capture-side feature unit (USB FU 0x30) controls. The host writes
+	// these via SET_CUR on the AudioControl interface — e.g. the Windows
+	// recording-device volume slider — and the sketch reads them here to
+	// scale the audio it sends to the host (typical use: a listenback /
+	// monitor mix where Windows still owns the level).
+	static struct usb_audio_features_struct features;
+	float volume(void) {
+		if (features.mute) return 0.0;
+		return (float)(features.volume) * (1.0 / (float)FEATURE_MAX_VOLUME);
+	}
+	bool mute(void) { return features.mute != 0; }
 private:
 	static bool update_responsibility;
 	static audio_block_t *left_1st;

--- a/teensy4/usb_desc.c
+++ b/teensy4/usb_desc.c
@@ -649,7 +649,7 @@ static uint8_t microsoft_os_compatible_id_desc[] = {
 
 #define AUDIO_INTERFACE_DESC_POS	KEYMEDIA_INTERFACE_DESC_POS+KEYMEDIA_INTERFACE_DESC_SIZE
 #ifdef  AUDIO_INTERFACE
-#define AUDIO_INTERFACE_DESC_SIZE	8 + 9+10+12+9+12+10+9 + 9+9+7+11+9+7 + 9+9+7+11+9+7+9
+#define AUDIO_INTERFACE_DESC_SIZE	8 + 9+10+12+10+9+12+10+9 + 9+9+7+11+9+7 + 9+9+7+11+9+7+9
 #else
 #define AUDIO_INTERFACE_DESC_SIZE	0
 #endif
@@ -1443,7 +1443,7 @@ PROGMEM const uint8_t usb_config_descriptor_480[CONFIG_DESC_SIZE] = {
 	0x24,					// bDescriptorType, 0x24 = CS_INTERFACE
 	0x01,					// bDescriptorSubtype, 1 = HEADER
 	0x00, 0x01,				// bcdADC (version 1.0)
-	LSB(62), MSB(62),			// wTotalLength
+	LSB(72), MSB(72),			// wTotalLength
 	2,					// bInCollection
 	AUDIO_INTERFACE+1,			// baInterfaceNr(1) - Transmit to PC
 	AUDIO_INTERFACE+2,			// baInterfaceNr(2) - Receive from PC
@@ -1461,6 +1461,19 @@ PROGMEM const uint8_t usb_config_descriptor_480[CONFIG_DESC_SIZE] = {
 	0x03, 0x00,				// wChannelConfig, 0x0003 = Left & Right Front
 	0,					// iChannelNames
 	0, 					// iTerminal
+	// Volume feature descriptor (capture path: IT1 -> FU 0x30 -> OT2)
+	// Lets the host (e.g. Windows recording-device slider) control mute/volume
+	// applied to audio sent from the device to the host.
+	10,					// bLength
+	0x24, 				// bDescriptorType = CS_INTERFACE
+	0x06, 				// bDescriptorSubType = FEATURE_UNIT
+	0x30, 				// bUnitID
+	0x01, 				// bSourceID (Input Terminal, ID=1)
+	0x01, 				// bControlSize (each channel is 1 byte, 3 channels)
+	0x01, 				// bmaControls(0) Master: Mute
+	0x02, 				// bmaControls(1) Left: Volume
+	0x02, 				// bmaControls(2) Right: Volume
+	0x00,				// iFeature
 	// Output Terminal Descriptor
 	// USB DCD for Audio Devices 1.0, Table 4-4, page 40
 	9,					// bLength
@@ -1469,7 +1482,7 @@ PROGMEM const uint8_t usb_config_descriptor_480[CONFIG_DESC_SIZE] = {
 	2,					// bTerminalID
 	0x01, 0x01,				// wTerminalType, 0x0101 = USB_STREAMING
 	0,					// bAssocTerminal, 0 = unidirectional
-	1,					// bCSourceID, connected to input terminal, ID=1
+	0x30,					// bCSourceID, connected to capture feature unit, ID=0x30
 	0,					// iTerminal
 	// Input Terminal Descriptor
 	// USB DCD for Audio Devices 1.0, Table 4-3, page 39
@@ -1483,12 +1496,12 @@ PROGMEM const uint8_t usb_config_descriptor_480[CONFIG_DESC_SIZE] = {
 	0x03, 0x00,				// wChannelConfig, 0x0003 = Left & Right Front
 	0,					// iChannelNames
 	0, 					// iTerminal
-	// Volume feature descriptor
+	// Volume feature descriptor (playback path: IT3 -> FU 0x31 -> OT4)
 	10,					// bLength
 	0x24, 				// bDescriptorType = CS_INTERFACE
 	0x06, 				// bDescriptorSubType = FEATURE_UNIT
 	0x31, 				// bUnitID
-	0x03, 				// bSourceID (Input Terminal)
+	0x03, 				// bSourceID (Input Terminal, ID=3)
 	0x01, 				// bControlSize (each channel is 1 byte, 3 channels)
 	0x01, 				// bmaControls(0) Master: Mute
 	0x02, 				// bmaControls(1) Left: Volume
@@ -2457,7 +2470,7 @@ PROGMEM const uint8_t usb_config_descriptor_12[CONFIG_DESC_SIZE] = {
 	0x24,					// bDescriptorType, 0x24 = CS_INTERFACE
 	0x01,					// bDescriptorSubtype, 1 = HEADER
 	0x00, 0x01,				// bcdADC (version 1.0)
-	LSB(62), MSB(62),			// wTotalLength
+	LSB(72), MSB(72),			// wTotalLength
 	2,					// bInCollection
 	AUDIO_INTERFACE+1,			// baInterfaceNr(1) - Transmit to PC
 	AUDIO_INTERFACE+2,			// baInterfaceNr(2) - Receive from PC
@@ -2475,6 +2488,19 @@ PROGMEM const uint8_t usb_config_descriptor_12[CONFIG_DESC_SIZE] = {
 	0x03, 0x00,				// wChannelConfig, 0x0003 = Left & Right Front
 	0,					// iChannelNames
 	0, 					// iTerminal
+	// Volume feature descriptor (capture path: IT1 -> FU 0x30 -> OT2)
+	// Lets the host (e.g. Windows recording-device slider) control mute/volume
+	// applied to audio sent from the device to the host.
+	10,					// bLength
+	0x24, 				// bDescriptorType = CS_INTERFACE
+	0x06, 				// bDescriptorSubType = FEATURE_UNIT
+	0x30, 				// bUnitID
+	0x01, 				// bSourceID (Input Terminal, ID=1)
+	0x01, 				// bControlSize (each channel is 1 byte, 3 channels)
+	0x01, 				// bmaControls(0) Master: Mute
+	0x02, 				// bmaControls(1) Left: Volume
+	0x02, 				// bmaControls(2) Right: Volume
+	0x00,				// iFeature
 	// Output Terminal Descriptor
 	// USB DCD for Audio Devices 1.0, Table 4-4, page 40
 	9,					// bLength
@@ -2483,7 +2509,7 @@ PROGMEM const uint8_t usb_config_descriptor_12[CONFIG_DESC_SIZE] = {
 	2,					// bTerminalID
 	0x01, 0x01,				// wTerminalType, 0x0101 = USB_STREAMING
 	0,					// bAssocTerminal, 0 = unidirectional
-	1,					// bCSourceID, connected to input terminal, ID=1
+	0x30,					// bCSourceID, connected to capture feature unit, ID=0x30
 	0,					// iTerminal
 	// Input Terminal Descriptor
 	// USB DCD for Audio Devices 1.0, Table 4-3, page 39
@@ -2497,12 +2523,12 @@ PROGMEM const uint8_t usb_config_descriptor_12[CONFIG_DESC_SIZE] = {
 	0x03, 0x00,				// wChannelConfig, 0x0003 = Left & Right Front
 	0,					// iChannelNames
 	0, 					// iTerminal
-	// Volume feature descriptor
+	// Volume feature descriptor (playback path: IT3 -> FU 0x31 -> OT4)
 	10,					// bLength
 	0x24, 				// bDescriptorType = CS_INTERFACE
 	0x06, 				// bDescriptorSubType = FEATURE_UNIT
 	0x31, 				// bUnitID
-	0x03, 				// bSourceID (Input Terminal)
+	0x03, 				// bSourceID (Input Terminal, ID=3)
 	0x01, 				// bControlSize (each channel is 1 byte, 3 channels)
 	0x01, 				// bmaControls(0) Master: Mute
 	0x02, 				// bmaControls(1) Left: Volume


### PR DESCRIPTION
## Summary

Adds a USB Audio Class 1.0 Feature Unit on the device-to-host (capture/recording) path so the host OS can control mute and volume on audio the Teensy sends. Previously the AudioControl descriptor only had a Feature Unit on the playback path (FU 0x31), so the host never exposed a recording-device volume slider — the Microphone level control in Windows Sound Settings had nothing to bind to.

**Topology after the patch:**
```
capture:   IT1 → FU 0x30 → OT2    ← new
playback:  IT3 → FU 0x31 → OT4    ← unchanged
```

## Changes

### `usb_desc.c`
- Insert a 10-byte `FEATURE_UNIT` descriptor block (ID 0x30: master mute + L/R volume) between Input Terminal 1 and Output Terminal 2 on the capture path
- Retarget OT2 `bCSourceID` from IT1 (0x01) to FU 0x30
- Bump AC header `wTotalLength` from 62 to 72
- Bump `AUDIO_INTERFACE_DESC_SIZE` to account for the new block
- Both high-speed (480 Mbps) and full-speed (12 Mbps) descriptor copies are updated

### `usb_audio.h`
- Add `static struct usb_audio_features_struct features` to `AudioOutputUSB`, mirroring the existing `AudioInputUSB::features`
- Add `volume()` and `mute()` accessors to `AudioOutputUSB`
- Add `mute()` accessor to `AudioInputUSB` for parity (the data was already there — `volume()` reads `features.mute` internally but there was no standalone accessor)
- Add `friend` declarations for `usb_audio_set_feature`/`usb_audio_get_feature` to `AudioOutputUSB`

### `usb_audio.cpp`
- Define `AudioOutputUSB::features` (initialized to same defaults as `AudioInputUSB::features`)
- Add `usb_audio_features_for_entity()` helper that routes by the Entity ID in the `wIndex` high byte:
  - FU 0x31 → `AudioInputUSB::features` (playback, unchanged behavior)
  - FU 0x30 → `AudioOutputUSB::features` (capture, new)
- Replace hardcoded `AudioInputUSB::features` references in `usb_audio_set_feature()` and `usb_audio_get_feature()` with the entity-routed pointer

## Usage

```cpp
// Playback volume (existing PJRC API — host speakers/output slider):
float playVol = usbIn.volume();   // 0.0–1.0, returns 0.0 when muted

// Capture volume (new — host recording/microphone slider):
float capVol  = usbOut.volume();  // 0.0–1.0, returns 0.0 when muted
bool  capMute = usbOut.mute();

// Or via the struct for separate volume/mute tracking:
int rawVol  = AudioOutputUSB::features.volume;  // 0 to 255
int rawMute = AudioOutputUSB::features.mute;    // 0 or 1
```

## Notes

- No changes to `usb.c` — the existing `word1` match in the control-endpoint dispatcher deliberately ignores `wIndex`, so SET_CUR requests to either Feature Unit already fall through into `usb_audio_set_feature()`, which now disambiguates by entity ID.
- The core does **not** auto-apply capture volume to the transmit path. The sketch decides how to use the value (same pattern as the existing playback-side `AudioInputUSB::volume()`).
- `bcdDevice` is not bumped (it's used for board identification by `teensy_ports`). Windows re-enumerates on descriptor-length change; if it caches stale topology, unplug/replug clears it.
- Tested on Teensy 4.1, Windows 11 — recording-device slider in Sound Settings correctly drives `AudioOutputUSB::features`.