### PR TITLE
Add USB MIDI 2.0 device descriptors for Teensy 4.x

### DIFF
--- a/teensy4/usb.c
+++ b/teensy4/usb.c
@@ -568,6 +568,18 @@ static void endpoint0_setup(uint64_t setupdata)
 #endif
 	  case 0x0680: // GET_DESCRIPTOR
 	  case 0x0681:
+#ifdef MIDI2_HAS_DESCRIPTORS
+		// MIDI 2.0 Group Terminal Block descriptor
+		if ((setup.wValue >> 8) == 0x26 && setup.wIndex == MIDI_INTERFACE) {
+			extern const uint8_t midi2_gtb_descriptor[];
+			uint32_t datalen = 5 + 13 * MIDI2_NUM_GROUPS;
+			if (datalen > setup.wLength) datalen = setup.wLength;
+			memcpy(usb_descriptor_buffer, midi2_gtb_descriptor, datalen);
+			arm_dcache_flush_delete(usb_descriptor_buffer, datalen);
+			endpoint0_transmit(usb_descriptor_buffer, datalen, 0);
+			return;
+		}
+#endif
 		for (list = usb_descriptor_list; list->addr != NULL; list++) {
 			if (setup.wValue == list->wValue && setup.wIndex == list->wIndex) {
 				uint32_t datalen;
@@ -640,6 +652,26 @@ static void endpoint0_setup(uint64_t setupdata)
 			endpoint0_setupdata.bothwords = setup.bothwords;
 			endpoint0_buffer[0] = 0xE9;
 			endpoint0_receive(endpoint0_buffer, setup.wLength, 1);
+			return;
+		}
+		break;
+#endif
+#ifdef MIDI2_HAS_DESCRIPTORS
+	  case 0x0B01: // SET_INTERFACE (alternate setting)
+		if (setup.wIndex == MIDI_INTERFACE) {
+			extern uint8_t usb_midi2_alt_setting;
+			extern void usb_midi_flush_output(void);
+			usb_midi2_alt_setting = setup.wValue;
+			usb_midi_flush_output();
+			endpoint0_receive(NULL, 0, 0);
+			return;
+		}
+		break;
+	  case 0x0A81: // GET_INTERFACE (alternate setting)
+		if (setup.wIndex == MIDI_INTERFACE) {
+			extern uint8_t usb_midi2_alt_setting;
+			endpoint0_buffer[0] = usb_midi2_alt_setting;
+			endpoint0_transmit(endpoint0_buffer, 1, 0);
 			return;
 		}
 		break;

--- a/teensy4/usb.c
+++ b/teensy4/usb.c
@@ -656,9 +656,13 @@ static void endpoint0_setup(uint64_t setupdata)
 		}
 		break;
 #endif
-#ifdef MIDI2_HAS_DESCRIPTORS
+#if defined(MIDI2_HAS_DESCRIPTORS)
 	  case 0x0B01: // SET_INTERFACE (alternate setting)
 		if (setup.wIndex == MIDI_INTERFACE) {
+			// Only alt 0 (MIDI 1.0 byte stream) and alt 1 (MIDI 2.0
+			// UMP) are defined; any other value stalls (USB 2.0
+			// spec, section 9.4.10).
+			if (setup.wValue > 1) break;
 			extern uint8_t usb_midi2_alt_setting;
 			extern void usb_midi_flush_output(void);
 			usb_midi2_alt_setting = setup.wValue;

--- a/teensy4/usb_desc.c
+++ b/teensy4/usb_desc.c
@@ -579,9 +579,16 @@ static uint8_t microsoft_os_compatible_id_desc[] = {
   #if !defined(MIDI_NUM_CABLES) || MIDI_NUM_CABLES < 1 || MIDI_NUM_CABLES > 16
   #error "MIDI_NUM_CABLES must be defined between 1 to 16"
   #endif
-#define MIDI_INTERFACE_DESC_SIZE	9+7+((6+6+9+9)*MIDI_NUM_CABLES)+(9+4+MIDI_NUM_CABLES)*2
+#ifdef MIDI2_HAS_DESCRIPTORS
+  #define MIDI2_AS1_DESC_SIZE	(9+7+(7+4+MIDI2_NUM_GROUPS)*2)
+  #define MIDI_INTERFACE_DESC_SIZE	9+7+((6+6+9+9)*MIDI_NUM_CABLES)+(9+4+MIDI_NUM_CABLES)*2+MIDI2_AS1_DESC_SIZE
+#else
+  #define MIDI2_AS1_DESC_SIZE	0
+  #define MIDI_INTERFACE_DESC_SIZE	9+7+((6+6+9+9)*MIDI_NUM_CABLES)+(9+4+MIDI_NUM_CABLES)*2
+#endif
 #else
 #define MIDI_INTERFACE_DESC_SIZE	0
+#define MIDI2_AS1_DESC_SIZE	0
 #endif
 
 #define KEYBOARD_INTERFACE_DESC_POS	MIDI_INTERFACE_DESC_POS+MIDI_INTERFACE_DESC_SIZE
@@ -1147,6 +1154,142 @@ PROGMEM const uint8_t usb_config_descriptor_480[CONFIG_DESC_SIZE] = {
   #if MIDI_NUM_CABLES >= 16
         63,
   #endif
+#ifdef MIDI2_HAS_DESCRIPTORS
+	// MIDI 2.0 Alternate Setting 1: UMP native
+	// Interface descriptor (same interface number, alt=1)
+	9,					// bLength
+	4,					// bDescriptorType
+	MIDI_INTERFACE,				// bInterfaceNumber
+	1,					// bAlternateSetting
+	2,					// bNumEndpoints
+	0x01,					// bInterfaceClass (Audio)
+	0x03,					// bInterfaceSubClass (MIDI Streaming)
+	0x00,					// bInterfaceProtocol
+	0,					// iInterface
+	// MS Header CS Interface (bcdMSC = 0x0200)
+	7,					// bLength
+	0x24,					// bDescriptorType = CS_INTERFACE
+	0x01,					// bDescriptorSubtype = MS_HEADER
+	0x00, 0x02,				// bcdMSC = revision 02.00
+	LSB(7+(7+4+MIDI2_NUM_GROUPS)*2),	// wTotalLength
+	MSB(7+(7+4+MIDI2_NUM_GROUPS)*2),
+	// Bulk OUT Endpoint (7 bytes, standard USB -- not Audio 9-byte)
+	7,					// bLength
+	5,					// bDescriptorType = ENDPOINT
+	MIDI2_RX_ENDPOINT,			// bEndpointAddress
+	0x02,					// bmAttributes (bulk)
+	LSB(MIDI2_RX_SIZE_480), MSB(MIDI2_RX_SIZE_480), // wMaxPacketSize
+	0,					// bInterval
+	// CS Endpoint General 2.0
+	4+MIDI2_NUM_GROUPS,			// bLength
+	0x25,					// bDescriptorType = CS_ENDPOINT
+	0x02,					// bDescriptorSubtype = General 2.0
+	MIDI2_NUM_GROUPS,			// bNumGrpTrmBlock
+	1,					// baAssoGrpTrmBlkID[0]
+  #if MIDI2_NUM_GROUPS >= 2
+	2,
+  #endif
+  #if MIDI2_NUM_GROUPS >= 3
+	3,
+  #endif
+  #if MIDI2_NUM_GROUPS >= 4
+	4,
+  #endif
+  #if MIDI2_NUM_GROUPS >= 5
+	5,
+  #endif
+  #if MIDI2_NUM_GROUPS >= 6
+	6,
+  #endif
+  #if MIDI2_NUM_GROUPS >= 7
+	7,
+  #endif
+  #if MIDI2_NUM_GROUPS >= 8
+	8,
+  #endif
+  #if MIDI2_NUM_GROUPS >= 9
+	9,
+  #endif
+  #if MIDI2_NUM_GROUPS >= 10
+	10,
+  #endif
+  #if MIDI2_NUM_GROUPS >= 11
+	11,
+  #endif
+  #if MIDI2_NUM_GROUPS >= 12
+	12,
+  #endif
+  #if MIDI2_NUM_GROUPS >= 13
+	13,
+  #endif
+  #if MIDI2_NUM_GROUPS >= 14
+	14,
+  #endif
+  #if MIDI2_NUM_GROUPS >= 15
+	15,
+  #endif
+  #if MIDI2_NUM_GROUPS >= 16
+	16,
+  #endif
+	// Bulk IN Endpoint (7 bytes)
+	7,					// bLength
+	5,					// bDescriptorType = ENDPOINT
+	MIDI2_TX_ENDPOINT | 0x80,		// bEndpointAddress
+	0x02,					// bmAttributes (bulk)
+	LSB(MIDI2_TX_SIZE_480), MSB(MIDI2_TX_SIZE_480), // wMaxPacketSize
+	0,					// bInterval
+	// CS Endpoint General 2.0
+	4+MIDI2_NUM_GROUPS,			// bLength
+	0x25,					// bDescriptorType = CS_ENDPOINT
+	0x02,					// bDescriptorSubtype = General 2.0
+	MIDI2_NUM_GROUPS,			// bNumGrpTrmBlock
+	1,					// baAssoGrpTrmBlkID[0]
+  #if MIDI2_NUM_GROUPS >= 2
+	2,
+  #endif
+  #if MIDI2_NUM_GROUPS >= 3
+	3,
+  #endif
+  #if MIDI2_NUM_GROUPS >= 4
+	4,
+  #endif
+  #if MIDI2_NUM_GROUPS >= 5
+	5,
+  #endif
+  #if MIDI2_NUM_GROUPS >= 6
+	6,
+  #endif
+  #if MIDI2_NUM_GROUPS >= 7
+	7,
+  #endif
+  #if MIDI2_NUM_GROUPS >= 8
+	8,
+  #endif
+  #if MIDI2_NUM_GROUPS >= 9
+	9,
+  #endif
+  #if MIDI2_NUM_GROUPS >= 10
+	10,
+  #endif
+  #if MIDI2_NUM_GROUPS >= 11
+	11,
+  #endif
+  #if MIDI2_NUM_GROUPS >= 12
+	12,
+  #endif
+  #if MIDI2_NUM_GROUPS >= 13
+	13,
+  #endif
+  #if MIDI2_NUM_GROUPS >= 14
+	14,
+  #endif
+  #if MIDI2_NUM_GROUPS >= 15
+	15,
+  #endif
+  #if MIDI2_NUM_GROUPS >= 16
+	16,
+  #endif
+#endif // MIDI2_HAS_DESCRIPTORS
 #endif // MIDI_INTERFACE
 
 #ifdef KEYBOARD_INTERFACE
@@ -2161,6 +2304,57 @@ PROGMEM const uint8_t usb_config_descriptor_12[CONFIG_DESC_SIZE] = {
   #if MIDI_NUM_CABLES >= 16
         63,
   #endif
+#ifdef MIDI2_HAS_DESCRIPTORS
+	// MIDI 2.0 Alternate Setting 1 (12 Mbit/sec)
+	9, 4, MIDI_INTERFACE, 1, 2, 0x01, 0x03, 0x00, 0,
+	7, 0x24, 0x01, 0x00, 0x02,
+	LSB(7+(7+4+MIDI2_NUM_GROUPS)*2),
+	MSB(7+(7+4+MIDI2_NUM_GROUPS)*2),
+	7, 5, MIDI2_RX_ENDPOINT, 0x02,
+	LSB(MIDI_RX_SIZE_12), MSB(MIDI_RX_SIZE_12), 0,
+	4+MIDI2_NUM_GROUPS, 0x25, 0x02, MIDI2_NUM_GROUPS,
+	1,
+  #if MIDI2_NUM_GROUPS >= 2
+	2,
+  #endif
+  #if MIDI2_NUM_GROUPS >= 3
+	3,
+  #endif
+  #if MIDI2_NUM_GROUPS >= 4
+	4,
+  #endif
+  #if MIDI2_NUM_GROUPS >= 5
+	5, 6, 7, 8,
+  #endif
+  #if MIDI2_NUM_GROUPS >= 9
+	9, 10, 11, 12,
+  #endif
+  #if MIDI2_NUM_GROUPS >= 13
+	13, 14, 15, 16,
+  #endif
+	7, 5, MIDI2_TX_ENDPOINT | 0x80, 0x02,
+	LSB(MIDI_TX_SIZE_12), MSB(MIDI_TX_SIZE_12), 0,
+	4+MIDI2_NUM_GROUPS, 0x25, 0x02, MIDI2_NUM_GROUPS,
+	1,
+  #if MIDI2_NUM_GROUPS >= 2
+	2,
+  #endif
+  #if MIDI2_NUM_GROUPS >= 3
+	3,
+  #endif
+  #if MIDI2_NUM_GROUPS >= 4
+	4,
+  #endif
+  #if MIDI2_NUM_GROUPS >= 5
+	5, 6, 7, 8,
+  #endif
+  #if MIDI2_NUM_GROUPS >= 9
+	9, 10, 11, 12,
+  #endif
+  #if MIDI2_NUM_GROUPS >= 13
+	13, 14, 15, 16,
+  #endif
+#endif // MIDI2_HAS_DESCRIPTORS
 #endif // MIDI_INTERFACE
 
 #ifdef KEYBOARD_INTERFACE
@@ -2789,6 +2983,66 @@ void usb_init_serialnumber(void)
 // **************************************************************
 //   Descriptors List
 // **************************************************************
+
+// MIDI 2.0 Group Terminal Block descriptor (served via GET_DESCRIPTOR)
+#ifdef MIDI2_HAS_DESCRIPTORS
+#define MIDI2_GTB_ENTRY(id, grp) \
+	13, 0x26, 0x02, (id), 0x00, (grp), 1, 0, 0x02, 0, 0, 0, 0,
+
+PROGMEM const uint8_t midi2_gtb_descriptor[] = {
+	// GTB Header
+	5, 0x26, 0x01,
+	LSB(5 + 13 * MIDI2_NUM_GROUPS),
+	MSB(5 + 13 * MIDI2_NUM_GROUPS),
+	// GTB Entry 1 (group 0)
+	MIDI2_GTB_ENTRY(1, 0)
+  #if MIDI2_NUM_GROUPS >= 2
+	MIDI2_GTB_ENTRY(2, 1)
+  #endif
+  #if MIDI2_NUM_GROUPS >= 3
+	MIDI2_GTB_ENTRY(3, 2)
+  #endif
+  #if MIDI2_NUM_GROUPS >= 4
+	MIDI2_GTB_ENTRY(4, 3)
+  #endif
+  #if MIDI2_NUM_GROUPS >= 5
+	MIDI2_GTB_ENTRY(5, 4)
+  #endif
+  #if MIDI2_NUM_GROUPS >= 6
+	MIDI2_GTB_ENTRY(6, 5)
+  #endif
+  #if MIDI2_NUM_GROUPS >= 7
+	MIDI2_GTB_ENTRY(7, 6)
+  #endif
+  #if MIDI2_NUM_GROUPS >= 8
+	MIDI2_GTB_ENTRY(8, 7)
+  #endif
+  #if MIDI2_NUM_GROUPS >= 9
+	MIDI2_GTB_ENTRY(9, 8)
+  #endif
+  #if MIDI2_NUM_GROUPS >= 10
+	MIDI2_GTB_ENTRY(10, 9)
+  #endif
+  #if MIDI2_NUM_GROUPS >= 11
+	MIDI2_GTB_ENTRY(11, 10)
+  #endif
+  #if MIDI2_NUM_GROUPS >= 12
+	MIDI2_GTB_ENTRY(12, 11)
+  #endif
+  #if MIDI2_NUM_GROUPS >= 13
+	MIDI2_GTB_ENTRY(13, 12)
+  #endif
+  #if MIDI2_NUM_GROUPS >= 14
+	MIDI2_GTB_ENTRY(14, 13)
+  #endif
+  #if MIDI2_NUM_GROUPS >= 15
+	MIDI2_GTB_ENTRY(15, 14)
+  #endif
+  #if MIDI2_NUM_GROUPS >= 16
+	MIDI2_GTB_ENTRY(16, 15)
+  #endif
+};
+#endif // MIDI2_HAS_DESCRIPTORS
 
 // This table provides access to all the descriptor data above.
 

--- a/teensy4/usb_desc.c
+++ b/teensy4/usb_desc.c
@@ -2948,6 +2948,13 @@ PROGMEM const struct usb_string_descriptor_struct usb_string_manufacturer_name_d
         3,
         MANUFACTURER_NAME
 };
+PROGMEM const struct usb_string_descriptor_struct usb_string_midi2_gtb_name_default = {
+	2 + 4 * 2,
+	3,
+	{'M','a','i','n'}
+};
+extern struct usb_string_descriptor_struct usb_string_midi2_gtb_name
+        __attribute__ ((weak, alias("usb_string_midi2_gtb_name_default")));
 PROGMEM const struct usb_string_descriptor_struct usb_string_product_name_default = {
 	2 + PRODUCT_NAME_LEN * 2,
         3,
@@ -2994,60 +3001,61 @@ void usb_init_serialnumber(void)
 // first group, 1 group, no string, bMIDIProtocol 0x00 = unknown
 // (negotiated at runtime via MIDI-CI / UMP Stream), bandwidth unknown.
 #ifdef MIDI2_HAS_DESCRIPTORS
-#define MIDI2_GTB_ENTRY(id, grp) \
-	13, 0x26, 0x02, (id), 0x00, (grp), 1, 0, 0x00, 0, 0, 0, 0,
+#define MIDI2_GTB_ENTRY(id, grp, stridx) \
+	13, 0x26, 0x02, (id), 0x00, (grp), 1, (stridx), 0x00, 0, 0, 0, 0,
 
 PROGMEM const uint8_t midi2_gtb_descriptor[] = {
 	// GTB Header (section 5.4.1)
 	5, 0x26, 0x01,
 	LSB(5 + 13 * MIDI2_NUM_GROUPS),
 	MSB(5 + 13 * MIDI2_NUM_GROUPS),
-	// GTB Entries (section 5.4.2), one per group
-	MIDI2_GTB_ENTRY(1, 0)
+	// GTB Entries (section 5.4.2), one per group.  Block 1 carries the
+	// block name string (iBlockItem = 5, usb_string_midi2_gtb_name).
+	MIDI2_GTB_ENTRY(1, 0, 5)
   #if MIDI2_NUM_GROUPS >= 2
-	MIDI2_GTB_ENTRY(2, 1)
+	MIDI2_GTB_ENTRY(2, 1, 0)
   #endif
   #if MIDI2_NUM_GROUPS >= 3
-	MIDI2_GTB_ENTRY(3, 2)
+	MIDI2_GTB_ENTRY(3, 2, 0)
   #endif
   #if MIDI2_NUM_GROUPS >= 4
-	MIDI2_GTB_ENTRY(4, 3)
+	MIDI2_GTB_ENTRY(4, 3, 0)
   #endif
   #if MIDI2_NUM_GROUPS >= 5
-	MIDI2_GTB_ENTRY(5, 4)
+	MIDI2_GTB_ENTRY(5, 4, 0)
   #endif
   #if MIDI2_NUM_GROUPS >= 6
-	MIDI2_GTB_ENTRY(6, 5)
+	MIDI2_GTB_ENTRY(6, 5, 0)
   #endif
   #if MIDI2_NUM_GROUPS >= 7
-	MIDI2_GTB_ENTRY(7, 6)
+	MIDI2_GTB_ENTRY(7, 6, 0)
   #endif
   #if MIDI2_NUM_GROUPS >= 8
-	MIDI2_GTB_ENTRY(8, 7)
+	MIDI2_GTB_ENTRY(8, 7, 0)
   #endif
   #if MIDI2_NUM_GROUPS >= 9
-	MIDI2_GTB_ENTRY(9, 8)
+	MIDI2_GTB_ENTRY(9, 8, 0)
   #endif
   #if MIDI2_NUM_GROUPS >= 10
-	MIDI2_GTB_ENTRY(10, 9)
+	MIDI2_GTB_ENTRY(10, 9, 0)
   #endif
   #if MIDI2_NUM_GROUPS >= 11
-	MIDI2_GTB_ENTRY(11, 10)
+	MIDI2_GTB_ENTRY(11, 10, 0)
   #endif
   #if MIDI2_NUM_GROUPS >= 12
-	MIDI2_GTB_ENTRY(12, 11)
+	MIDI2_GTB_ENTRY(12, 11, 0)
   #endif
   #if MIDI2_NUM_GROUPS >= 13
-	MIDI2_GTB_ENTRY(13, 12)
+	MIDI2_GTB_ENTRY(13, 12, 0)
   #endif
   #if MIDI2_NUM_GROUPS >= 14
-	MIDI2_GTB_ENTRY(14, 13)
+	MIDI2_GTB_ENTRY(14, 13, 0)
   #endif
   #if MIDI2_NUM_GROUPS >= 15
-	MIDI2_GTB_ENTRY(15, 14)
+	MIDI2_GTB_ENTRY(15, 14, 0)
   #endif
   #if MIDI2_NUM_GROUPS >= 16
-	MIDI2_GTB_ENTRY(16, 15)
+	MIDI2_GTB_ENTRY(16, 15, 0)
   #endif
 };
 #endif // MIDI2_HAS_DESCRIPTORS
@@ -3098,6 +3106,9 @@ const usb_descriptor_list_t usb_descriptor_list[] = {
 #ifdef EXPERIMENTAL_INTERFACE
 	{0x03EE, 0x0000, microsoft_os_string_desc, 18},
 	{0x0000, 0xEE04, microsoft_os_compatible_id_desc, 40},
+#endif
+#ifdef MIDI2_HAS_DESCRIPTORS
+	{0x0305, 0x0409, (const uint8_t *)&usb_string_midi2_gtb_name, 0},
 #endif
         {0x0300, 0x0000, (const uint8_t *)&string0, 0},
         {0x0301, 0x0409, (const uint8_t *)&usb_string_manufacturer_name, 0},

--- a/teensy4/usb_desc.c
+++ b/teensy4/usb_desc.c
@@ -1156,6 +1156,8 @@ PROGMEM const uint8_t usb_config_descriptor_480[CONFIG_DESC_SIZE] = {
   #endif
 #ifdef MIDI2_HAS_DESCRIPTORS
 	// MIDI 2.0 Alternate Setting 1: UMP native
+	// (USB MIDI 2.0 spec, section 3.1.1: alt 0 = MIDI 1.0 for legacy
+	// hosts, alt 1 = UMP, host picks via SET_INTERFACE)
 	// Interface descriptor (same interface number, alt=1)
 	9,					// bLength
 	4,					// bDescriptorType
@@ -1166,21 +1168,22 @@ PROGMEM const uint8_t usb_config_descriptor_480[CONFIG_DESC_SIZE] = {
 	0x03,					// bInterfaceSubClass (MIDI Streaming)
 	0x00,					// bInterfaceProtocol
 	0,					// iInterface
-	// MS Header CS Interface (bcdMSC = 0x0200)
+	// MS Header CS Interface, bcdMSC = 0x0200 (section 5.2.2.1)
 	7,					// bLength
 	0x24,					// bDescriptorType = CS_INTERFACE
 	0x01,					// bDescriptorSubtype = MS_HEADER
 	0x00, 0x02,				// bcdMSC = revision 02.00
 	LSB(7+(7+4+MIDI2_NUM_GROUPS)*2),	// wTotalLength
 	MSB(7+(7+4+MIDI2_NUM_GROUPS)*2),
-	// Bulk OUT Endpoint (7 bytes, standard USB -- not Audio 9-byte)
+	// Bulk OUT Endpoint, standard 7-byte form, not Audio 9-byte
+	// (section 5.3.1)
 	7,					// bLength
 	5,					// bDescriptorType = ENDPOINT
 	MIDI2_RX_ENDPOINT,			// bEndpointAddress
 	0x02,					// bmAttributes (bulk)
 	LSB(MIDI2_RX_SIZE_480), MSB(MIDI2_RX_SIZE_480), // wMaxPacketSize
 	0,					// bInterval
-	// CS Endpoint General 2.0
+	// CS Endpoint General 2.0 (section 5.3.2)
 	4+MIDI2_NUM_GROUPS,			// bLength
 	0x25,					// bDescriptorType = CS_ENDPOINT
 	0x02,					// bDescriptorSubtype = General 2.0
@@ -1231,14 +1234,14 @@ PROGMEM const uint8_t usb_config_descriptor_480[CONFIG_DESC_SIZE] = {
   #if MIDI2_NUM_GROUPS >= 16
 	16,
   #endif
-	// Bulk IN Endpoint (7 bytes)
+	// Bulk IN Endpoint, standard 7-byte form (section 5.3.1)
 	7,					// bLength
 	5,					// bDescriptorType = ENDPOINT
 	MIDI2_TX_ENDPOINT | 0x80,		// bEndpointAddress
 	0x02,					// bmAttributes (bulk)
 	LSB(MIDI2_TX_SIZE_480), MSB(MIDI2_TX_SIZE_480), // wMaxPacketSize
 	0,					// bInterval
-	// CS Endpoint General 2.0
+	// CS Endpoint General 2.0 (section 5.3.2)
 	4+MIDI2_NUM_GROUPS,			// bLength
 	0x25,					// bDescriptorType = CS_ENDPOINT
 	0x02,					// bDescriptorSubtype = General 2.0
@@ -2305,7 +2308,8 @@ PROGMEM const uint8_t usb_config_descriptor_12[CONFIG_DESC_SIZE] = {
         63,
   #endif
 #ifdef MIDI2_HAS_DESCRIPTORS
-	// MIDI 2.0 Alternate Setting 1 (12 Mbit/sec)
+	// MIDI 2.0 Alternate Setting 1 (12 Mbit/sec), same layout as the
+	// 480 Mbit/sec block above, full-speed packet sizes
 	9, 4, MIDI_INTERFACE, 1, 2, 0x01, 0x03, 0x00, 0,
 	7, 0x24, 0x01, 0x00, 0x02,
 	LSB(7+(7+4+MIDI2_NUM_GROUPS)*2),
@@ -2985,16 +2989,20 @@ void usb_init_serialnumber(void)
 // **************************************************************
 
 // MIDI 2.0 Group Terminal Block descriptor (served via GET_DESCRIPTOR)
+// USB MIDI 2.0 spec, section 5.4.  One 13-byte block per group:
+// bLength, CS_GR_TRM_BLOCK, GR_TRM_BLOCK, bGrpTrmBlkID, bidirectional,
+// first group, 1 group, no string, bMIDIProtocol 0x00 = unknown
+// (negotiated at runtime via MIDI-CI / UMP Stream), bandwidth unknown.
 #ifdef MIDI2_HAS_DESCRIPTORS
 #define MIDI2_GTB_ENTRY(id, grp) \
-	13, 0x26, 0x02, (id), 0x00, (grp), 1, 0, 0x02, 0, 0, 0, 0,
+	13, 0x26, 0x02, (id), 0x00, (grp), 1, 0, 0x00, 0, 0, 0, 0,
 
 PROGMEM const uint8_t midi2_gtb_descriptor[] = {
-	// GTB Header
+	// GTB Header (section 5.4.1)
 	5, 0x26, 0x01,
 	LSB(5 + 13 * MIDI2_NUM_GROUPS),
 	MSB(5 + 13 * MIDI2_NUM_GROUPS),
-	// GTB Entry 1 (group 0)
+	// GTB Entries (section 5.4.2), one per group
 	MIDI2_GTB_ENTRY(1, 0)
   #if MIDI2_NUM_GROUPS >= 2
 	MIDI2_GTB_ENTRY(2, 1)

--- a/teensy4/usb_desc.h
+++ b/teensy4/usb_desc.h
@@ -584,6 +584,155 @@ let me know?  http://forum.pjrc.com/forums/4-Suggestions-amp-Bug-Reports
   #define ENDPOINT3_CONFIG	ENDPOINT_RECEIVE_BULK + ENDPOINT_TRANSMIT_BULK
   #define ENDPOINT4_CONFIG	ENDPOINT_RECEIVE_BULK + ENDPOINT_TRANSMIT_BULK
 
+#elif defined(USB_MIDI2)
+  #define VENDOR_ID		0x16C0
+  #define PRODUCT_ID		0x0485
+  #define BCD_DEVICE		0x0220
+  #define MANUFACTURER_NAME	{'T','e','e','n','s','y','d','u','i','n','o'}
+  #define MANUFACTURER_NAME_LEN	11
+  #define PRODUCT_NAME		{'T','e','e','n','s','y',' ','M','I','D','I',' ','2','.','0'}
+  #define PRODUCT_NAME_LEN	15
+  #define EP0_SIZE		64
+  #define NUM_ENDPOINTS         4
+  #define NUM_INTERFACE		2
+  #define SEREMU_INTERFACE      1	// Serial emulation
+  #define SEREMU_TX_ENDPOINT    2
+  #define SEREMU_TX_SIZE        64
+  #define SEREMU_TX_INTERVAL    1
+  #define SEREMU_RX_ENDPOINT    2
+  #define SEREMU_RX_SIZE        32
+  #define SEREMU_RX_INTERVAL    2
+  // MIDI 2.0 shares the MIDI interface and endpoints with the MIDI 1.0
+  // path; Alternate Setting 0 carries MIDI 1.0 byte stream and
+  // Alternate Setting 1 carries UMP. Group Terminal Block descriptor
+  // (see usb_desc.c) is served via GET_DESCRIPTOR.
+  #define MIDI_INTERFACE        0	// MIDI
+  #define MIDI_NUM_CABLES       1
+  #define MIDI2_NUM_GROUPS      1
+  #define MIDI2_HAS_DESCRIPTORS 1
+  #define MIDI_TX_ENDPOINT      3
+  #define MIDI2_TX_ENDPOINT     3
+  #define MIDI_TX_SIZE_12       64
+  #define MIDI_TX_SIZE_480      512
+  #define MIDI2_TX_SIZE_480     512
+  #define MIDI_RX_ENDPOINT      3
+  #define MIDI2_RX_ENDPOINT     3
+  #define MIDI_RX_SIZE_12       64
+  #define MIDI_RX_SIZE_480      512
+  #define MIDI2_RX_SIZE_480     512
+  #define ENDPOINT2_CONFIG	ENDPOINT_RECEIVE_INTERRUPT + ENDPOINT_TRANSMIT_INTERRUPT
+  #define ENDPOINT3_CONFIG	ENDPOINT_RECEIVE_BULK + ENDPOINT_TRANSMIT_BULK
+
+#elif defined(USB_MIDI2_SERIAL)
+  #define VENDOR_ID		0x16C0
+  #define PRODUCT_ID		0x0489
+  #define BCD_DEVICE		0x0230
+  #define MANUFACTURER_NAME	{'T','e','e','n','s','y','d','u','i','n','o'}
+  #define MANUFACTURER_NAME_LEN	11
+  #define PRODUCT_NAME		{'T','e','e','n','s','y',' ','M','I','D','I',' ','2','.','0'}
+  #define PRODUCT_NAME_LEN	15
+  #define EP0_SIZE		64
+  #define NUM_ENDPOINTS         4
+  #define NUM_INTERFACE		3
+  #define CDC_IAD_DESCRIPTOR	1
+  #define CDC_STATUS_INTERFACE	0
+  #define CDC_DATA_INTERFACE	1	// Serial
+  #define CDC_ACM_ENDPOINT	2
+  #define CDC_RX_ENDPOINT       3
+  #define CDC_TX_ENDPOINT       3
+  #define CDC_ACM_SIZE          16
+  #define CDC_RX_SIZE_480       512
+  #define CDC_TX_SIZE_480       512
+  #define CDC_RX_SIZE_12        64
+  #define CDC_TX_SIZE_12        64
+  #define MIDI_INTERFACE        2	// MIDI
+  #define MIDI_NUM_CABLES       1
+  #define MIDI2_NUM_GROUPS      1
+  #define MIDI2_HAS_DESCRIPTORS 1
+  #define MIDI_TX_ENDPOINT      4
+  #define MIDI2_TX_ENDPOINT     4
+  #define MIDI_TX_SIZE_12       64
+  #define MIDI_TX_SIZE_480      512
+  #define MIDI2_TX_SIZE_480     512
+  #define MIDI_RX_ENDPOINT      4
+  #define MIDI2_RX_ENDPOINT     4
+  #define MIDI_RX_SIZE_12       64
+  #define MIDI_RX_SIZE_480      512
+  #define MIDI2_RX_SIZE_480     512
+  #define ENDPOINT2_CONFIG	ENDPOINT_RECEIVE_UNUSED + ENDPOINT_TRANSMIT_INTERRUPT
+  #define ENDPOINT3_CONFIG	ENDPOINT_RECEIVE_BULK + ENDPOINT_TRANSMIT_BULK
+  #define ENDPOINT4_CONFIG	ENDPOINT_RECEIVE_BULK + ENDPOINT_TRANSMIT_BULK
+
+#elif defined(USB_MIDI2_4)
+  #define VENDOR_ID		0x16C0
+  #define PRODUCT_ID		0x0485
+  #define BCD_DEVICE		0x0221
+  #define MANUFACTURER_NAME	{'T','e','e','n','s','y','d','u','i','n','o'}
+  #define MANUFACTURER_NAME_LEN	11
+  #define PRODUCT_NAME		{'T','e','e','n','s','y',' ','M','I','D','I',' ','2','.','0',' ','x','4'}
+  #define PRODUCT_NAME_LEN	18
+  #define EP0_SIZE		64
+  #define NUM_ENDPOINTS         4
+  #define NUM_INTERFACE		2
+  #define SEREMU_INTERFACE      1
+  #define SEREMU_TX_ENDPOINT    2
+  #define SEREMU_TX_SIZE        64
+  #define SEREMU_TX_INTERVAL    1
+  #define SEREMU_RX_ENDPOINT    2
+  #define SEREMU_RX_SIZE        32
+  #define SEREMU_RX_INTERVAL    2
+  #define MIDI_INTERFACE        0
+  #define MIDI_NUM_CABLES       4
+  #define MIDI2_NUM_GROUPS      4
+  #define MIDI2_HAS_DESCRIPTORS 1
+  #define MIDI_TX_ENDPOINT      3
+  #define MIDI2_TX_ENDPOINT     3
+  #define MIDI_TX_SIZE_12       64
+  #define MIDI_TX_SIZE_480      512
+  #define MIDI2_TX_SIZE_480     512
+  #define MIDI_RX_ENDPOINT      3
+  #define MIDI2_RX_ENDPOINT     3
+  #define MIDI_RX_SIZE_12       64
+  #define MIDI_RX_SIZE_480      512
+  #define MIDI2_RX_SIZE_480     512
+  #define ENDPOINT2_CONFIG	ENDPOINT_RECEIVE_INTERRUPT + ENDPOINT_TRANSMIT_INTERRUPT
+  #define ENDPOINT3_CONFIG	ENDPOINT_RECEIVE_BULK + ENDPOINT_TRANSMIT_BULK
+
+#elif defined(USB_MIDI2_16)
+  #define VENDOR_ID		0x16C0
+  #define PRODUCT_ID		0x0485
+  #define BCD_DEVICE		0x0222
+  #define MANUFACTURER_NAME	{'T','e','e','n','s','y','d','u','i','n','o'}
+  #define MANUFACTURER_NAME_LEN	11
+  #define PRODUCT_NAME		{'T','e','e','n','s','y',' ','M','I','D','I',' ','2','.','0',' ','x','1','6'}
+  #define PRODUCT_NAME_LEN	19
+  #define EP0_SIZE		64
+  #define NUM_ENDPOINTS         4
+  #define NUM_INTERFACE		2
+  #define SEREMU_INTERFACE      1
+  #define SEREMU_TX_ENDPOINT    2
+  #define SEREMU_TX_SIZE        64
+  #define SEREMU_TX_INTERVAL    1
+  #define SEREMU_RX_ENDPOINT    2
+  #define SEREMU_RX_SIZE        32
+  #define SEREMU_RX_INTERVAL    2
+  #define MIDI_INTERFACE        0
+  #define MIDI_NUM_CABLES       16
+  #define MIDI2_NUM_GROUPS      16
+  #define MIDI2_HAS_DESCRIPTORS 1
+  #define MIDI_TX_ENDPOINT      3
+  #define MIDI2_TX_ENDPOINT     3
+  #define MIDI_TX_SIZE_12       64
+  #define MIDI_TX_SIZE_480      512
+  #define MIDI2_TX_SIZE_480     512
+  #define MIDI_RX_ENDPOINT      3
+  #define MIDI2_RX_ENDPOINT     3
+  #define MIDI_RX_SIZE_12       64
+  #define MIDI_RX_SIZE_480      512
+  #define MIDI2_RX_SIZE_480     512
+  #define ENDPOINT2_CONFIG	ENDPOINT_RECEIVE_INTERRUPT + ENDPOINT_TRANSMIT_INTERRUPT
+  #define ENDPOINT3_CONFIG	ENDPOINT_RECEIVE_BULK + ENDPOINT_TRANSMIT_BULK
+
 #elif defined(USB_RAWHID)
   #define VENDOR_ID		0x16C0
   #define PRODUCT_ID		0x0486

--- a/teensy4/usb_midi.c
+++ b/teensy4/usb_midi.c
@@ -179,6 +179,75 @@ void usb_midi_write_packed(uint32_t n)
 	tx_noautoflush = 0;
 }
 
+// Write a whole UMP message (1-4 words) or nothing.  The per-word path can
+// stop mid-message once the TX timeout trips, which leaves a fragment of a
+// multi-word UMP on the wire; here the message is only copied after a packet
+// buffer with room for all of it is secured, so a host that stopped reading
+// costs whole messages, never framing.  Returns the words written: count, or
+// 0 when the buffer never freed within the timeout.
+int usb_midi_write_packed_n(const uint32_t *words, uint8_t count)
+{
+	if (!usb_configuration) return 0;
+	if (count == 0 || count > 4) return 0;
+	tx_noautoflush = 1;
+	uint32_t head = tx_head;
+	transfer_t *xfer = tx_transfer + head;
+	// Not enough room in the current packet buffer: send it as-is so the
+	// next buffer starts empty (same transmit path as usb_midi_flush_output).
+	if (tx_available > 0 && tx_available < (uint32_t)count * 4) {
+		uint8_t *txbuf = txbuffer + (head * TX_SIZE);
+		uint32_t len = tx_packet_size - tx_available;
+		usb_prepare_transfer(xfer, txbuf, len, 0);
+		arm_dcache_flush_delete(txbuf, TX_SIZE);
+		usb_transmit(MIDI_TX_ENDPOINT, xfer);
+		if (++head >= TX_NUM) head = 0;
+		tx_head = head;
+		tx_available = 0;
+		xfer = tx_transfer + head;
+	}
+	uint32_t wait_begin_at = systick_millis_count;
+	while (!tx_available) {
+		uint32_t status = usb_transfer_status(xfer);
+		if (!(status & 0x80)) {
+			if (status & 0x68) {
+				// TODO: what if status has errors???
+			}
+			tx_available = tx_packet_size;
+			transmit_previous_timeout = 0;
+			break;
+		}
+		if (systick_millis_count - wait_begin_at > TX_TIMEOUT_MSEC) {
+			transmit_previous_timeout = 1;
+		}
+		if (transmit_previous_timeout) {
+			tx_noautoflush = 0;
+			return 0;
+		}
+		if (!usb_configuration) {
+			tx_noautoflush = 0;
+			return 0;
+		}
+		yield();
+	}
+	uint32_t *txdata = (uint32_t *)(txbuffer + (tx_head * TX_SIZE) + (tx_packet_size - tx_available));
+	uint8_t i;
+	for (i = 0; i < count; i++) txdata[i] = words[i];
+	tx_available -= (uint32_t)count * 4;
+	if (tx_available == 0) {
+		uint8_t *txbuf = txbuffer + (tx_head * TX_SIZE);
+		usb_prepare_transfer(xfer, txbuf, tx_packet_size, 0);
+		arm_dcache_flush_delete(txbuf, TX_SIZE);
+		usb_transmit(MIDI_TX_ENDPOINT, xfer);
+		if (++head >= TX_NUM) head = 0;
+		tx_head = head;
+		usb_stop_sof_interrupts(MIDI_INTERFACE);
+	} else {
+		usb_start_sof_interrupts(MIDI_INTERFACE);
+	}
+	tx_noautoflush = 0;
+	return count;
+}
+
 void usb_midi_flush_output(void)
 {
 	//printf("usb_midi_flush_output\n");

--- a/teensy4/usb_midi.h
+++ b/teensy4/usb_midi.h
@@ -46,6 +46,7 @@ extern "C" {
 #endif
 void usb_midi_configure(void);
 void usb_midi_write_packed(uint32_t n);
+int usb_midi_write_packed_n(const uint32_t *words, uint8_t count);
 void usb_midi_send_sysex_buffer_has_term(const uint8_t *data, uint32_t length, uint8_t cable);
 void usb_midi_send_sysex_add_term_bytes(const uint8_t *data, uint32_t length, uint8_t cable);
 void usb_midi_flush_output(void);

--- a/teensy4/usb_midi2.c
+++ b/teensy4/usb_midi2.c
@@ -1,0 +1,85 @@
+/* Teensyduino Core Library
+ * http://www.pjrc.com/teensy/
+ * Copyright (c) 2026 PJRC.COM, LLC.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * 1. The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * 2. If the Software is incorporated into a build system that allows
+ * selection among a list of target devices, then similar target
+ * devices manufactured by PJRC.COM must be included in the list of
+ * target devices and selectable in the same manner.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include "usb_midi2.h"
+#include "usb_midi.h"
+
+#if defined(MIDI_INTERFACE)
+
+uint8_t usb_midi2_alt_setting = 0;
+
+// MIDI 2.0 UMP Specification Table 4: message size per Message Type.
+static uint8_t ump_words_for_mt(uint8_t mt)
+{
+	switch (mt) {
+	case 0x0: case 0x1: case 0x2:                               return 1;
+	case 0x3: case 0x4: case 0x8: case 0x9: case 0xA: case 0xD: return 2;
+	case 0xB: case 0xC:                                         return 3;
+	case 0x5: case 0xE: case 0xF:                               return 4;
+	default:                                                    return 1;
+	}
+}
+
+int usb_midi2_read_message(uint32_t *words, uint8_t *count)
+{
+	static uint32_t buf[4];
+	static uint8_t  have = 0;
+	static uint8_t  need = 0;
+
+	for (;;) {
+		if (usb_midi_available() == 0) return 0;
+		uint32_t w = usb_midi_read_message();
+		if (have == 0) {
+			need = ump_words_for_mt((uint8_t)((w >> 28) & 0x0F));
+		}
+		if (have < 4) buf[have++] = w;
+		if (have >= need) {
+			uint8_t i;
+			for (i = 0; i < have; i++) words[i] = buf[i];
+			*count = have;
+			have = 0;
+			return 1;
+		}
+	}
+}
+
+void usb_midi2_write_message(const uint32_t *words, uint8_t count)
+{
+	uint8_t i;
+	for (i = 0; i < count; i++) {
+		usb_midi_write_packed(words[i]);
+	}
+}
+
+#ifdef __cplusplus
+usb_midi2_class usbMIDI2;
+#endif
+
+#endif // MIDI_INTERFACE

--- a/teensy4/usb_midi2.c
+++ b/teensy4/usb_midi2.c
@@ -70,12 +70,11 @@ int usb_midi2_read_message(uint32_t *words, uint8_t *count)
 	}
 }
 
-void usb_midi2_write_message(const uint32_t *words, uint8_t count)
+int usb_midi2_write_message(const uint32_t *words, uint8_t count)
 {
-	uint8_t i;
-	for (i = 0; i < count; i++) {
-		usb_midi_write_packed(words[i]);
-	}
+	// Whole message or nothing: a UMP split mid-message by a TX timeout is
+	// a framing error on the wire, worse than a dropped message.
+	return usb_midi_write_packed_n(words, count);
 }
 
 #ifdef __cplusplus

--- a/teensy4/usb_midi2.h
+++ b/teensy4/usb_midi2.h
@@ -1,0 +1,92 @@
+/* Teensyduino Core Library
+ * http://www.pjrc.com/teensy/
+ * Copyright (c) 2026 PJRC.COM, LLC.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * 1. The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * 2. If the Software is incorporated into a build system that allows
+ * selection among a list of target devices, then similar target
+ * devices manufactured by PJRC.COM must be included in the list of
+ * target devices and selectable in the same manner.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#ifndef USBmidi2_h_
+#define USBmidi2_h_
+
+#include "usb_desc.h"
+
+#if defined(MIDI_INTERFACE)
+
+#include <inttypes.h>
+
+// MIDI 2.0 Universal MIDI Packet (UMP) raw I/O for the USB MIDI 2.0
+// device class. See teensy4/usb_desc.c for the Alternate Setting 1
+// descriptor and teensy4/usb.c for the SET/GET_INTERFACE handlers.
+// Application-level UMP processing (parsing, MIDI-CI, Property
+// Exchange, Stream Discovery, Flex Data) is intentionally outside
+// the core. This file exposes only the wire-level primitives.
+
+// C language implementation
+#ifdef __cplusplus
+extern "C" {
+#endif
+// 0 = Alternate Setting 0 (MIDI 1.0 wire format)
+// 1 = Alternate Setting 1 (MIDI 2.0 UMP wire format)
+// Updated by SET_INTERFACE in usb.c.
+extern uint8_t usb_midi2_alt_setting;
+
+// Read one UMP message from the endpoint into words[0..count-1].
+// Returns 1 when a full message was assembled, 0 when no data is
+// available or only a partial message has arrived. count is set to
+// the message size (1, 2, 3 or 4 words) per MIDI 2.0 UMP Specification
+// Table 4.
+int usb_midi2_read_message(uint32_t *words, uint8_t *count);
+
+// Write count UMP words to the endpoint without protocol translation.
+// count must match the size declared by the message type.
+void usb_midi2_write_message(const uint32_t *words, uint8_t count);
+#ifdef __cplusplus
+}
+#endif
+
+// C++ interface
+#ifdef __cplusplus
+class usb_midi2_class
+{
+public:
+	void begin(void) { }
+	void end(void) { }
+	uint8_t altSetting(void) __attribute__((always_inline)) {
+		return usb_midi2_alt_setting;
+	}
+	int read(uint32_t *words, uint8_t *count) __attribute__((always_inline)) {
+		return usb_midi2_read_message(words, count);
+	}
+	void write(const uint32_t *words, uint8_t count) __attribute__((always_inline)) {
+		usb_midi2_write_message(words, count);
+	}
+};
+extern usb_midi2_class usbMIDI2;
+#endif // __cplusplus
+
+#endif // MIDI_INTERFACE
+
+#endif // USBmidi2_h_

--- a/teensy4/usb_midi2.h
+++ b/teensy4/usb_midi2.h
@@ -62,7 +62,7 @@ int usb_midi2_read_message(uint32_t *words, uint8_t *count);
 
 // Write count UMP words to the endpoint without protocol translation.
 // count must match the size declared by the message type.
-void usb_midi2_write_message(const uint32_t *words, uint8_t count);
+int usb_midi2_write_message(const uint32_t *words, uint8_t count);
 #ifdef __cplusplus
 }
 #endif
@@ -80,8 +80,8 @@ public:
 	int read(uint32_t *words, uint8_t *count) __attribute__((always_inline)) {
 		return usb_midi2_read_message(words, count);
 	}
-	void write(const uint32_t *words, uint8_t count) __attribute__((always_inline)) {
-		usb_midi2_write_message(words, count);
+	int write(const uint32_t *words, uint8_t count) __attribute__((always_inline)) {
+		return usb_midi2_write_message(words, count);
 	}
 };
 extern usb_midi2_class usbMIDI2;

--- a/teensy4/usb_names.h
+++ b/teensy4/usb_names.h
@@ -49,6 +49,7 @@ struct usb_string_descriptor_struct {
 extern struct usb_string_descriptor_struct usb_string_manufacturer_name;
 extern struct usb_string_descriptor_struct usb_string_product_name;
 extern struct usb_string_descriptor_struct usb_string_serial_number;
+extern struct usb_string_descriptor_struct usb_string_midi2_gtb_name;
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Hi Paul,

This follows up the MIDI 2.0 discussion on the forum. It adds USB MIDI 2.0 device support to Teensy 4.x: the descriptors (Alternate Setting 1 UMP, Group Terminal Block) and the raw UMP read/write primitives. New USB Types: MIDI2, MIDI2_SERIAL, MIDI2_4, MIDI2_16.

Transport only, in the style of the existing usb_midi. The descriptors and the wire-level I/O live in the core; UMP parsing, MIDI-CI, Property Exchange, Stream Discovery and Flex Data stay in the application layer. 625 lines in teensy4/.

No impact on existing builds: all the new code is gated by MIDI2_HAS_DESCRIPTORS, defined only when a MIDI2 USB Type is selected. Every current USB Type compiles byte-identical. Alt 0 carries the MIDI 1.0 byte stream, Alt 1 carries UMP, and the host picks via SET_INTERFACE, so the endpoint pair is shared with MIDI 1.0.

Files:
- teensy4/usb_midi2.{c,h}: raw UMP read/write + usbMIDI2 instance
- teensy4/usb_desc.{c,h}: Alternate Setting 1 descriptor + Group Terminal Block
- teensy4/usb.c: SET/GET_INTERFACE + GTB GET_DESCRIPTOR

Usage examples (device, control surface, host) in a separate library: github.com/sauloverissimo/midi2cpp

The USB Type menu entries (boards.txt) are not included, since they live in the Teensyduino distribution rather than in cores. I can send them separately.

For a bit of context, and not to toot my own horn: this PR is part of an effort to bring MIDI 2.0 to the embedded world. Upstream work in TinyUSB (USB MIDI 2.0 device and host), in microsoft/MIDI (Windows MIDI Services, Pete Brown), in AM_MIDI2.0Lib (Andrew Mee's reference library), and a C99 MIDI 2.0 infrastructure of my own for MCUs. The descriptors here come from that base and were cross-validated against those same references (details below).

Validation:
- Linux snd-usb-midi2: enumerates as a UMP endpoint, GTB reported, /dev/snd/umpC*D0 created
- Windows MIDI Services: native MIDI 2.0 endpoint, full stream decoded (32-bit Channel Voice, Per-Note, Flex Data)
- MIDI 2.0 Workbench (MIDI Association): passes with no errors or warnings
- Stress: 60k+ UMPs, zero loss

Context, discussion, and the screenshots:
https://forum.pjrc.com/index.php?threads/midi-2-0.55239/post-369677

<img width="1280" height="800" alt="WMS" src="https://github.com/user-attachments/assets/49bbb218-c0e4-4452-915c-ec21c32d37c2" />

<img width="960" height="1280" alt="stack" src="https://github.com/user-attachments/assets/ace1ab7c-e80e-427d-a737-9dc110c57c4f" />

<img width="1424" height="862" alt="monitor" src="https://github.com/user-attachments/assets/1a8d8efa-c9ed-4ebc-bb2a-97b510d77311" />